### PR TITLE
improve mvcc with index, undo, rollback, catalog, etc

### DIFF
--- a/doradb-datatype/src/konst.rs
+++ b/doradb-datatype/src/konst.rs
@@ -218,6 +218,7 @@ pub const F64_ZERO: ValidF64 = ValidF64(0.0);
 pub const F64_ONE: ValidF64 = ValidF64(1.0);
 
 #[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
 pub struct ValidF64(f64);
 
 impl ValidF64 {
@@ -260,6 +261,7 @@ impl Ord for ValidF64 {
 }
 
 impl Hash for ValidF64 {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_u64(self.0.to_bits())
     }
@@ -267,6 +269,66 @@ impl Hash for ValidF64 {
 
 impl Deref for ValidF64 {
     type Target = f64;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub const F32_ZERO: ValidF32 = ValidF32(0.0);
+pub const F32_ONE: ValidF32 = ValidF32(1.0);
+
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub struct ValidF32(f32);
+
+impl ValidF32 {
+    #[inline]
+    pub fn new(value: f32) -> Option<Self> {
+        if value.is_infinite() || value.is_nan() {
+            None
+        } else {
+            Some(ValidF32(value))
+        }
+    }
+
+    #[inline]
+    pub const fn value(&self) -> f32 {
+        self.0
+    }
+}
+
+impl PartialEq for ValidF32 {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl Eq for ValidF32 {}
+
+impl PartialOrd for ValidF32 {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for ValidF32 {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.partial_cmp(&other.0).unwrap()
+    }
+}
+
+impl Hash for ValidF32 {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u32(self.0.to_bits())
+    }
+}
+
+impl Deref for ValidF32 {
+    type Target = f32;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/doradb-storage/examples/bench_channel.rs
+++ b/doradb-storage/examples/bench_channel.rs
@@ -18,6 +18,7 @@ fn channel_sync() {
             sum += data.len();
         }
         // println!("received sum={}", sum);
+        sum
     });
 
     let start = Instant::now();
@@ -77,6 +78,7 @@ fn mutex_deque() {
             sum += data.len();
         }
         // println!("received sum={}", sum);
+        sum
     });
 
     let start = Instant::now();
@@ -96,7 +98,7 @@ fn mutex_deque() {
 }
 
 #[inline]
-pub fn mutex_deque_unbounded<T>() -> (MutexDequeSender<T>, MutexDequeReceiver<T>) {
+fn mutex_deque_unbounded<T>() -> (MutexDequeSender<T>, MutexDequeReceiver<T>) {
     let inner = Arc::new(Inner::new());
     (MutexDequeSender(inner.clone()), MutexDequeReceiver(inner))
 }

--- a/doradb-storage/src/index/mod.rs
+++ b/doradb-storage/src/index/mod.rs
@@ -1,5 +1,7 @@
 mod block_index;
 mod secondary_index;
+mod smart_key;
 
 pub use block_index::*;
 pub use secondary_index::*;
+pub use smart_key::*;

--- a/doradb-storage/src/index/secondary_index.rs
+++ b/doradb-storage/src/index/secondary_index.rs
@@ -1,87 +1,313 @@
+use crate::index::smart_key::SmartKey;
 use crate::row::RowID;
-use crate::value::Val;
+use crate::table::schema::IndexSchema;
+use crate::value::{Val, ValKind, ValType};
+use doradb_datatype::konst::{ValidF32, ValidF64};
+use either::Either;
 use parking_lot::RwLock;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::mem::MaybeUninit;
+use std::sync::Arc;
 
-/// Simple index interface for single key.
-/// The purpose is to demonstrate MVCC functionality with index
-/// lookup.
-/// A full-featured index interface and implementation is to be
-/// developed soon.
-pub trait SingleKeyIndex {
-    fn lookup(&self, key: &Val) -> Option<RowID>;
+pub const INDEX_KEY_MAX_LEN: usize = 255;
 
-    fn insert(&self, key: Val, row_id: RowID) -> Option<RowID>;
+#[derive(Clone)]
+pub struct SecondaryIndex {
+    pub index_no: usize,
+    pub kind: IndexKind,
+}
 
-    fn insert_if_not_exists(&self, key: Val, row_id: RowID) -> Option<RowID>;
+impl SecondaryIndex {
+    #[inline]
+    pub fn new(index_no: usize, index_schema: &IndexSchema, user_col_types: &[ValType]) -> Self {
+        debug_assert!(!index_schema.keys.is_empty());
+        if index_schema.unique {
+            // create unique index
+            let kind = match &index_schema.keys[..] {
+                [] => unreachable!(),
+                [key] => {
+                    // single-key index
+                    let key_ty = user_col_types[key.user_col_idx as usize];
+                    match key_ty.kind {
+                        ValKind::I8 => IndexKind::unique(PartitionSingleKeyIndex::<i8>::empty()),
+                        ValKind::U8 => IndexKind::unique(PartitionSingleKeyIndex::<u8>::empty()),
+                        ValKind::I16 => IndexKind::unique(PartitionSingleKeyIndex::<i16>::empty()),
+                        ValKind::U16 => IndexKind::unique(PartitionSingleKeyIndex::<u16>::empty()),
+                        ValKind::I32 => IndexKind::unique(PartitionSingleKeyIndex::<i32>::empty()),
+                        ValKind::U32 => IndexKind::unique(PartitionSingleKeyIndex::<u32>::empty()),
+                        ValKind::I64 => IndexKind::unique(PartitionSingleKeyIndex::<i64>::empty()),
+                        ValKind::U64 => IndexKind::unique(PartitionSingleKeyIndex::<u64>::empty()),
+                        ValKind::F32 => {
+                            IndexKind::unique(PartitionSingleKeyIndex::<ValidF32>::empty())
+                        }
+                        ValKind::F64 => {
+                            IndexKind::unique(PartitionSingleKeyIndex::<ValidF64>::empty())
+                        }
+                        ValKind::VarByte => {
+                            IndexKind::unique(PartitionSingleKeyIndex::<SmartKey>::empty())
+                        }
+                    }
+                }
+                keys => {
+                    // multi-key index
+                    let types: Vec<_> = keys
+                        .iter()
+                        .map(|key| user_col_types[key.user_col_idx as usize])
+                        .collect();
+                    let encoder = multi_key_encoder(types);
+                    IndexKind::unique(PartitionMultiKeyIndex::empty(encoder))
+                }
+            };
+            return SecondaryIndex { index_no, kind };
+        }
+        // create non-unique index
+        todo!()
+    }
 
-    fn delete(&self, key: &Val) -> Option<RowID>;
+    #[inline]
+    pub fn is_unique(&self) -> bool {
+        matches!(self.kind, IndexKind::Unique(_))
+    }
 
-    fn compare_exchange(&self, key: &Val, old_row_id: RowID, new_row_id: RowID) -> bool;
+    #[inline]
+    pub fn unique(&self) -> Option<&dyn UniqueIndex> {
+        match &self.kind {
+            IndexKind::Unique(idx) => Some(&**idx),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn non_unique(&self) -> Option<&dyn NonUniqueIndex> {
+        match &self.kind {
+            IndexKind::NonUnique(idx) => Some(&**idx),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum IndexKind {
+    Unique(Arc<dyn UniqueIndex>),
+    NonUnique(Arc<dyn NonUniqueIndex>),
+}
+
+impl IndexKind {
+    #[inline]
+    pub fn unique<T: UniqueIndex + 'static>(index: T) -> Self {
+        IndexKind::Unique(Arc::new(index))
+    }
+}
+
+pub trait UniqueIndex {
+    fn lookup(&self, key: &[Val]) -> Option<RowID>;
+
+    fn insert(&self, key: &[Val], row_id: RowID) -> Option<RowID>;
+
+    fn insert_if_not_exists(&self, key: &[Val], row_id: RowID) -> Option<RowID>;
+
+    fn delete(&self, key: &[Val]) -> Option<RowID>;
+
+    fn compare_exchange(&self, key: &[Val], old_row_id: RowID, new_row_id: RowID) -> bool;
 
     // todo: scan
+}
+
+pub trait NonUniqueIndex {
+    fn lookup(&self, key: &[Val], res: &mut Vec<RowID>);
+
+    fn insert(&self, key: &[Val], row_id: RowID);
+
+    fn delete(&self, key: &[Val], row_id: RowID) -> bool;
+
+    fn update(&self, key: &[Val], old_row_id: RowID, new_row_id: RowID) -> bool;
+}
+
+pub trait EncodeKeySelf {
+    fn encode(key: &[Val]) -> Self;
+}
+
+macro_rules! impl_self_encode_int {
+    ($ty:ty, $func:ident) => {
+        impl EncodeKeySelf for $ty {
+            #[inline]
+            fn encode(key: &[Val]) -> Self {
+                key[0].$func().unwrap()
+            }
+        }
+    };
+}
+
+impl_self_encode_int!(i8, as_i8);
+impl_self_encode_int!(u8, as_u8);
+impl_self_encode_int!(i16, as_i16);
+impl_self_encode_int!(u16, as_u16);
+impl_self_encode_int!(i32, as_i32);
+impl_self_encode_int!(u32, as_u32);
+impl_self_encode_int!(i64, as_i64);
+impl_self_encode_int!(u64, as_u64);
+
+macro_rules! impl_self_encode_float {
+    ($ty:ty, $func:ident) => {
+        impl EncodeKeySelf for $ty {
+            #[inline]
+            fn encode(key: &[Val]) -> Self {
+                key[0].$func().unwrap()
+            }
+        }
+    };
+}
+
+impl_self_encode_float!(ValidF32, as_f32);
+impl_self_encode_float!(ValidF64, as_f64);
+
+impl EncodeKeySelf for SmartKey {
+    #[inline]
+    fn encode(key: &[Val]) -> Self {
+        let bs = key[0].as_bytes().unwrap();
+        SmartKey::from(bs)
+    }
+}
+
+pub trait EncodeMultiKeys {
+    fn encode(&self, key: &[Val]) -> Val;
+}
+
+#[inline]
+pub fn multi_key_encoder(types: Vec<ValType>) -> Either<FixLenEncoder, VarLenEncoder> {
+    debug_assert!(types.len() > 1);
+    if types.iter().all(|ty| ty.kind.is_fixed()) {
+        let len = types
+            .iter()
+            .map(|ty| ty.memcmp_encoded_len().unwrap())
+            .sum::<usize>();
+        let encoder = FixLenEncoder::new(types, len);
+        return Either::Left(encoder);
+    }
+    let min_len = types
+        .iter()
+        .map(|ty| ty.memcmp_encoded_len_maybe_var())
+        .sum::<usize>();
+    let encoder = VarLenEncoder::new(types, min_len);
+    Either::Right(encoder)
+}
+
+pub struct FixLenEncoder {
+    types: Box<[ValType]>,
+    len: usize,
+}
+
+impl FixLenEncoder {
+    #[inline]
+    pub fn new(types: Vec<ValType>, len: usize) -> Self {
+        debug_assert!(types.len() > 1);
+        debug_assert!(types.iter().all(|ty| ty.kind.is_fixed()));
+        debug_assert!(
+            types
+                .iter()
+                .map(|ty| ty.memcmp_encoded_len().unwrap())
+                .sum::<usize>()
+                == len
+        );
+        FixLenEncoder {
+            types: types.into_boxed_slice(),
+            len,
+        }
+    }
+}
+
+impl EncodeMultiKeys for FixLenEncoder {
+    #[inline]
+    fn encode(&self, key: &[Val]) -> Val {
+        debug_assert!(key.len() == self.types.len());
+        let mut buf = Vec::with_capacity(self.len);
+        for (ty, val) in self.types.iter().zip(key) {
+            val.encode_memcmp(*ty, &mut buf);
+        }
+        Val::from(buf)
+    }
+}
+
+pub struct VarLenEncoder {
+    types: Box<[ValType]>,
+    min_len: usize,
+}
+
+impl VarLenEncoder {
+    #[inline]
+    pub fn new(types: Vec<ValType>, min_len: usize) -> Self {
+        debug_assert!(types.len() > 1);
+        debug_assert!(types.iter().any(|ty| !ty.kind.is_fixed()));
+        VarLenEncoder {
+            types: types.into_boxed_slice(),
+            min_len,
+        }
+    }
+}
+
+impl VarLenEncoder {
+    #[inline]
+    fn encode(&self, key: &[Val]) -> Val {
+        debug_assert!(key.len() == self.types.len());
+        let mut buf = Vec::with_capacity(self.min_len);
+        for (ty, val) in self.types.iter().zip(key) {
+            val.encode_memcmp(*ty, &mut buf);
+        }
+        Val::from(buf)
+    }
 }
 
 pub const INDEX_PARTITIONS: usize = 64;
 
 // Simple partitioned index implementation backed by BTreeMap in standard library.
-pub struct PartitionIntIndex([RwLock<BTreeMap<i32, RowID>>; INDEX_PARTITIONS]);
+pub struct PartitionSingleKeyIndex<T>([RwLock<BTreeMap<T, RowID>>; INDEX_PARTITIONS]);
 
-impl PartitionIntIndex {
+impl<T: Hash> PartitionSingleKeyIndex<T> {
     #[inline]
     pub fn empty() -> Self {
-        let mut init: MaybeUninit<[RwLock<BTreeMap<i32, RowID>>; INDEX_PARTITIONS]> =
+        let mut init: MaybeUninit<[RwLock<BTreeMap<T, RowID>>; INDEX_PARTITIONS]> =
             MaybeUninit::uninit();
         let array = unsafe {
             for ptr in init.assume_init_mut().iter_mut() {
-                (ptr as *mut RwLock<BTreeMap<i32, RowID>>).write(RwLock::new(BTreeMap::new()));
+                (ptr as *mut RwLock<BTreeMap<T, RowID>>).write(RwLock::new(BTreeMap::new()));
             }
             init.assume_init()
         };
-        PartitionIntIndex(array)
+        PartitionSingleKeyIndex(array)
     }
 
     #[inline]
-    fn select(&self, key: i32) -> &RwLock<BTreeMap<i32, RowID>> {
+    fn select(&self, key: &T) -> &RwLock<BTreeMap<T, RowID>> {
         let mut hasher = DefaultHasher::new();
         key.hash(&mut hasher);
         let hash = hasher.finish();
         &self.0[hash as usize % INDEX_PARTITIONS]
     }
-
-    #[inline]
-    fn key_to_int(&self, key: &Val) -> i32 {
-        match key {
-            Val::Byte4(v) => *v as i32,
-            _ => panic!("other key type not support"),
-        }
-    }
 }
 
-impl SingleKeyIndex for PartitionIntIndex {
+impl<T: Hash + Ord + EncodeKeySelf> UniqueIndex for PartitionSingleKeyIndex<T> {
     #[inline]
-    fn lookup(&self, key: &Val) -> Option<RowID> {
-        let key = self.key_to_int(key);
-        let tree = self.select(key);
+    fn lookup(&self, key: &[Val]) -> Option<RowID> {
+        let key = T::encode(key);
+        let tree = self.select(&key);
         let g = tree.read();
         g.get(&key).cloned()
     }
 
     #[inline]
-    fn insert(&self, key: Val, row_id: RowID) -> Option<RowID> {
-        let key = self.key_to_int(&key);
-        let tree = self.select(key);
+    fn insert(&self, key: &[Val], row_id: RowID) -> Option<RowID> {
+        let key = T::encode(key);
+        let tree = self.select(&key);
         let mut g = tree.write();
         g.insert(key, row_id)
     }
 
     #[inline]
-    fn insert_if_not_exists(&self, key: Val, row_id: RowID) -> Option<RowID> {
-        let key = self.key_to_int(&key);
-        let tree = self.select(key);
+    fn insert_if_not_exists(&self, key: &[Val], row_id: RowID) -> Option<RowID> {
+        let key = T::encode(key);
+        let tree = self.select(&key);
         let mut g = tree.write();
         match g.entry(key) {
             Entry::Occupied(occ) => Some(*occ.get()),
@@ -93,17 +319,17 @@ impl SingleKeyIndex for PartitionIntIndex {
     }
 
     #[inline]
-    fn delete(&self, key: &Val) -> Option<RowID> {
-        let key = self.key_to_int(key);
-        let tree = self.select(key);
+    fn delete(&self, key: &[Val]) -> Option<RowID> {
+        let key = T::encode(key);
+        let tree = self.select(&key);
         let mut g = tree.write();
         g.remove(&key)
     }
 
     #[inline]
-    fn compare_exchange(&self, key: &Val, old_row_id: RowID, new_row_id: RowID) -> bool {
-        let key = self.key_to_int(key);
-        let tree = self.select(key);
+    fn compare_exchange(&self, key: &[Val], old_row_id: RowID, new_row_id: RowID) -> bool {
+        let key = T::encode(key);
+        let tree = self.select(&key);
         let mut g = tree.write();
         match g.get_mut(&key) {
             Some(row_id) => {
@@ -116,5 +342,63 @@ impl SingleKeyIndex for PartitionIntIndex {
             }
             None => false,
         }
+    }
+}
+
+pub struct PartitionMultiKeyIndex {
+    encoder: Either<FixLenEncoder, VarLenEncoder>,
+    index: PartitionSingleKeyIndex<SmartKey>,
+}
+
+impl PartitionMultiKeyIndex {
+    #[inline]
+    pub fn empty(encoder: Either<FixLenEncoder, VarLenEncoder>) -> Self {
+        let index = PartitionSingleKeyIndex::empty();
+        PartitionMultiKeyIndex { encoder, index }
+    }
+
+    #[inline]
+    pub fn encode(&self, key: &[Val]) -> Val {
+        match &self.encoder {
+            Either::Left(fe) => fe.encode(key),
+            Either::Right(ve) => ve.encode(key),
+        }
+    }
+}
+
+impl UniqueIndex for PartitionMultiKeyIndex {
+    #[inline]
+    fn lookup(&self, key: &[Val]) -> Option<RowID> {
+        let key = self.encode(key);
+        let key = std::slice::from_ref(&key);
+        self.index.lookup(key)
+    }
+
+    #[inline]
+    fn insert(&self, key: &[Val], row_id: RowID) -> Option<RowID> {
+        let key = self.encode(key);
+        let key = std::slice::from_ref(&key);
+        self.index.insert(key, row_id)
+    }
+
+    #[inline]
+    fn insert_if_not_exists(&self, key: &[Val], row_id: RowID) -> Option<RowID> {
+        let key = self.encode(key);
+        let key = std::slice::from_ref(&key);
+        self.index.insert_if_not_exists(key, row_id)
+    }
+
+    #[inline]
+    fn delete(&self, key: &[Val]) -> Option<RowID> {
+        let key = self.encode(key);
+        let key = std::slice::from_ref(&key);
+        self.index.delete(key)
+    }
+
+    #[inline]
+    fn compare_exchange(&self, key: &[Val], old_row_id: RowID, new_row_id: RowID) -> bool {
+        let key = self.encode(key);
+        let key = std::slice::from_ref(&key);
+        self.index.compare_exchange(key, old_row_id, new_row_id)
     }
 }

--- a/doradb-storage/src/index/smart_key.rs
+++ b/doradb-storage/src/index/smart_key.rs
@@ -1,0 +1,146 @@
+use std::alloc::{alloc, Layout};
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::mem::{self, ManuallyDrop, MaybeUninit};
+use std::ops::Deref;
+
+pub const SMART_KEY_LEN: usize = 64;
+pub const SMART_KEY_INLINE: usize = SMART_KEY_LEN - mem::size_of::<usize>();
+pub const SMART_KEY_HEAP_PREFIX: usize =
+    SMART_KEY_LEN - mem::size_of::<usize>() - mem::size_of::<Box<[u8]>>();
+
+#[repr(transparent)]
+pub struct SmartKey(Inner);
+
+impl SmartKey {
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        if self.0.len <= SMART_KEY_INLINE {
+            unsafe { &self.0.u.i[..self.0.len] }
+        } else {
+            unsafe { &self.0.u.h.data[..self.0.len] }
+        }
+    }
+}
+
+impl From<Vec<u8>> for SmartKey {
+    #[inline]
+    fn from(mut value: Vec<u8>) -> Self {
+        if value.len() <= SMART_KEY_INLINE {
+            unsafe {
+                let mut k = MaybeUninit::<SmartKey>::uninit();
+                let k_mut = k.assume_init_mut();
+                k_mut.0.len = value.len();
+                k_mut.0.u.i[..value.len()].copy_from_slice(&value);
+                return k.assume_init();
+            };
+        }
+        unsafe {
+            // avoid allocation caused by shrinking.
+            let len = value.len();
+            let cap = value.capacity();
+            value.set_len(cap);
+            let data = value.into_boxed_slice();
+            let mut k = MaybeUninit::<SmartKey>::uninit();
+            let k_mut = k.assume_init_mut();
+            k_mut.0.len = len;
+            (*k_mut.0.u.h)
+                .prefix
+                .copy_from_slice(&data[..SMART_KEY_HEAP_PREFIX]);
+            std::ptr::write(&mut (*k_mut.0.u.h).data, data);
+            k.assume_init()
+        }
+    }
+}
+
+impl From<&[u8]> for SmartKey {
+    #[inline]
+    fn from(value: &[u8]) -> Self {
+        if value.len() <= SMART_KEY_INLINE {
+            unsafe {
+                let mut k = MaybeUninit::<SmartKey>::uninit();
+                let k_mut = k.assume_init_mut();
+                k_mut.0.len = value.len();
+                k_mut.0.u.i[..value.len()].copy_from_slice(&value);
+                return k.assume_init();
+            };
+        }
+        unsafe {
+            let ptr = alloc(Layout::from_size_align_unchecked(value.len(), 1));
+            let mut data = Vec::from_raw_parts(ptr, value.len(), value.len());
+            data.copy_from_slice(value);
+            let data = data.into_boxed_slice();
+            let mut k = MaybeUninit::<SmartKey>::uninit();
+            let k_mut = k.assume_init_mut();
+            k_mut.0.len = value.len();
+            (*k_mut.0.u.h)
+                .prefix
+                .copy_from_slice(&data[..SMART_KEY_HEAP_PREFIX]);
+            std::ptr::write(&mut (*k_mut.0.u.h).data, data);
+            k.assume_init()
+        }
+    }
+}
+
+impl Deref for SmartKey {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
+    }
+}
+
+impl Drop for SmartKey {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.len > SMART_KEY_INLINE {
+            unsafe {
+                ManuallyDrop::drop(&mut self.0.u.h);
+            }
+        }
+    }
+}
+
+impl Hash for SmartKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
+impl PartialEq for SmartKey {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes().eq(other.as_bytes())
+    }
+}
+
+impl Eq for SmartKey {}
+
+impl Ord for SmartKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_bytes().cmp(other.as_bytes())
+    }
+}
+
+impl PartialOrd for SmartKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[repr(C)]
+struct Inner {
+    len: usize,
+    u: InlineOrHeap,
+}
+
+union InlineOrHeap {
+    i: [u8; SMART_KEY_INLINE],
+    h: ManuallyDrop<Heap>,
+}
+
+#[repr(C)]
+struct Heap {
+    data: Box<[u8]>,
+    prefix: [u8; SMART_KEY_HEAP_PREFIX],
+}

--- a/doradb-storage/src/row/ops.rs
+++ b/doradb-storage/src/row/ops.rs
@@ -1,6 +1,28 @@
-use crate::row::{Row, RowID, RowMut};
+use crate::buffer::guard::PageSharedGuard;
+use crate::row::{Row, RowID, RowMut, RowPage};
 use crate::value::Val;
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SelectKey {
+    pub index_no: usize,
+    pub vals: Vec<Val>,
+}
+
+impl SelectKey {
+    #[inline]
+    pub fn new(index_no: usize, vals: Vec<Val>) -> Self {
+        SelectKey { index_no, vals }
+    }
+
+    #[inline]
+    pub fn null(index_no: usize, val_count: usize) -> Self {
+        SelectKey {
+            index_no,
+            vals: vec![Val::Null; val_count],
+        }
+    }
+}
 
 pub enum Select<'a> {
     Ok(Row<'a>),
@@ -85,7 +107,7 @@ impl InsertMvcc {
     }
 }
 
-pub enum MoveInsert {
+pub enum MoveLinkForIndex {
     Ok,
     None,
     WriteConflict,
@@ -127,6 +149,7 @@ impl UpdateMvcc {
 }
 
 pub enum UpdateIndex {
+    // sometimes we may get back page guard to update next index.
     Ok,
     WriteConflict,
     DuplicateKey,

--- a/doradb-storage/src/stmt.rs
+++ b/doradb-storage/src/stmt.rs
@@ -1,20 +1,18 @@
-use crate::buffer::guard::PageGuard;
 use crate::buffer::page::PageID;
 use crate::buffer::BufferPool;
 use crate::catalog::Catalog;
-use crate::latch::LatchFallbackMode;
-use crate::row::{RowID, RowPage};
+use crate::row::RowID;
 use crate::table::TableID;
 use crate::trx::redo::RedoEntry;
-use crate::trx::undo::{IndexUndo, IndexUndoKind, OwnedRowUndo};
+use crate::trx::undo::{IndexUndoLogs, RowUndoLogs};
 use crate::trx::ActiveTrx;
 
 pub struct Statement {
     pub trx: ActiveTrx,
     // statement-level undo logs of row data.
-    pub row_undo: Vec<OwnedRowUndo>,
+    pub row_undo: RowUndoLogs,
     // statement-level index undo operations.
-    pub index_undo: Vec<IndexUndo>,
+    pub index_undo: IndexUndoLogs,
     // statement-level redo logs.
     pub redo: Vec<RedoEntry>,
 }
@@ -24,48 +22,34 @@ impl Statement {
     pub fn new(trx: ActiveTrx) -> Self {
         Statement {
             trx,
-            row_undo: vec![],
-            index_undo: vec![],
+            row_undo: RowUndoLogs::empty(),
+            index_undo: IndexUndoLogs::empty(),
             redo: vec![],
         }
     }
 }
 
 impl Statement {
+    /// Succeed current statement and return transaction it belongs to.
+    /// All undo and redo logs it holds will be merged into transaction buffer.
     #[inline]
-    pub fn commit(mut self) -> ActiveTrx {
-        self.trx.row_undo.extend(self.row_undo.drain(..));
-        self.trx.index_undo.extend(self.index_undo.drain(..));
+    pub fn succeed(mut self) -> ActiveTrx {
+        self.trx.row_undo.merge(&mut self.row_undo);
+        self.trx.index_undo.merge(&mut self.index_undo);
         self.trx.redo.extend(self.redo.drain(..));
         self.trx
     }
 
-    /// Statement level rollback.
+    /// Fail current statement and return transaction it belongs to.
+    /// This will trigger statement-level rollback based on its undo.
+    /// Redo logs will be discarded.
     #[inline]
-    pub fn rollback<P: BufferPool>(mut self, buf_pool: &P, catalog: &Catalog<P>) -> ActiveTrx {
+    pub fn fail<P: BufferPool>(mut self, buf_pool: &P, catalog: &Catalog<P>) -> ActiveTrx {
         // rollback row data.
         // todo: group by page level may be better.
-        while let Some(entry) = self.row_undo.pop() {
-            let page_guard: PageGuard<'_, RowPage> =
-                buf_pool.get_page(entry.page_id, LatchFallbackMode::Shared);
-            let page_guard = page_guard.block_until_shared();
-            let row_idx = page_guard.page().row_idx(entry.row_id);
-            let mut access = page_guard.write_row(row_idx);
-            access.rollback_first_undo(entry);
-        }
+        self.row_undo.rollback(buf_pool);
         // rollback index data.
-        while let Some(entry) = self.index_undo.pop() {
-            let table = catalog.get_table(entry.table_id).unwrap();
-            match entry.kind {
-                IndexUndoKind::Insert(key, row_id) => {
-                    let res = table.sec_idx.delete(&key);
-                    assert!(res.unwrap() == row_id);
-                }
-                IndexUndoKind::Update(key, old_id, new_id) => {
-                    assert!(table.sec_idx.compare_exchange(&key, new_id, old_id));
-                }
-            }
-        }
+        self.index_undo.rollback(catalog);
         // clear redo logs.
         self.redo.clear();
         self.trx

--- a/doradb-storage/src/trx/undo/index.rs
+++ b/doradb-storage/src/trx/undo/index.rs
@@ -1,19 +1,108 @@
+use crate::buffer::BufferPool;
+use crate::catalog::Catalog;
+use crate::row::ops::SelectKey;
 use crate::row::RowID;
 use crate::table::TableID;
-use crate::value::Val;
+
+#[derive(Default)]
+pub struct IndexUndoLogs(Vec<IndexUndo>);
+
+impl IndexUndoLogs {
+    /// Create an empty index undo buffer.
+    #[inline]
+    pub fn empty() -> Self {
+        IndexUndoLogs(vec![])
+    }
+
+    /// Returns whether the index undo buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Add a new index undo log at end of the buffer.
+    #[inline]
+    pub fn push(&mut self, value: IndexUndo) {
+        self.0.push(value);
+    }
+
+    /// Rollback all index changes.
+    #[inline]
+    pub fn rollback<P: BufferPool>(&mut self, catalog: &Catalog<P>) {
+        while let Some(entry) = self.0.pop() {
+            let table = catalog.get_table(entry.table_id).unwrap();
+            match entry.kind {
+                IndexUndoKind::InsertUnique(key) => {
+                    let res = table.sec_idx[key.index_no]
+                        .unique()
+                        .unwrap()
+                        .delete(&key.vals);
+                    assert!(res.unwrap() == entry.row_id);
+                }
+                IndexUndoKind::UpdateUnique(key, old_row_id) => {
+                    let new_row_id = entry.row_id;
+                    let res = table.sec_idx[key.index_no]
+                        .unique()
+                        .unwrap()
+                        .compare_exchange(&key.vals, new_row_id, old_row_id);
+                    assert!(res);
+                }
+                IndexUndoKind::GC(_) => (), // do nothing.
+            }
+        }
+    }
+
+    /// Merge another undo log buffer.
+    /// This is used when a statement succeeds, and statement-level index undo buffer
+    /// should be merged into transaction-level index undo buffer.
+    #[inline]
+    pub fn merge(&mut self, other: &mut Self) {
+        self.0.extend(other.0.drain(..));
+    }
+
+    /// Prepare index undo logs for GC.
+    /// Index undo logs is mainly for proactive/passive rollback.
+    /// And to support MVCC, index deletion is delayed to GC phase.
+    /// So here we should only keep potential index deletions.
+    #[inline]
+    pub fn prepare_for_gc(&mut self) -> Self {
+        let logs_for_gc: Vec<_> = self
+            .0
+            .drain(..)
+            .filter_map(|entry| match entry.kind {
+                IndexUndoKind::InsertUnique(_) => None,
+                IndexUndoKind::UpdateUnique(key, old_row_id) => {
+                    let kind = IndexUndoKind::GC(key);
+                    Some(IndexUndo {
+                        table_id: entry.table_id,
+                        row_id: old_row_id,
+                        kind,
+                    })
+                }
+                IndexUndoKind::GC(_) => Some(entry),
+            })
+            .collect();
+        IndexUndoLogs(logs_for_gc)
+    }
+}
 
 /// IndexUndo represent the undo operation of a index.
 pub struct IndexUndo {
     pub table_id: TableID,
+    // The new row id of index change.
+    pub row_id: RowID,
     pub kind: IndexUndoKind,
 }
 
 pub enum IndexUndoKind {
-    // Insert key -> row_id into index.
-    Insert(Val, RowID),
-    // Update key -> old_row_id to key -> new_row_id.
-    Update(Val, RowID, RowID),
-    // Delete is not included in index undo.
-    // Because the deletion of index will only be executed by GC thread,
-    // not transaction thread. So DELETE undo is unneccessary.
+    /// Insert key.
+    InsertUnique(SelectKey),
+    /// Update key and old row id.
+    UpdateUnique(SelectKey, RowID),
+    /// Delete is not included in index undo,
+    /// because transaction thread does not perform index deletion,
+    /// in order to support MVCC.
+    /// The actual deletion is performed solely by GC thread.
+    /// This is what GC entry means.
+    GC(SelectKey),
 }


### PR DESCRIPTION
Improve MVCC with following:
1. Add simple catalog to retrieve table instance for statement-level rollback.
2. Implement unique index with single-key and multi-key partitioned btree map.
3. Simple SmartKey for index key(not used).
4. Statement-level rollback.
5. lightweight row undo log structure refactor.
6. Index undo for rollback and GC.
7. Reborn branch in row undo chain.
 