### PR TITLE
simplify undo log ownership and remove locks

### DIFF
--- a/doradb-storage/src/row/ops.rs
+++ b/doradb-storage/src/row/ops.rs
@@ -2,68 +2,71 @@ use crate::row::{Row, RowID, RowMut};
 use crate::value::Val;
 use serde::{Deserialize, Serialize};
 
-pub enum SelectResult<'a> {
+pub enum Select<'a> {
     Ok(Row<'a>),
     RowDeleted(Row<'a>),
     RowNotFound,
 }
 
-impl SelectResult<'_> {
+impl Select<'_> {
     /// Returns if select succeeds.
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, SelectResult::Ok(_))
+        matches!(self, Select::Ok(_))
     }
 }
 
-pub enum SelectMvccResult {
+pub enum SelectMvcc {
     Ok(Vec<Val>),
     RowNotFound,
     InvalidIndex,
 }
 
-impl SelectMvccResult {
+impl SelectMvcc {
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, SelectMvccResult::Ok(_))
+        matches!(self, SelectMvcc::Ok(_))
     }
 }
 
-pub enum InsertResult {
+pub enum InsertRow {
     Ok(RowID),
     NoFreeSpaceOrRowID,
 }
 
-impl InsertResult {
+impl InsertRow {
     /// Returns if insert succeeds.
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, InsertResult::Ok(_))
+        matches!(self, InsertRow::Ok(_))
     }
 }
 
-pub enum InsertMvccResult {
+pub enum InsertMvcc {
+    // PageGuard is required if table has unique index and
+    // we may need to linke a deleted version to the new version.
+    // In such scenario, we should keep the page for shared mode
+    // and acquire row lock when we do the linking.
     Ok(RowID),
     WriteConflict,
     DuplicateKey,
 }
 
-impl InsertMvccResult {
+impl InsertMvcc {
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, InsertMvccResult::Ok(_))
+        matches!(self, InsertMvcc::Ok(_))
     }
 }
 
-pub enum MoveInsertResult {
+pub enum MoveInsert {
     Ok,
     None,
     WriteConflict,
     DuplicateKey,
-    Retry,
 }
 
-pub enum UpdateResult {
+pub enum Update {
     // RowID may change if the update is out-of-place.
     Ok(RowID),
     RowNotFound,
@@ -74,15 +77,15 @@ pub enum UpdateResult {
     NoFreeSpace(Vec<Val>),
 }
 
-impl UpdateResult {
+impl Update {
     /// Returns if update succeeds.
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, UpdateResult::Ok(..))
+        matches!(self, Update::Ok(..))
     }
 }
 
-pub enum UpdateMvccResult {
+pub enum UpdateMvcc {
     Ok(RowID),
     RowNotFound,
     RowDeleted,
@@ -91,11 +94,11 @@ pub enum UpdateMvccResult {
     Retry(Vec<UpdateCol>),
 }
 
-impl UpdateMvccResult {
+impl UpdateMvcc {
     /// Returns if update with undo succeeds.
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, UpdateMvccResult::Ok(_))
+        matches!(self, UpdateMvcc::Ok(_))
     }
 }
 
@@ -110,22 +113,22 @@ pub enum UpdateRow<'a> {
     NoFreeSpace(Vec<Val>),
 }
 
-pub enum DeleteResult {
+pub enum Delete {
     Ok,
     RowNotFound,
     RowAlreadyDeleted,
 }
 
-pub enum DeleteMvccResult {
+pub enum DeleteMvcc {
     Ok,
     RowNotFound,
     RowAlreadyDeleted,
     WriteConflict,
 }
 
-impl DeleteMvccResult {
+impl DeleteMvcc {
     #[inline]
     pub fn is_ok(&self) -> bool {
-        matches!(self, DeleteMvccResult::Ok)
+        matches!(self, DeleteMvcc::Ok)
     }
 }

--- a/doradb-storage/src/stmt.rs
+++ b/doradb-storage/src/stmt.rs
@@ -3,13 +3,13 @@ use crate::buffer::BufferPool;
 use crate::row::RowID;
 use crate::table::TableID;
 use crate::trx::redo::RedoEntry;
-use crate::trx::undo::SharedUndoEntry;
+use crate::trx::undo::OwnedUndoEntry;
 use crate::trx::ActiveTrx;
 
 pub struct Statement {
     pub trx: ActiveTrx,
     // statement-level undo logs.
-    pub undo: Vec<SharedUndoEntry>,
+    pub undo: Vec<OwnedUndoEntry>,
     // statement-level redo logs.
     pub redo: Vec<RedoEntry>,
 }
@@ -34,11 +34,6 @@ impl Statement {
     #[inline]
     pub fn rollback<P: BufferPool>(self, buf_pool: &P) -> ActiveTrx {
         todo!();
-    }
-
-    #[inline]
-    pub fn last_undo_entry(&self) -> Option<&SharedUndoEntry> {
-        self.undo.last()
     }
 
     #[inline]

--- a/doradb-storage/src/table/mod.rs
+++ b/doradb-storage/src/table/mod.rs
@@ -4,7 +4,6 @@ use crate::buffer::FixedBufferPool;
 use crate::index::{BlockIndex, SingleKeyIndex};
 use crate::table::mvcc::MvccTable;
 use crate::value::{Layout, Val};
-use std::ops::Deref;
 use std::sync::Arc;
 
 // todo: integrate with doradb_catalog::TableID.

--- a/doradb-storage/src/trx/mod.rs
+++ b/doradb-storage/src/trx/mod.rs
@@ -23,7 +23,7 @@ pub mod undo;
 use crate::session::{InternalSession, IntoSession, Session};
 use crate::stmt::Statement;
 use crate::trx::redo::{RedoBin, RedoEntry, RedoKind, RedoLog};
-use crate::trx::undo::SharedUndoEntry;
+use crate::trx::undo::OwnedUndoEntry;
 use crate::value::Val;
 use flume::{Receiver, Sender};
 use parking_lot::Mutex;
@@ -118,7 +118,7 @@ pub struct ActiveTrx {
     // which log partition it belongs to.
     pub log_partition_idx: usize,
     // transaction-level undo logs.
-    pub(crate) undo: Vec<SharedUndoEntry>,
+    pub(crate) undo: Vec<OwnedUndoEntry>,
     // transaction-level redo logs.
     pub(crate) redo: Vec<RedoEntry>,
     // session of current transaction.
@@ -259,7 +259,7 @@ pub struct PreparedTrx {
     status: Arc<SharedTrxStatus>,
     sts: TrxID,
     redo_bin: Option<RedoBin>,
-    undo: Vec<SharedUndoEntry>,
+    undo: Vec<OwnedUndoEntry>,
     session: Option<Box<InternalSession>>,
 }
 
@@ -316,7 +316,7 @@ pub struct PrecommitTrx {
     pub sts: TrxID,
     pub cts: TrxID,
     pub redo_bin: Option<RedoBin>,
-    pub undo: Vec<SharedUndoEntry>,
+    pub undo: Vec<OwnedUndoEntry>,
     session: Option<Box<InternalSession>>,
 }
 
@@ -371,7 +371,7 @@ impl IntoSession for PrecommitTrx {
 pub struct CommittedTrx {
     pub sts: TrxID,
     pub cts: TrxID,
-    pub undo: Vec<SharedUndoEntry>,
+    pub undo: Vec<OwnedUndoEntry>,
     session: Option<Box<InternalSession>>,
 }
 


### PR DESCRIPTION
Make undo log link single direction.
Remove lock which protects two pointers.
Let transaction undo buffer own undo logs.
This will simplify GC and speed up MVCC read.