### PR TITLE
update row page

### DIFF
--- a/doradb-catalog/src/lib.rs
+++ b/doradb-catalog/src/lib.rs
@@ -110,6 +110,7 @@ pub struct TableSpec {
     pub schema_name: SemiStr,
     pub table_name: SemiStr,
     pub columns: Vec<ColumnSpec>,
+    // todo: index and constraint
 }
 
 impl TableSpec {

--- a/doradb-storage/src/row/layout.rs
+++ b/doradb-storage/src/row/layout.rs
@@ -1,0 +1,28 @@
+/// ColLayout defines the memory layout of columns 
+/// stored in row page. 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ColLayout {
+    Byte1,   // i8, u8, bool, char(1) with ascii/latin charset
+    Byte2,   // i16, u16, decimal(1-2)
+    Byte4,   // i32, u32, f32, decimal(3-8)
+    Byte8,   // i64, u64, f64, decimal(9-18)
+    Byte16,  // decimal(19-38)
+    VarByte, // bytes, string, no more than 60k.
+}
+
+impl ColLayout {
+    #[inline]
+    pub const fn fix_len(&self) -> usize {
+        match self {
+            ColLayout::Byte1 => 1,
+            ColLayout::Byte2 => 2,
+            ColLayout::Byte4 => 4,
+            ColLayout::Byte8 => 8,
+            ColLayout::Byte16 => 16,
+            // 2-byte len, 2-byte offset, 12-byte prefix
+            // or inline version, 2-byte len, at most 14 inline bytes
+            ColLayout::VarByte => 16, 
+        }
+    }
+}

--- a/doradb-storage/src/row/mod.rs
+++ b/doradb-storage/src/row/mod.rs
@@ -1,12 +1,21 @@
 pub mod action;
+pub mod layout;
+pub mod value;
 
 use crate::buffer::page::PAGE_SIZE;
 use crate::row::action::{RowAction, InsertRow, DeleteRow, UpdateRow};
+use crate::row::layout::ColLayout;
+use crate::row::value::*;
 use crate::error::{Result, Error};
 use std::mem;
-use doradb_datatype::Const;
+use std::slice;
 
 pub type RowID = u64;
+pub const INVALID_ROW_ID: RowID = !0;
+
+const _: () = assert!({
+    std::mem::size_of::<RowPageHeader>() % 8 == 0
+}, "RowPageHeader should have size align to 8 bytes");
 
 /// RowPage is the core data structure of row-store.
 /// It is designed to be fast in both TP and AP scenarios.
@@ -14,12 +23,19 @@ pub type RowID = u64;
 /// 
 /// Header:
 /// 
-/// | field            | length(B) |
-/// |------------------|-----------|
-/// | start_row_id     | 8         |
-/// | end_row_id       | 8         |
-/// | count            | 4         |
-/// | var_field_end    | 4         |
+/// | field                   | length(B) |
+/// |-------------------------|-----------|
+/// | start_row_id            | 8         |
+/// | max_row_count           | 2         |
+/// | row_count               | 2         |
+/// | col_count               | 2         |
+/// | del_bitset_offset       | 2         |
+/// | null_bitset_list_offset | 2         |
+/// | col_offset_list_offset  | 2         |
+/// | fix_field_offset        | 2         |
+/// | fix_field_end           | 2         |
+/// | var_field_offset        | 2         |
+/// | padding                 | 6         |
 /// 
 /// Data:
 /// 
@@ -27,6 +43,7 @@ pub type RowID = u64;
 /// |------------------|-----------------------------------------------|
 /// | del_bitset       | (count + 63) / 64 * 8                         |
 /// | null_bitmap_list | (col_count + 7) / 8 * count, align to 8 bytes |
+/// | col_offset_list  | col_count * 2, align to 8 bytes               |
 /// | c_0              | depends on column type, align to 8 bytes      |
 /// | c_1              | same as above                                 |
 /// | ...              | ...                                           |
@@ -41,13 +58,100 @@ pub struct RowPage {
 
 impl RowPage {
     #[inline]
-    pub fn init(&mut self, start_row_id: u64, end_row_id: u64) {
+    pub fn init(&mut self, start_row_id: u64, max_count: u16, cols: &[ColLayout]) {
         self.header.start_row_id = start_row_id;
-        self.header.end_row_id = end_row_id;
-        self.header.var_field_end = PAGE_SIZE as u32;
-        self.header.count = 0;
+        self.header.max_row_count = max_count;
+        self.header.row_count = 0;
+        let row_count = max_count as usize;
+        let col_count = cols.len();
+        // initialize offset fields.
+        self.header.del_bitset_offset = 0; // always starts at data_ptr().
+        self.header.null_bitset_list_offset = self.header.del_bitset_offset + del_bitset_len(row_count) as u16;
+        self.header.col_offset_list_offset = self.header.null_bitset_list_offset + null_bitset_list_len(col_count, max_count as usize) as u16;
+        self.header.fix_field_offset = self.header.col_offset_list_offset + col_offset_list_len(col_count) as u16;
+        self.init_col_offset_list_and_fix_field_end(cols, max_count);
+        self.header.var_field_offset = (PAGE_SIZE - mem::size_of::<RowPageHeader>()) as u16;
+        self.init_data();
     }
 
+    #[inline]
+    fn init_col_offset_list_and_fix_field_end(&mut self, cols: &[ColLayout], row_count: u16) {
+        debug_assert!(cols.len() >= 2); // at least RowID and one user column.
+        debug_assert!(cols[0] == ColLayout::Byte8); // first column must be RowID, with 8-byte layout.
+        debug_assert!(self.header.col_offset_list_offset != 0);
+        debug_assert!(self.header.fix_field_offset != 0);
+        let mut col_offset = self.header.fix_field_offset;
+        for (i, col) in cols.iter().enumerate() {
+            *self.col_offset_mut(i) = col_offset;
+            col_offset += col_fix_len(col, row_count as usize) as u16;
+        }
+        self.header.fix_field_end = col_offset;
+    }
+
+    #[inline]
+    fn init_data(&mut self) {
+        unsafe {
+            // zero del_bitset, null_bitset_list and col_offset_list
+            let count = (self.header.fix_field_offset - self.header.del_bitset_offset) as usize;
+            let ptr = self.data_ptr_mut().add(self.header.del_bitset_offset as usize);
+            std::ptr::write_bytes(ptr, 0, count);
+        
+            // initialize all RowIDs to INVALID_ROW_ID
+            let row_ids = self.values_mut_unchecked::<RowID>(0, self.header.max_row_count as usize);
+            for row_id in row_ids {
+                *row_id = INVALID_ROW_ID;
+            }
+        }
+    }
+
+    #[inline]
+    pub fn row_ids(&self) -> &[RowID] {
+        self.values::<RowID>(0)
+    }
+
+    #[inline]
+    pub fn row_ids_mut(&mut self) -> &mut [RowID] {
+        self.values_mut::<RowID>(0)
+    }
+
+    #[inline]
+    pub fn values<V: Value>(&self, col_idx: usize) -> &[V] {
+        let len = self.header.row_count as usize;
+        unsafe {
+            self.values_unchecked(col_idx, len)
+        }
+    }
+
+    #[inline]
+    pub unsafe fn values_unchecked<V: Value>(&self, col_idx: usize, len: usize) -> &[V] {
+        let offset = self.col_offset(col_idx) as usize;
+        let ptr = self.data_ptr().add(offset);
+        let data: *const V = mem::transmute(ptr);
+        std::slice::from_raw_parts(data, len)
+    }
+
+    #[inline]
+    pub fn values_mut<V: Value>(&mut self, col_idx: usize) -> &mut [V] {
+        let len = self.header.row_count as usize;
+        unsafe {
+            self.values_mut_unchecked(col_idx, len)
+        }
+    }
+
+    #[inline]
+    pub unsafe fn values_mut_unchecked<V: Value>(&mut self, col_idx: usize, len: usize) -> &mut [V] {
+        let offset = self.col_offset(col_idx) as usize;
+        let ptr = self.data_ptr_mut().add(offset);
+        let data: *mut V = mem::transmute(ptr);
+        std::slice::from_raw_parts_mut(data, len)
+    }
+
+    /// Returns free space of current page.
+    /// The free space is used to hold data of var-len columns.
+    #[inline]
+    pub fn free_space(&self) -> u16 {
+        self.header.var_field_offset - self.header.fix_field_end
+    }
 
     /// Add row to page.
     #[inline]
@@ -95,46 +199,81 @@ impl RowPage {
 
     #[inline]
     fn data_ptr(&self) -> *const u8 {
-        self.data.as_ptr() as *const _
+        self.data.as_ptr()
+    }
+
+    #[inline]
+    fn data_ptr_mut(&mut self) -> *mut u8 {
+        self.data.as_mut_ptr()
     }
 
     #[inline]
     fn del_bitset(&self) -> &[u8] {
-        todo!()
+        let len = del_bitset_len(self.header.max_row_count as usize);
+        unsafe {
+            slice::from_raw_parts(self.data_ptr().add(self.header.del_bitset_offset as usize), len)
+        }
     }
 
     #[inline]
     fn del_bitset_mut(&mut self) -> &mut [u8] {
-        todo!()
+        let len = del_bitset_len(self.header.max_row_count as usize);
+        unsafe {
+            slice::from_raw_parts_mut(self.data_ptr_mut().add(self.header.del_bitset_offset as usize), len)
+        }
     }
 
     #[inline]
-    fn null_bitsets(&self) -> &[u8] {
-        todo!()
+    fn null_bitset(&self, row_offset: usize) -> &[u8] {
+        let len = align8(self.header.col_count as usize) / 8;
+        let offset = self.header.null_bitset_list_offset as usize;
+        unsafe {
+            slice::from_raw_parts(self.data_ptr().add(offset + len * row_offset), len)
+        }
     }
 
     #[inline]
-    fn null_bitsets_mut(&mut self) -> &mut [u8] {
-        todo!()
+    fn null_bitset_mut(&mut self, row_offset: usize) -> &[u8] {
+        let len = align8(self.header.col_count as usize) / 8;
+        let offset = self.header.null_bitset_list_offset as usize;
+        unsafe {
+            slice::from_raw_parts_mut(self.data_ptr_mut().add(offset + len * row_offset), len)
+        }
     }
 
     #[inline]
-    fn null_bitset(&self, row_id: RowID) -> &[u8] {
-        todo!()
+    fn col_offset(&self, col_idx: usize) -> u16 {
+        let offset = self.header.col_offset_list_offset as usize;
+        unsafe {
+            let ptr = self.data_ptr().add(offset) as *const u16;
+            *ptr.add(col_idx)
+        }
     }
 
     #[inline]
-    fn null_bitset_mut(&mut self, row_id: RowID) -> &[u8] {
-        todo!()
+    fn col_offset_mut(&mut self, col_idx: usize) -> &mut u16 {
+        let offset = self.header.col_offset_list_offset as usize;
+        unsafe {
+            let ptr = self.data_ptr_mut().add(offset) as *mut u16;
+            &mut *ptr.add(col_idx)
+        }
     }
 }
 
 #[derive(Debug, Clone)]
+#[repr(C)]
 pub struct RowPageHeader {
     pub start_row_id: u64,
-    pub end_row_id: u64,
-    pub count: u32,
-    pub var_field_end: u32,
+    pub max_row_count: u16,
+    pub row_count: u16,
+    pub col_count: u16,
+    pub del_bitset_offset: u16,
+    pub null_bitset_list_offset: u16,
+    pub col_offset_list_offset: u16,
+    pub fix_field_offset: u16,
+    pub fix_field_end: u16,
+    pub var_field_offset: u16,
+    padding: [u8; 6],
 }
 
 #[inline]
@@ -147,9 +286,57 @@ const fn align64(len: usize) -> usize {
     (len + 63) / 64 * 64
 }
 
-/// delete bitset length, align to 8 bytes
+/// delete bitset length, align to 8 bytes.
 #[inline]
-const fn row_page_del_bitset_len(count: usize) -> usize {
+const fn del_bitset_len(count: usize) -> usize {
     align64(count) / 8
 }
 
+// null bitset length, align to 8 bytes.
+#[inline]
+const fn null_bitset_list_len(col_count: usize, row_count: usize) -> usize {
+    align8(align8(col_count) / 8 * row_count)
+}
+
+// column offset list len, align to 8 bytes.
+#[inline]
+const fn col_offset_list_len(col_count: usize) -> usize {
+    align8(mem::size_of::<u16>() * col_count)
+}
+
+// column fixed length, align to 8 bytes.
+#[inline]
+const fn col_fix_len(col: &ColLayout, row_count: usize) -> usize {
+    align8(col.fix_len() * row_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use mem::MaybeUninit;
+
+    use super::*;
+
+    #[test]
+    fn test_row_page_init() {
+        let cols = vec![ColLayout::Byte8, ColLayout::Byte8];
+        let mut page = create_row_page();
+        page.init(100, 105, &cols);
+        println!("page header={:?}", page.header);
+        assert!(page.header.start_row_id == 100);
+        assert!(page.header.max_row_count == 105);
+        assert!(page.header.row_count == 0);
+        assert!(page.header.del_bitset_offset == 0);
+        assert!(page.header.null_bitset_list_offset % 8 == 0);
+        assert!(page.header.col_offset_list_offset % 8 == 0);
+        assert!(page.header.fix_field_offset % 8 == 0);
+        assert!(page.header.fix_field_end % 8 == 0);
+        assert!(page.header.var_field_offset % 8 == 0);
+    }
+
+    fn create_row_page() -> RowPage {
+        unsafe {
+            let new = MaybeUninit::<RowPage>::uninit();
+            new.assume_init()
+        }
+    }
+}

--- a/doradb-storage/src/row/value.rs
+++ b/doradb-storage/src/row/value.rs
@@ -1,0 +1,473 @@
+use std::mem::{self, MaybeUninit};
+
+pub trait SliceGuard {}
+
+pub trait Value {
+
+    fn as_u8(&self) -> u8 {
+        unimplemented!()
+    }
+
+    fn as_u8_mut(&mut self) -> &mut u8 {
+        unimplemented!()
+    }
+
+    fn as_i8(&self) -> i8 {
+        unimplemented!()
+    }
+
+    fn as_i8_mut(&mut self) -> &mut i8 {
+        unimplemented!()
+    }
+
+    fn as_u16(&self) -> u16 {
+        unimplemented!()
+    }
+
+    fn as_u16_mut(&mut self) -> &mut u16 {
+        unimplemented!()
+    }
+
+    fn as_i16(&self) -> i16 {
+        unimplemented!()
+    }
+
+    fn as_i16_mut(&mut self) -> &mut i16 {
+        unimplemented!()
+    }
+
+    fn as_u32(&self) -> u32 {
+        unimplemented!()
+    }
+
+    fn as_u32_mut(&mut self) -> &mut u32 {
+        unimplemented!()
+    }
+
+    fn as_i32(&self) -> i32 {
+        unimplemented!()
+    }
+
+    fn as_i32_mut(&mut self) -> &mut i32 {
+        unimplemented!()
+    }
+
+    fn as_u64(&self) -> u64 {
+        unimplemented!()
+    }
+
+    fn as_u64_mut(&mut self) -> &mut u64 {
+        unimplemented!()
+    }
+
+    fn as_i64(&self) -> i64 {
+        unimplemented!()
+    }
+
+    fn as_i64_mut(&mut self) -> &mut i64 {
+        unimplemented!()
+    }
+
+    // fn as_u128(&self) -> u128 {
+    //     unimplemented!()
+    // }
+
+    // fn as_u128_mut(&mut self) -> &mut u128 {
+    //     unimplemented!()
+    // }
+
+    fn as_bytes(&self, ptr: *const u8) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn as_bytes_mut(&mut self, ptr: *mut u8) -> &mut [u8] {
+        unimplemented!()
+    }
+
+    fn as_str(&self, ptr: *const u8) -> &str {
+        unimplemented!()
+    }
+
+    fn as_str_mut(&mut self, ptr: *mut u8) -> &mut str {
+        unimplemented!()
+    }
+}
+
+pub trait ValueSlice {
+    fn as_u8(&self) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn as_u8_mut(&mut self) -> &mut [u8] {
+        unimplemented!()
+    }
+
+    fn as_i8(&self) -> &[i8] {
+        unimplemented!()
+    }
+
+    fn as_i8_mut(&mut self) -> &mut [i8] {
+        unimplemented!()
+    }
+
+    fn as_u16(&self) -> &[u16] {
+        unimplemented!()
+    }
+
+    fn as_u16_mut(&mut self) -> &mut [u16] {
+        unimplemented!()
+    }
+
+    fn as_i16(&self) -> &[i16] {
+        unimplemented!()
+    }
+
+    fn as_i16_mut(&mut self) -> &mut [i16] {
+        unimplemented!()
+    }
+
+    fn as_u32(&self) -> &[u32] {
+        unimplemented!()
+    }
+
+    fn as_u32_mut(&mut self) -> &mut [u32] {
+        unimplemented!()
+    }
+
+    fn as_i32(&self) -> &[i32] {
+        unimplemented!()
+    }
+
+    fn as_i32_mut(&mut self) -> &mut [i32] {
+        unimplemented!()
+    }
+
+    fn as_u64(&self) -> &[u64] {
+        unimplemented!()
+    }
+
+    fn as_u64_mut(&mut self) -> &mut [u64] {
+        unimplemented!()
+    }
+
+    fn as_i64(&self) -> &[i64] {
+        unimplemented!()
+    }
+
+    fn as_i64_mut(&mut self) -> &mut [i64] {
+        unimplemented!()
+    }
+
+    fn as_u128(&self) -> &[u128] {
+        unimplemented!()
+    }
+
+    fn as_u128_mut(&mut self) -> &mut [u128] {
+        unimplemented!()
+    }
+}
+
+pub type Byte1Val = u8;
+
+impl Value for Byte1Val {
+    #[inline]
+    fn as_u8(&self) -> u8 {
+        *self
+    }
+
+    #[inline]
+    fn as_u8_mut(&mut self) -> &mut u8 {
+        self
+    }
+
+    #[inline]
+    fn as_i8(&self) -> i8 {
+        unsafe { mem::transmute(*self) }
+    }
+
+    #[inline]
+    fn as_i8_mut(&mut self) -> &mut i8 {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl ValueSlice for [Byte1Val] {
+    #[inline]
+    fn as_u8(&self) -> &[u8] {
+        self
+    }
+
+    #[inline]
+    fn as_u8_mut(&mut self) -> &mut [u8] {
+        self
+    }
+
+    #[inline]
+    fn as_i8(&self) -> &[i8] {
+        unsafe { mem::transmute(self) }
+    }
+
+    #[inline]
+    fn as_i8_mut(&mut self) -> &mut [i8] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+pub type Byte2Val = u16;
+
+impl Value for Byte2Val {
+    #[inline]
+    fn as_u16(&self) -> u16 {
+        *self
+    }
+
+    #[inline]
+    fn as_u16_mut(&mut self) -> &mut u16 {
+        self
+    }
+
+    #[inline]
+    fn as_i16(&self) -> i16 {
+        unsafe { mem::transmute(*self) }
+    }
+
+    #[inline]
+    fn as_i16_mut(&mut self) -> &mut i16 {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl ValueSlice for [Byte2Val] {
+    #[inline]
+    fn as_u16(&self) -> &[u16] {
+        self
+    }
+
+    #[inline]
+    fn as_u16_mut(&mut self) -> &mut [u16] {
+        self
+    }
+
+    #[inline]
+    fn as_i16(&self) -> &[i16] {
+        unsafe { mem::transmute(self) }
+    }
+
+    #[inline]
+    fn as_i16_mut(&mut self) -> &mut [i16] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+pub type Byte4Val = u32;
+
+impl Value for Byte4Val {
+    #[inline]
+    fn as_u32(&self) -> u32 {
+        *self
+    }
+
+    #[inline]
+    fn as_u32_mut(&mut self) -> &mut u32 {
+        self
+    }
+
+    #[inline]
+    fn as_i32(&self) -> i32 {
+        unsafe { mem::transmute(*self) }
+    }
+
+    #[inline]
+    fn as_i32_mut(&mut self) -> &mut i32 {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl ValueSlice for [Byte4Val] {
+    #[inline]
+    fn as_u32(&self) -> &[u32] {
+        self
+    }
+
+    #[inline]
+    fn as_u32_mut(&mut self) -> &mut [u32] {
+        self
+    }
+
+    #[inline]
+    fn as_i32(&self) -> &[i32] {
+        unsafe { mem::transmute(self) }
+    }
+
+    #[inline]
+    fn as_i32_mut(&mut self) -> &mut [i32] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+pub type Byte8Val = u64;
+
+impl Value for Byte8Val {
+    #[inline]
+    fn as_u64(&self) -> u64 {
+        *self
+    }
+
+    #[inline]
+    fn as_u64_mut(&mut self) -> &mut u64 {
+        self
+    }
+
+    #[inline]
+    fn as_i64(&self) -> i64 {
+        unsafe { mem::transmute(*self) }
+    }
+
+    #[inline]
+    fn as_i64_mut(&mut self) -> &mut i64 {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl ValueSlice for [Byte8Val] {
+    #[inline]
+    fn as_u64(&self) -> &[u64] {
+        self
+    }
+
+    #[inline]
+    fn as_u64_mut(&mut self) -> &mut [u64] {
+        self
+    }
+
+    #[inline]
+    fn as_i64(&self) -> &[i64] {
+        unsafe { mem::transmute(self) }
+    }
+
+    #[inline]
+    fn as_i64_mut(&mut self) -> &mut [i64] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+pub struct VarByteVal {
+    inner: VarByteInner,
+}
+
+impl VarByteVal {
+    /// Create a new VarByteVal with inline data.
+    /// The data length must be no more than 14 bytes.
+    #[inline]
+    pub fn inline(val: &[u8]) -> Self {
+        debug_assert!(val.len() <= 14);
+        let mut inline = MaybeUninit::<Inline>::uninit();
+        unsafe {
+            let  i = inline.assume_init_mut();
+            i.len = val.len() as u16;
+            i.data[..val.len()].copy_from_slice(val);
+            VarByteVal{
+                inner: VarByteInner{v: inline.assume_init()},
+            }
+        }
+    }
+
+    /// Create a new VarByteVal with pointer info.
+    /// The prefix length must be 12 bytes.
+    #[inline]
+    pub fn pointer(len: u16, offset: u16, prefix: &[u8]) -> Self {
+        debug_assert!(prefix.len() == 12);
+        let mut pointer = MaybeUninit::<Pointer>::uninit();
+        unsafe {
+            let p = pointer.assume_init_mut();
+            p.len = len;
+            p.offset = offset;
+            p.prefix.copy_from_slice(prefix);
+            VarByteVal{
+                inner: VarByteInner{p: pointer.assume_init() }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { self.inner.v.len as usize }
+    }
+
+}
+
+impl Value for VarByteVal {
+    #[inline]
+    fn as_bytes(&self, ptr: *const u8) -> &[u8] {
+        let len = self.len();
+        if len <= 14 {
+            unsafe { &self.inner.v.data[..len] }
+        } else {
+            unsafe { 
+                let data = ptr.add(self.inner.p.offset as usize);
+                std::slice::from_raw_parts(data, len)
+            }
+        }
+    }
+
+    #[inline]
+    fn as_bytes_mut(&mut self, ptr: *mut u8) -> &mut [u8] {
+        let len = self.len();
+        if len <= 14 {
+            unsafe { &mut self.inner.v.data[..len] }
+        } else {
+            unsafe { 
+                let data = ptr.add(self.inner.p.offset as usize);
+                std::slice::from_raw_parts_mut(data, len)
+            }
+        }
+    }
+
+    #[inline]
+    fn as_str(&self, ptr: *const u8) -> &str {
+        let len = self.len();
+        if len <= 14 {
+            unsafe { std::str::from_utf8_unchecked(&self.inner.v.data[..len]) }
+        } else {
+            unsafe { 
+                let data = ptr.add(self.inner.p.offset as usize);
+                let bytes = std::slice::from_raw_parts(data, len);
+                std::str::from_utf8_unchecked(bytes)
+            }
+        }
+    }
+
+    #[inline]
+    fn as_str_mut(&mut self, ptr: *mut u8) -> &mut str {
+        let len = self.len();
+        if len <= 14 {
+            unsafe { std::str::from_utf8_unchecked_mut(&mut self.inner.v.data[..len]) }
+        } else {
+            unsafe { 
+                let data = ptr.add(self.inner.p.offset as usize);
+                let bytes = std::slice::from_raw_parts_mut(data, len);
+                std::str::from_utf8_unchecked_mut(bytes)
+            }
+        }
+    }
+}
+
+impl ValueSlice for [VarByteVal] {}
+
+union VarByteInner {
+    v: Inline,
+    p: Pointer,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Inline {
+    len: u16,
+    data: [u8; 14],
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Pointer {
+    len: u16,
+    offset: u16,
+    prefix: [u8; 12],
+}


### PR DESCRIPTION
Refine row page with PAX format, adding delete bitset, null bitset, column offset list.
Define column layouts with 1,2,4,8 and variable bytes.
Transactional info will be kept in separate location, so row page won't maintain them.