### PR TITLE
add redo logger abstraction and example program to test multi-threaded trx

### DIFF
--- a/doradb-storage/Cargo.toml
+++ b/doradb-storage/Cargo.toml
@@ -25,3 +25,4 @@ flume = "0.11"
 [dev-dependencies]
 rand = "0.8"
 bitcode = { version = "0.6.3", features = ["serde"] }
+clap = { version = "4.5", features = ["derive"] }

--- a/doradb-storage/examples/multi_threaded_trx.rs
+++ b/doradb-storage/examples/multi_threaded_trx.rs
@@ -1,0 +1,113 @@
+//! Multi-threaded transaction processing.
+//! This example runs empty transactions via multiple threads. 
+//! Its goal is to testing system bottleneck on starting and committing transactions.
+use doradb_storage::prelude::*;
+use doradb_storage::trx::redo::{RedoBin, RedoLogger};
+use clap::Parser;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+use std::io::BufWriter;
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let args = Args::parse();
+    let stop = Arc::new(AtomicBool::new(false));
+    let trx_sys = TransactionSystem::new_static();
+    if args.gc_enabled {
+        trx_sys.start_gc_thread();
+    }
+    if let Some(log_file) = &args.log_file {
+        let logger = CtsOnlyRedoLogger::new(log_file, args.buf_size);
+        trx_sys.set_redo_logger(Box::new(logger));
+    }
+    {
+        let mut total_trx_count = 0;
+        let mut handles = vec![];
+        let start = Instant::now();
+        for _ in 1..args.threads {
+            let stop = Arc::clone(&stop);
+            let handle =
+                std::thread::spawn(move || worker(trx_sys, args.count, stop));
+            handles.push(handle);
+        }
+        total_trx_count += worker(trx_sys, args.count, stop);
+        for handle in handles {
+            total_trx_count += handle.join().unwrap();
+        }
+        let dur = start.elapsed();
+        println!(
+            "{:?} transactions cost {:?} microseconds, avg {:?} trx/s",
+            total_trx_count,
+            dur.as_micros(),
+            total_trx_count as f64 * 1_000_000_000f64 / dur.as_nanos() as f64
+        );
+    }
+    unsafe { TransactionSystem::drop_static(trx_sys); }
+}
+
+#[inline]
+fn worker(trx_sys: &TransactionSystem, max_count: usize, stop: Arc<AtomicBool>) -> usize {
+    let mut count = 0;
+    let stop = &*stop;
+    while !stop.load(Ordering::Relaxed) {
+        let trx = trx_sys.new_trx();
+        trx_sys.commit(trx);
+        count += 1;
+        if count == max_count {
+            stop.store(true, Ordering::SeqCst); // notify others to stop.
+            break;
+        }
+    }
+    count
+}
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// thread number to run transactions
+    #[arg(short, long, default_value = "4")]
+    threads: usize,
+
+    /// Number of transactions at least one thread should complete
+    #[arg(short, long, default_value = "100000")]
+    count: usize,
+
+    /// path of redo log file
+    #[arg(short, long, default_value = "redo.log")]
+    log_file: Option<String>,
+
+    /// size of redo log buffer
+    #[arg(short, long, default_value = "4096")]
+    buf_size: usize,
+
+    /// whether to enable GC
+    #[arg(short, long)]
+    gc_enabled: bool,
+}
+
+struct CtsOnlyRedoLogger {
+    writer: BufWriter<File>,
+}
+
+impl CtsOnlyRedoLogger {
+    #[inline]
+    fn new(log_file: &str, buf_size: usize) -> Self {
+        let f = File::create(log_file).expect("fail to create log file");
+        let writer = BufWriter::with_capacity(buf_size, f);
+        CtsOnlyRedoLogger {writer}
+    }
+}
+
+impl RedoLogger for CtsOnlyRedoLogger {
+    #[inline]
+    fn write(&mut self, cts: TrxID, _redo_bin: RedoBin) {
+        write!(self.writer, "{}\n", cts).unwrap();
+    }
+
+    #[inline]
+    fn sync(&mut self) {
+        self.writer.flush().unwrap();
+    }
+}

--- a/doradb-storage/src/lib.rs
+++ b/doradb-storage/src/lib.rs
@@ -8,3 +8,11 @@ pub mod row;
 pub mod trx;
 pub mod value;
 pub mod table;
+
+pub mod prelude {
+    pub use crate::trx::*;
+    pub use crate::trx::sys::*;
+    pub use crate::error::*;
+    pub use crate::value::*;
+    pub use crate::table::*;
+}

--- a/doradb-storage/src/trx/mod.rs
+++ b/doradb-storage/src/trx/mod.rs
@@ -103,6 +103,8 @@ impl ActiveTrx {
         debug_assert!(self.stmt_redo.is_empty());
         // use bincode to serialize redo log
         let redo_bin = if self.trx_redo.is_empty() {
+            // todo: only for test
+            // Some(vec![])
             None
         } else {
             // todo: use customized serialization method, and keep CTS placeholder.

--- a/doradb-storage/src/trx/redo.rs
+++ b/doradb-storage/src/trx/redo.rs
@@ -28,13 +28,14 @@ pub struct RedoLog {
 /// RedoBin is serialized redo log in binary format
 pub type RedoBin = Vec<u8>;
 
-pub struct RedoLogger;
+/// Abstraction of redo logger.
+/// It's responsible to persist redo logs and wait for it's persisted.
+pub trait RedoLogger {
+    /// Write redo binary logs to disk.
+    fn write(&mut self, cts: TrxID, redo_bin: RedoBin);
 
-impl RedoLogger {
-    #[inline]
-    pub fn log(&mut self) {
-        // todo
-    }
+    /// wait for previous written logs to be persisted.
+    fn sync(&mut self);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Current group commit is similar to the implementation of MySQL, without multiple stages.
But it's not performant in multi-threaded environment.
The test of example program shows, when redo log disabled, the group commit encounters a large drop when there are more than 4 threads, contending the global mutex...
I'd like to try an optimization to use ringbuffer directly to aggregate logs to eliminate the lock in group commit.