### PR TITLE
implement unique index for btree

### DIFF
--- a/doradb-storage/Cargo.toml
+++ b/doradb-storage/Cargo.toml
@@ -32,6 +32,7 @@ byte-unit = { version = "5", features = ["serde"] }
 glob = "0.3"
 memmap2 = "0.9"
 async-lock = "3"
+futures = "0.3"
 
 [features]
 default = []
@@ -50,4 +51,3 @@ perfcnt = "0.8"
 fastrand = "2"
 tikv-jemallocator = "0.6"
 bplustree = "0.1.0"
-futures = "0.3"

--- a/doradb-storage/examples/btree_analysis.rs
+++ b/doradb-storage/examples/btree_analysis.rs
@@ -1,7 +1,7 @@
 use byte_unit::{Byte, ParseError};
 use clap::Parser;
 use doradb_storage::buffer::{BufferPool, FixedBufferPool};
-use doradb_storage::index::{BTree, BTreeCompactConfig};
+use doradb_storage::index::{BTree, BTreeCompactConfig, BTreeU64};
 use doradb_storage::lifetime::StaticLifetime;
 use rand_distr::{Distribution, Poisson, Uniform};
 
@@ -24,7 +24,7 @@ async fn single_thread_bench_btree(args: &Args) {
         match &args.mode[..] {
             "seq" => {
                 for i in 0..args.total_rows {
-                    tree.insert(&i.to_be_bytes(), i, 100).await;
+                    tree.insert(&i.to_be_bytes(), BTreeU64::from(i), 100).await;
                 }
             }
             "rand" => {
@@ -32,7 +32,7 @@ async fn single_thread_bench_btree(args: &Args) {
                 let mut thd_rng = rand::rng();
                 for i in 0..args.total_rows {
                     let k = between.sample(&mut thd_rng);
-                    tree.insert(&k.to_be_bytes(), i, 100).await;
+                    tree.insert(&k.to_be_bytes(), BTreeU64::from(i), 100).await;
                 }
             }
             _ => panic!("unknown mode"),
@@ -54,7 +54,7 @@ async fn single_thread_bench_btree(args: &Args) {
 
         if args.compact {
             let purge_list = tree
-                .compact_all::<u64>(BTreeCompactConfig::new(1.0, 1.0).unwrap())
+                .compact_all::<BTreeU64>(BTreeCompactConfig::new(1.0, 1.0).unwrap())
                 .await;
             for g in purge_list {
                 pool.deallocate_page(g);
@@ -71,7 +71,7 @@ async fn single_thread_bench_btree(args: &Args) {
         match &args.search_mode[..] {
             "seq" => {
                 for i in 0..args.total_rows {
-                    tree.lookup_optimistic::<u64>(&i.to_be_bytes()).await;
+                    tree.lookup_optimistic::<BTreeU64>(&i.to_be_bytes()).await;
                 }
             }
             "rand" => {
@@ -79,7 +79,7 @@ async fn single_thread_bench_btree(args: &Args) {
                 let mut thd_rng = rand::rng();
                 for _ in 0..args.total_rows {
                     let k = between.sample(&mut thd_rng);
-                    tree.lookup_optimistic::<u64>(&k.to_be_bytes()).await;
+                    tree.lookup_optimistic::<BTreeU64>(&k.to_be_bytes()).await;
                 }
             }
             "poisson" => {
@@ -87,7 +87,7 @@ async fn single_thread_bench_btree(args: &Args) {
                 let mut thd_rng = rand::rng();
                 for _ in 0..args.total_rows {
                     let k = between.sample(&mut thd_rng) as u64;
-                    tree.lookup_optimistic::<u64>(&k.to_be_bytes()).await;
+                    tree.lookup_optimistic::<BTreeU64>(&k.to_be_bytes()).await;
                 }
             }
             _ => panic!("unknown search mode"),

--- a/doradb-storage/src/engine.rs
+++ b/doradb-storage/src/engine.rs
@@ -41,7 +41,7 @@ impl Engine {
         Engine(EngineInner {
             trx_sys: self.0.trx_sys,
             meta_pool: self.0.meta_pool,
-            _index_pool: self.0._index_pool,
+            index_pool: self.0.index_pool,
             data_pool: self.0.data_pool,
             stop_all: false,
         })
@@ -54,7 +54,7 @@ pub struct EngineInner {
     pub meta_pool: &'static FixedBufferPool,
     // index pool is used for secondary index.
     // This pool will be optimized to support CoW B+tree index.
-    pub _index_pool: &'static FixedBufferPool,
+    pub index_pool: &'static FixedBufferPool,
     // data pool is used for data tables.
     pub data_pool: &'static EvictableBufferPool,
     // only one instance should have this flag to be true to
@@ -92,11 +92,11 @@ impl EngineInitializer {
         let trx_sys = self
             .trx_sys_config
             .build()
-            .init(self.meta_pool, self.data_pool)
+            .init(self.meta_pool, self.index_pool, self.data_pool)
             .await?;
         let engine = Engine(EngineInner {
             meta_pool: self.meta_pool,
-            _index_pool: self.index_pool,
+            index_pool: self.index_pool,
             data_pool: self.data_pool,
             trx_sys,
             stop_all: true,
@@ -106,11 +106,13 @@ impl EngineInitializer {
 }
 
 const DEFAULT_META_BUFFER: usize = 32 * 1024 * 1024;
+const DEFAULT_INDEX_BUFFER: usize = 1024 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EngineConfig {
     trx: TrxSysConfig,
     meta_buffer: Byte,
+    index_buffer: Byte,
     data_buffer: EvictableBufferPoolConfig,
 }
 
@@ -120,6 +122,7 @@ impl Default for EngineConfig {
         EngineConfig {
             trx: TrxSysConfig::default(),
             meta_buffer: Byte::from_u64(DEFAULT_META_BUFFER as u64),
+            index_buffer: Byte::from_u64(DEFAULT_INDEX_BUFFER as u64),
             data_buffer: EvictableBufferPoolConfig::default(),
         }
     }
@@ -139,6 +142,12 @@ impl EngineConfig {
     }
 
     #[inline]
+    pub fn index_buffer(mut self, index_buffer: impl Into<Byte>) -> Self {
+        self.index_buffer = index_buffer.into();
+        self
+    }
+
+    #[inline]
     pub fn data_buffer(mut self, data_buffer: EvictableBufferPoolConfig) -> Self {
         self.data_buffer = data_buffer;
         self
@@ -147,15 +156,16 @@ impl EngineConfig {
     #[inline]
     pub fn build(self) -> Result<EngineInitializer> {
         let meta_pool = FixedBufferPool::with_capacity_static(self.meta_buffer.as_u64() as usize)?;
-        // mock index pool using meta pool because index pool is not used.
         // todo: implement index pool
-        let (buf_pool, pool_start_ctx) = self.data_buffer.build()?;
-        let buf_pool = StaticLifetime::new_static(buf_pool);
-        buf_pool.start(pool_start_ctx);
+        let index_pool =
+            FixedBufferPool::with_capacity_static(self.index_buffer.as_u64() as usize)?;
+        let (data_pool, pool_start_ctx) = self.data_buffer.build()?;
+        let data_pool = StaticLifetime::new_static(data_pool);
+        data_pool.start(pool_start_ctx);
         Ok(EngineInitializer {
             meta_pool,
-            index_pool: meta_pool,
-            data_pool: buf_pool,
+            index_pool,
+            data_pool,
             trx_sys_config: self.trx,
         })
     }

--- a/doradb-storage/src/index/block_index.rs
+++ b/doradb-storage/src/index/block_index.rs
@@ -8,8 +8,7 @@ use crate::error::{
     Error, Result, Validation,
     Validation::{Invalid, Valid},
 };
-use crate::index::util::ParentPosition;
-use crate::index::util::RedoLogPageCommitter;
+use crate::index::util::{Maskable, ParentPosition, RedoLogPageCommitter};
 use crate::latch::LatchFallbackMode;
 use crate::row::{RowID, RowPage, INVALID_ROW_ID};
 use crate::trx::sys::TransactionSystem;
@@ -535,6 +534,7 @@ impl BlockIndex {
     /// Find location of given row id, maybe in column file or row page.
     #[inline]
     pub async fn find_row(&self, row_id: RowID) -> RowLocation {
+        debug_assert!(!row_id.is_deleted());
         loop {
             let res = self.try_find_row(row_id).await;
             let res = verify_continue!(res);

--- a/doradb-storage/src/index/btree_value.rs
+++ b/doradb-storage/src/index/btree_value.rs
@@ -1,0 +1,81 @@
+use crate::buffer::page::INVALID_PAGE_ID;
+use crate::index::util::Maskable;
+use crate::row::INVALID_ROW_ID;
+use std::ops::Deref;
+
+/// BTreeValue is the value type stored in leaf node.
+/// In branch node, the value type is always page id,
+/// which is a logical pointer to child node.
+///
+/// There are two implementations of BTreeValue.
+/// 1. BTreeU64(u64).
+///    a) PageID(u64): value of branch node, represents
+///    logical pointer to child node.
+///    b) RowID(u64), which supports unique index.
+/// 3. Single byte(u8), which supports non-unique index.
+///    Non-unique index is a bit complicated.
+///    The key of non-unique index is user-defined
+///    key followed by RowID, to make it unique for
+///    B-tree operations(e.g. deletion).
+///    As a consequence, if we still use RowID as
+///    value type, it's waste of space.
+///    Instead, we can only store single byte as its
+///    value, in order to represent delete bit.
+///    If we want to retrieve value, we can always
+///    extract last 8 byte from key and convert it
+///    to RowID.
+pub trait BTreeValue: Maskable {}
+
+/// U64 value type to support both page id in branch node
+/// and row id in leaf node.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct BTreeU64(u64);
+
+impl Deref for BTreeU64 {
+    type Target = u64;
+    #[inline]
+    fn deref(&self) -> &u64 {
+        &self.0
+    }
+}
+
+impl From<u64> for BTreeU64 {
+    #[inline]
+    fn from(value: u64) -> Self {
+        BTreeU64(value)
+    }
+}
+
+impl BTreeU64 {
+    #[inline]
+    pub fn to_u64(self) -> u64 {
+        self.0
+    }
+}
+
+const BTREE_VALUE_U64_DELETE_BIT: u64 = 1u64 << 63;
+
+const _: () = assert!(BTreeU64::INVALID_VALUE.0 == INVALID_ROW_ID);
+const _: () = assert!(BTreeU64::INVALID_VALUE.0 == INVALID_PAGE_ID);
+
+impl Maskable for BTreeU64 {
+    const INVALID_VALUE: Self = BTreeU64(!0);
+
+    #[inline]
+    fn deleted(self) -> Self {
+        BTreeU64(*self | BTREE_VALUE_U64_DELETE_BIT)
+    }
+
+    #[inline]
+    fn value(self) -> Self {
+        BTreeU64(*self & !BTREE_VALUE_U64_DELETE_BIT)
+    }
+
+    #[inline]
+    fn is_deleted(self) -> bool {
+        *self & BTREE_VALUE_U64_DELETE_BIT != 0
+    }
+}
+
+impl BTreeValue for BTreeU64 {}

--- a/doradb-storage/src/index/mod.rs
+++ b/doradb-storage/src/index/mod.rs
@@ -3,11 +3,13 @@ mod btree;
 mod btree_hint;
 mod btree_key;
 mod btree_node;
+mod btree_value;
 mod secondary_index;
-mod util;
+pub(crate) mod util;
 
 pub use block_index::*;
 pub use btree::*;
 pub use btree_key::*;
 pub use btree_node::*;
+pub use btree_value::*;
 pub use secondary_index::*;

--- a/doradb-storage/src/trx/purge.rs
+++ b/doradb-storage/src/trx/purge.rs
@@ -525,7 +525,7 @@ mod tests {
     use crate::buffer::guard::PageSharedGuard;
     use crate::buffer::EvictableBufferPoolConfig;
     use crate::engine::EngineConfig;
-    use crate::index::RowLocation;
+    use crate::index::{RowLocation, UniqueIndex};
     use crate::latch::LatchFallbackMode;
     use crate::row::ops::SelectKey;
     use crate::row::RowPage;
@@ -737,7 +737,7 @@ mod tests {
                 // see which one is not purged, and its cts.
                 let index = table.sec_idx[0].unique().unwrap();
                 let mut remained_row_ids = vec![];
-                index.scan_values(&mut remained_row_ids);
+                index.scan_values(&mut remained_row_ids, 100).await;
                 println!("gc timeout, remained_row_ids={:?}", remained_row_ids);
                 let row_id = remained_row_ids[0];
                 let location = table.blk_idx.find_row(row_id).await;


### PR DESCRIPTION
1. Implement unique index for B-tree, including unique index insert, update(value only), mask delete, delete(GC).
2. Add newtype for B-tree value, and refine B-tree public methods(with explicit delete flag).
3. Box BTreeNode when merge/split to avoid stack overflow among async calls.