### PR TITLE
Implement non-unique index for b-tree

### DIFF
--- a/doradb-storage/examples/bench_btree.rs
+++ b/doradb-storage/examples/bench_btree.rs
@@ -41,7 +41,8 @@ async fn single_thread_bench_btree(args: &Args) {
             "seq" => {
                 for i in 0..args.total_rows {
                     // trick to use lower 4 bytes as head
-                    tree.insert(&i.to_be_bytes(), BTreeU64::from(i), 100).await;
+                    tree.insert(&i.to_be_bytes(), BTreeU64::from(i), false, 100)
+                        .await;
                 }
             }
             "rand" => {
@@ -49,7 +50,8 @@ async fn single_thread_bench_btree(args: &Args) {
                 let mut thd_rng = rand::rng();
                 for i in 0..args.total_rows {
                     let k = between.sample(&mut thd_rng);
-                    tree.insert(&k.to_be_bytes(), BTreeU64::from(i), 100).await;
+                    tree.insert(&k.to_be_bytes(), BTreeU64::from(i), false, 100)
+                        .await;
                 }
             }
             _ => panic!("unknown mode"),

--- a/doradb-storage/examples/btree_analysis.rs
+++ b/doradb-storage/examples/btree_analysis.rs
@@ -24,7 +24,8 @@ async fn single_thread_bench_btree(args: &Args) {
         match &args.mode[..] {
             "seq" => {
                 for i in 0..args.total_rows {
-                    tree.insert(&i.to_be_bytes(), BTreeU64::from(i), 100).await;
+                    tree.insert(&i.to_be_bytes(), BTreeU64::from(i), false, 100)
+                        .await;
                 }
             }
             "rand" => {
@@ -32,7 +33,8 @@ async fn single_thread_bench_btree(args: &Args) {
                 let mut thd_rng = rand::rng();
                 for i in 0..args.total_rows {
                     let k = between.sample(&mut thd_rng);
-                    tree.insert(&k.to_be_bytes(), BTreeU64::from(i), 100).await;
+                    tree.insert(&k.to_be_bytes(), BTreeU64::from(i), false, 100)
+                        .await;
                 }
             }
             _ => panic!("unknown mode"),

--- a/doradb-storage/src/catalog/mod.rs
+++ b/doradb-storage/src/catalog/mod.rs
@@ -367,4 +367,57 @@ pub mod tests {
         drop(session);
         table_id
     }
+
+    /// Table4 has two i32 columns.
+    /// First is unique index.
+    /// Second is non-unique index.
+    #[inline]
+    pub(crate) async fn table4(engine: &Engine) -> TableID {
+        let schema_id = db1(engine).await;
+
+        let session = engine.new_session();
+        let trx = session.begin_trx();
+        let mut stmt = trx.start_stmt();
+
+        let table_id = stmt
+            .create_table(
+                schema_id,
+                TableSpec {
+                    table_name: SemiStr::new("table4"),
+                    columns: vec![
+                        ColumnSpec {
+                            column_name: SemiStr::new("id"),
+                            column_type: PreciseType::Int(4, false),
+                            column_attributes: ColumnAttributes::empty(),
+                        },
+                        ColumnSpec {
+                            column_name: SemiStr::new("val"),
+                            column_type: PreciseType::Int(4, false),
+                            column_attributes: ColumnAttributes::empty(),
+                        },
+                    ],
+                },
+                vec![
+                    IndexSpec::new(
+                        "idx_table4_id",
+                        vec![IndexKey::new(0)],
+                        // unique index.
+                        IndexAttributes::PK,
+                    ),
+                    IndexSpec::new(
+                        "idx_table4_val",
+                        vec![IndexKey::new(1)],
+                        // non-unique index.
+                        IndexAttributes::empty(),
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let trx = stmt.succeed();
+        let session = trx.commit().await.unwrap();
+        drop(session);
+        table_id
+    }
 }

--- a/doradb-storage/src/index/btree_hint.rs
+++ b/doradb-storage/src/index/btree_hint.rs
@@ -79,6 +79,7 @@ unsafe fn search_hints_avx2(hints: &[u32; 8], key_head: u32) -> (usize, usize) {
 }
 
 /// Search hints fallback method.
+#[allow(dead_code)]
 #[inline]
 fn search_hints_scalar(hints: &[u32; 8], key_head: u32) -> (usize, usize) {
     let i = hints.partition_point(|&h| h < key_head);

--- a/doradb-storage/src/index/btree_key.rs
+++ b/doradb-storage/src/index/btree_key.rs
@@ -23,6 +23,7 @@ trait KeyEncoder {
     /// This method is not recommended, unless the keys are dynamically added.
     /// Otherwise, we can always create fixed-length container with encode_len()
     /// and then encode_copy() keys into it.
+    #[allow(dead_code)]
     fn encode_extend<T: BytesExtendable>(&self, key: &Val, buf: &mut T);
 }
 

--- a/doradb-storage/src/index/mod.rs
+++ b/doradb-storage/src/index/mod.rs
@@ -15,5 +15,6 @@ pub use btree::*;
 pub use btree_key::*;
 pub use btree_node::*;
 pub use btree_value::*;
+pub use non_unique_index::*;
 pub use secondary_index::*;
 pub use unique_index::*;

--- a/doradb-storage/src/index/non_unique_index.rs
+++ b/doradb-storage/src/index/non_unique_index.rs
@@ -1,29 +1,60 @@
-use crate::index::btree::BTree;
+use crate::buffer::guard::PageGuard;
+use crate::index::btree::{BTree, BTreeDelete, BTreeInsert, BTreeUpdate};
 use crate::index::btree_key::BTreeKeyEncoder;
+use crate::index::btree_node::{BTreeNode, BTreeSlot};
+use crate::index::btree_scan::BTreeSlotCallback;
+use crate::index::btree_value::{BTreeByte, BTreeU64, BTREE_BYTE_ZERO};
+use crate::index::secondary_index::IndexInsert;
+use crate::index::util::Maskable;
 use crate::row::RowID;
+use crate::trx::TrxID;
 use crate::value::Val;
 use std::future::Future;
+use std::mem;
 
 /// Abstraction of non-unique index.
 pub trait NonUniqueIndex: Send + Sync + 'static {
     /// Lookup key and put associated values into given collection.
-    fn lookup(&self, key: &[Val], res: &mut Vec<RowID>) -> impl Future<Output = ()>;
+    fn lookup(&self, key: &[Val], res: &mut Vec<RowID>, ts: TrxID) -> impl Future<Output = ()>;
+
+    /// Lookup key and value(row_id) uniquely.
+    /// Return None if not found.
+    /// Return Some(true) if found and exist(not masked as deleted).
+    fn lookup_unique(
+        &self,
+        key: &[Val],
+        row_id: RowID,
+        ts: TrxID,
+    ) -> impl Future<Output = Option<bool>>;
 
     /// Insert key value pair into the index.
     /// Value is always RowID.
-    fn insert(&self, key: &[Val], row_id: RowID) -> impl Future<Output = ()>;
+    fn insert_if_not_exists(
+        &self,
+        key: &[Val],
+        row_id: RowID,
+        merge_if_match_deleted: bool,
+        ts: TrxID,
+    ) -> impl Future<Output = IndexInsert>;
+
+    /// Mask a given key value as deleted.
+    fn mask_as_deleted(&self, key: &[Val], row_id: RowID, ts: TrxID) -> impl Future<Output = bool>;
+
+    /// Mask a given key value as not deleted.
+    fn mask_as_active(&self, key: &[Val], row_id: RowID, ts: TrxID) -> impl Future<Output = bool>;
 
     /// Delete key value pair from the index.
     /// Value is always RowID.
-    fn delete(&self, key: &[Val], row_id: RowID) -> impl Future<Output = bool>;
-
-    /// Update existing key value pair to new value.
-    fn update(
+    fn compare_delete(
         &self,
         key: &[Val],
-        old_row_id: RowID,
-        new_row_id: RowID,
+        row_id: RowID,
+        ignore_del_mask: bool,
+        ts: TrxID,
     ) -> impl Future<Output = bool>;
+
+    /// Scan values into given collection.
+    fn scan_values(&self, values: &mut Vec<RowID>, ts: TrxID) -> impl Future<Output = ()>;
 }
 
 pub struct NonUniqueBTreeIndex {
@@ -40,22 +71,237 @@ impl NonUniqueBTreeIndex {
 
 impl NonUniqueIndex for NonUniqueBTreeIndex {
     #[inline]
-    async fn lookup(&self, key: &[Val], res: &mut Vec<RowID>) {
-        todo!()
+    async fn lookup(&self, key: &[Val], res: &mut Vec<RowID>, _ts: TrxID) {
+        let k = self
+            .encoder
+            .encode_prefix(key, Some(mem::size_of::<RowID>()));
+        let mut scanner = self.tree.prefix_scanner(CollectRowID(res));
+        scanner.scan_prefix(k.as_bytes()).await;
     }
 
     #[inline]
-    async fn insert(&self, key: &[Val], row_id: RowID) {
-        todo!()
+    async fn lookup_unique(&self, key: &[Val], row_id: RowID, _ts: TrxID) -> Option<bool> {
+        let k = self.encoder.encode_pair(key, Val::from(row_id));
+        self.tree
+            .lookup_optimistic::<BTreeByte>(k.as_bytes())
+            .await
+            .map(|v| !v.is_deleted())
     }
 
     #[inline]
-    async fn delete(&self, key: &[Val], row_id: RowID) -> bool {
-        todo!()
+    async fn insert_if_not_exists(
+        &self,
+        key: &[Val],
+        row_id: RowID,
+        merge_if_match_deleted: bool,
+        ts: TrxID,
+    ) -> IndexInsert {
+        debug_assert!(!row_id.is_deleted());
+        let k = self.encoder.encode_pair(key, Val::from(row_id));
+        match self
+            .tree
+            .insert::<BTreeByte>(k.as_bytes(), BTREE_BYTE_ZERO, merge_if_match_deleted, ts)
+            .await
+        {
+            BTreeInsert::Ok(merged) => IndexInsert::Ok(merged),
+            BTreeInsert::DuplicateKey(v) => IndexInsert::DuplicateKey(row_id, v.is_deleted()),
+        }
     }
 
     #[inline]
-    async fn update(&self, key: &[Val], old_row_id: RowID, new_row_id: RowID) -> bool {
-        todo!()
+    async fn mask_as_deleted(&self, key: &[Val], row_id: RowID, ts: TrxID) -> bool {
+        debug_assert!(!row_id.is_deleted());
+        let k = self.encoder.encode_pair(key, Val::from(row_id));
+        match self
+            .tree
+            .update(k.as_bytes(), BTREE_BYTE_ZERO, BTREE_BYTE_ZERO.deleted(), ts)
+            .await
+        {
+            BTreeUpdate::Ok(_) => true,
+            BTreeUpdate::NotFound | BTreeUpdate::ValueMismatch(_) => false,
+        }
+    }
+
+    #[inline]
+    async fn mask_as_active(&self, key: &[Val], row_id: RowID, ts: TrxID) -> bool {
+        debug_assert!(!row_id.is_deleted());
+        let k = self.encoder.encode_pair(key, Val::from(row_id));
+        match self
+            .tree
+            .update(k.as_bytes(), BTREE_BYTE_ZERO.deleted(), BTREE_BYTE_ZERO, ts)
+            .await
+        {
+            BTreeUpdate::Ok(_) => true,
+            BTreeUpdate::NotFound | BTreeUpdate::ValueMismatch(_) => false,
+        }
+    }
+
+    #[inline]
+    async fn compare_delete(
+        &self,
+        key: &[Val],
+        row_id: RowID,
+        ignore_del_mask: bool,
+        ts: TrxID,
+    ) -> bool {
+        debug_assert!(!row_id.is_deleted());
+        let k = self.encoder.encode_pair(key, Val::from(row_id));
+        match self
+            .tree
+            .delete(k.as_bytes(), BTREE_BYTE_ZERO, ignore_del_mask, ts)
+            .await
+        {
+            BTreeDelete::Ok | BTreeDelete::NotFound => true,
+            BTreeDelete::ValueMismatch => false,
+        }
+    }
+
+    #[inline]
+    async fn scan_values(&self, values: &mut Vec<RowID>, _ts: TrxID) -> () {
+        let mut cursor = self.tree.cursor(0);
+        cursor.seek(&[]).await;
+        while let Some(g) = cursor.next().await {
+            let node = g.page();
+            for slot in node.slots() {
+                let value = node.unpack_value::<BTreeU64>(slot);
+                values.push(value.to_u64());
+            }
+        }
+    }
+}
+
+struct CollectRowID<'a>(&'a mut Vec<RowID>);
+
+impl BTreeSlotCallback for CollectRowID<'_> {
+    #[inline]
+    fn apply(&mut self, node: &BTreeNode, slot: &BTreeSlot) -> bool {
+        // todo: with covering index support, we may further skip deleted row ids.
+        let value = node.unpack_value::<BTreeU64>(slot);
+        // The result collection may contains deleted row id.
+        self.0.push(value.to_u64());
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::FixedBufferPool;
+    use crate::lifetime::StaticLifetime;
+    use crate::value::{ValKind, ValType};
+
+    #[test]
+    fn test_non_unique_index() {
+        smol::block_on(async {
+            let pool = FixedBufferPool::with_capacity_static(1024usize * 1024 * 1024).unwrap();
+            {
+                // i32 column and row id
+                let index = NonUniqueBTreeIndex {
+                    tree: BTree::new(pool, true, 100).await,
+                    encoder: BTreeKeyEncoder::new(vec![
+                        ValType {
+                            kind: ValKind::I32,
+                            nullable: false,
+                        },
+                        ValType {
+                            kind: ValKind::U64,
+                            nullable: false,
+                        },
+                    ]),
+                };
+                run_test_suit_for_non_unique_index(&index).await;
+            }
+            unsafe {
+                StaticLifetime::drop_static(pool);
+            }
+        })
+    }
+
+    async fn run_test_suit_for_non_unique_index<T: NonUniqueIndex>(index: &T) {
+        // 测试用例1：基本插入和查找操作
+        let key = vec![Val::from(42i32)];
+        let row_id = 100u64;
+
+        // 测试插入
+        index.insert_if_not_exists(&key, row_id, false, 100).await;
+
+        // 测试查找
+        let mut res = vec![];
+        index.lookup(&key, &mut res, 100).await;
+        assert_eq!(res.len(), 1);
+
+        // 测试不存在的键
+        let non_existent_key = vec![Val::from(43i32)];
+        res.clear();
+        index.lookup(&non_existent_key, &mut res, 100).await;
+        assert!(res.is_empty());
+
+        // 测试用例2：重复插入
+        let new_row_id = 200u64;
+        index
+            .insert_if_not_exists(&key, new_row_id, false, 100)
+            .await;
+        // non-unique index allow duplicate key, but row id must be different.
+        res.clear();
+        index.lookup(&key, &mut res, 100).await;
+        assert_eq!(res.len(), 2);
+
+        // 测试用例3：删除操作
+        assert!(index.compare_delete(&key, row_id, true, 100).await);
+        res.clear();
+        index.lookup(&key, &mut res, 100).await;
+        assert_eq!(res.len(), 1);
+
+        // 测试删除不存在的键 still ok
+        assert!(index.compare_delete(&key, 1000, false, 100).await);
+
+        // 测试用例4：scan_values 操作
+        res.clear();
+        index.scan_values(&mut res, 100).await;
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0], new_row_id);
+
+        // 测试用例5：多分区操作
+        let key1 = vec![Val::from(1i32)];
+        let key2 = vec![Val::from(2i32)];
+        let key3 = vec![Val::from(3i32)];
+
+        let row_id1 = 500u64;
+        let row_id2 = 600u64;
+        let row_id3 = 700u64;
+
+        // 插入多个键值对
+        index.insert_if_not_exists(&key1, row_id1, false, 100).await;
+        index.insert_if_not_exists(&key2, row_id2, false, 100).await;
+        index.insert_if_not_exists(&key3, row_id3, false, 100).await;
+
+        // 验证所有键都能正确查找
+        res.clear();
+        index.lookup(&key1, &mut res, 100).await;
+        assert_eq!(res.len(), 1);
+        res.clear();
+        index.lookup(&key2, &mut res, 100).await;
+        assert_eq!(res.len(), 1);
+        res.clear();
+        index.lookup(&key3, &mut res, 100).await;
+        assert_eq!(res.len(), 1);
+
+        // 验证 scan_values 包含所有值
+        res.clear();
+        index.scan_values(&mut res, 100).await;
+        assert_eq!(res.len(), 4); // 包含之前插入的 row_id2
+
+        // 验证insert覆盖
+        let key4 = vec![Val::from(97i32)];
+        let row_id4 = 800u64;
+        let inserted = index.insert_if_not_exists(&key4, row_id4, false, 100).await;
+        assert!(inserted.is_ok());
+        let masked = index.mask_as_deleted(&key4, row_id4, 100).await;
+        assert!(masked);
+        let inserted = index.insert_if_not_exists(&key4, row_id4, true, 100).await;
+        assert!(inserted.is_merged());
+        res.clear();
+        index.lookup(&key4, &mut res, 100).await;
+        assert_eq!(res[0], row_id4);
     }
 }

--- a/doradb-storage/src/row/ops.rs
+++ b/doradb-storage/src/row/ops.rs
@@ -125,6 +125,8 @@ impl SelectResult for SelectMvcc {
     const NOT_FOUND: SelectMvcc = SelectMvcc::NotFound;
 }
 
+pub type ScanMvcc = Vec<Vec<Val>>;
+
 pub enum ReadRow {
     Ok(Vec<Val>),
     NotFound,
@@ -222,6 +224,13 @@ pub enum UpdateIndex {
     Ok,
     WriteConflict,
     DuplicateKey,
+}
+
+impl UpdateIndex {
+    #[inline]
+    pub fn is_ok(&self) -> bool {
+        matches!(self, UpdateIndex::Ok)
+    }
 }
 
 pub enum InsertIndex {

--- a/doradb-storage/src/table/access.rs
+++ b/doradb-storage/src/table/access.rs
@@ -1,0 +1,560 @@
+use crate::buffer::guard::{PageGuard, PageSharedGuard};
+use crate::buffer::BufferPool;
+use crate::index::{NonUniqueIndex, RowLocation, UniqueIndex};
+use crate::latch::LatchFallbackMode;
+use crate::row::ops::{
+    DeleteMvcc, InsertIndex, InsertMvcc, ScanMvcc, SelectKey, SelectMvcc, UpdateCol, UpdateIndex,
+    UpdateMvcc,
+};
+use crate::row::{estimate_max_row_count, var_len_for_insert, Row, RowID, RowPage, RowRead};
+use crate::stmt::Statement;
+use crate::table::{row_len, DeleteInternal, Table, UpdateRowInplace};
+use crate::trx::undo::RowUndoKind;
+use crate::trx::MIN_SNAPSHOT_TS;
+use crate::value::Val;
+use std::future::Future;
+
+pub trait TableAccess {
+    /// Table scan including uncommitted versions.
+    fn table_scan_uncommitted<P: BufferPool, F>(
+        &self,
+        data_pool: &'static P,
+        row_action: F,
+    ) -> impl Future<Output = ()>
+    where
+        F: for<'a> FnMut(Row<'a>) -> bool;
+
+    /// Index lookup unique row with MVCC.
+    /// Result should be no more than one row.
+    fn index_lookup_unique_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &Statement,
+        key: &SelectKey,
+        user_read_set: &[usize],
+    ) -> impl Future<Output = SelectMvcc>;
+
+    /// Index lookup unique row including uncommitted version.
+    fn index_lookup_unique_uncommitted<P: BufferPool, R, F>(
+        &self,
+        data_pool: &'static P,
+        key: &SelectKey,
+        row_action: F,
+    ) -> impl Future<Output = Option<R>>
+    where
+        for<'a> F: FnOnce(Row<'a>) -> R;
+
+    /// Index scan with MVCC of given key.
+    fn index_scan_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &Statement,
+        key: &SelectKey,
+        user_read_set: &[usize],
+    ) -> impl Future<Output = ScanMvcc>;
+
+    /// Insert row in transaction.
+    fn insert_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &mut Statement,
+        cols: Vec<Val>,
+    ) -> impl Future<Output = InsertMvcc>;
+
+    /// Insert row in non-transactional way.
+    fn insert_no_trx<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        cols: &[Val],
+    ) -> impl Future<Output = ()>;
+
+    /// Update row in transaction.
+    /// This method is for update based on unique index lookup.
+    /// It also takes care of index change.
+    ///
+    /// If parameter disable_inplace is set to true, update will be
+    /// converted to delete+insert.
+    fn update_unique_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &mut Statement,
+        key: &SelectKey,
+        update: Vec<UpdateCol>,
+        disable_inplace: bool,
+    ) -> impl Future<Output = UpdateMvcc>;
+
+    /// Delete row in transaction.
+    /// This method is for delete based on unique index lookup.
+    ///
+    /// If the parameter log_by_key is set to true, the delete operation
+    /// is logged with (unique) key instead of row id.
+    /// Such type of log is used for catalog tables, which will have
+    /// inconsistent page_id/row_id among multiple restarts(recoveries)
+    /// of database.
+    fn delete_unique_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &mut Statement,
+        key: &SelectKey,
+        log_by_key: bool,
+    ) -> impl Future<Output = DeleteMvcc>;
+
+    /// Delete row in non-transactional way.
+    fn delete_unique_no_trx<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        key: &SelectKey,
+    ) -> impl Future<Output = ()>;
+
+    /// Delete index by purge threads.
+    /// This method will be only called by internal threads and don't maintain
+    /// transaction properties.
+    ///
+    /// It checks whether the index entry still points to valid row, and if not,
+    /// remove the entry.
+    ///
+    /// The validation is based on MVCC with minimum active STS. If the input
+    /// key is not found on the path of undo chain, it means the index entry can be
+    /// removed.
+    ///
+    /// todo: The look-back mechanism for each index entry is not performant. A
+    /// potential optimization is similar to covering index, page ts can be checked
+    /// to see if all delete-masked values in it can be remove directly.
+    fn delete_index<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        key: &SelectKey,
+        row_id: RowID,
+        unique: bool,
+    ) -> impl Future<Output = bool>;
+}
+
+impl TableAccess for Table {
+    async fn table_scan_uncommitted<P: BufferPool, F>(
+        &self,
+        data_pool: &'static P,
+        mut row_action: F,
+    ) where
+        F: for<'a> FnMut(Row<'a>) -> bool,
+    {
+        // With cursor, we lock two pages in block index and one row page
+        // when scanning rows.
+        let mut cursor = self.blk_idx.cursor();
+        cursor.seek(0).await;
+        while let Some(leaf) = cursor.next().await {
+            let g = leaf.shared_async().await;
+            debug_assert!(g.page().is_leaf());
+            let blocks = g.page().leaf_blocks();
+            for block in blocks {
+                for page_entry in block.row_page_entries() {
+                    let row_page: PageSharedGuard<RowPage> = data_pool
+                        .get_page(page_entry.page_id, LatchFallbackMode::Shared)
+                        .await
+                        .shared_async()
+                        .await;
+                    for row_access in row_page.read_all_rows() {
+                        if !row_action(row_access.row()) {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn index_lookup_unique_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &Statement,
+        key: &SelectKey,
+        user_read_set: &[usize],
+    ) -> SelectMvcc {
+        debug_assert!(key.index_no < self.sec_idx.len());
+        debug_assert!(self.metadata.index_specs[key.index_no].unique());
+        debug_assert!(self.metadata.index_layout_match(key.index_no, &key.vals));
+        debug_assert!({
+            !user_read_set.is_empty()
+                && user_read_set
+                    .iter()
+                    .zip(user_read_set.iter().skip(1))
+                    .all(|(l, r)| l < r)
+        });
+        match self.sec_idx[key.index_no]
+            .unique()
+            .unwrap()
+            .lookup(&key.vals, stmt.trx.sts)
+            .await
+        {
+            None => SelectMvcc::NotFound,
+            Some((row_id, _)) => {
+                self.index_lookup_unique_row_mvcc(data_pool, stmt, key, user_read_set, row_id)
+                    .await
+            }
+        }
+    }
+
+    async fn index_lookup_unique_uncommitted<P: BufferPool, R, F>(
+        &self,
+        data_pool: &'static P,
+        key: &SelectKey,
+        row_action: F,
+    ) -> Option<R>
+    where
+        for<'a> F: FnOnce(Row<'a>) -> R,
+    {
+        debug_assert!(key.index_no < self.sec_idx.len());
+        debug_assert!(self.metadata.index_specs[key.index_no].unique());
+        debug_assert!(self.metadata.index_layout_match(key.index_no, &key.vals));
+        let (page_guard, row_id) = match self.sec_idx[key.index_no]
+            .unique()
+            .unwrap()
+            .lookup(&key.vals, MIN_SNAPSHOT_TS)
+            .await
+        {
+            None => return None,
+            Some((row_id, _)) => match self.blk_idx.find_row(row_id).await {
+                RowLocation::NotFound => return None,
+                RowLocation::ColSegment(..) => todo!(),
+                RowLocation::RowPage(page_id) => {
+                    let page_guard = data_pool
+                        .get_page::<RowPage>(page_id, LatchFallbackMode::Shared)
+                        .await
+                        .shared_async()
+                        .await;
+                    (page_guard, row_id)
+                }
+            },
+        };
+        let page = page_guard.page();
+        if !page.row_id_in_valid_range(row_id) {
+            return None;
+        }
+        let access = page_guard.read_row_by_id(row_id);
+        let row = access.row();
+        // latest version in row page.
+        if row.is_deleted() {
+            return None;
+        }
+        if row.is_key_different(&self.metadata, key) {
+            return None;
+        }
+        Some(row_action(row))
+    }
+
+    async fn index_scan_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &Statement,
+        key: &SelectKey,
+        user_read_set: &[usize],
+    ) -> ScanMvcc {
+        debug_assert!(key.index_no < self.sec_idx.len());
+        // Index scan should be applied to non-unique index.
+        // todo: support partial key scan on unique index.
+        debug_assert!(!self.metadata.index_specs[key.index_no].unique());
+        debug_assert!(self.metadata.index_layout_match(key.index_no, &key.vals));
+        debug_assert!({
+            !user_read_set.is_empty()
+                && user_read_set
+                    .iter()
+                    .zip(user_read_set.iter().skip(1))
+                    .all(|(l, r)| l < r)
+        });
+        // todo: support batching, streaming and sorting.
+        let mut row_ids = vec![];
+        self.sec_idx[key.index_no]
+            .non_unique()
+            .unwrap()
+            .lookup(&key.vals, &mut row_ids, stmt.trx.sts)
+            .await;
+        let mut res = vec![];
+        for row_id in row_ids {
+            match self
+                .index_lookup_unique_row_mvcc(data_pool, stmt, key, user_read_set, row_id)
+                .await
+            {
+                SelectMvcc::NotFound => (),
+                SelectMvcc::Ok(vals) => {
+                    res.push(vals);
+                }
+            }
+        }
+        res
+    }
+
+    async fn insert_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &mut Statement,
+        cols: Vec<Val>,
+    ) -> InsertMvcc {
+        debug_assert!(cols.len() == self.metadata.col_count());
+        debug_assert!({
+            cols.iter()
+                .enumerate()
+                .all(|(idx, val)| self.metadata.col_type_match(idx, val))
+        });
+        let keys = self.metadata.keys_for_insert(&cols);
+        // insert row into page with undo log linked.
+        let (row_id, page_guard) = self
+            .insert_row_internal(data_pool, stmt, cols, RowUndoKind::Insert, None)
+            .await;
+        // insert index
+        for key in keys {
+            match self
+                .insert_index(data_pool, stmt, key, row_id, &page_guard)
+                .await
+            {
+                InsertIndex::Ok => (),
+                InsertIndex::DuplicateKey => {
+                    return InsertMvcc::DuplicateKey;
+                }
+                InsertIndex::WriteConflict => {
+                    return InsertMvcc::WriteConflict;
+                }
+            }
+        }
+        page_guard.set_dirty(); // mark as dirty page.
+        InsertMvcc::Ok(row_id)
+    }
+
+    async fn insert_no_trx<P: BufferPool>(&self, data_pool: &'static P, cols: &[Val]) {
+        debug_assert!(cols.len() == self.metadata.col_count());
+        debug_assert!({
+            cols.iter()
+                .enumerate()
+                .all(|(idx, val)| self.metadata.col_type_match(idx, val))
+        });
+        // prepare index keys.
+        let keys = self.metadata.keys_for_insert(cols);
+        // calculate row length.
+        let row_len = row_len(&self.metadata, cols);
+        // estimate max row count for insert page.
+        let row_count = estimate_max_row_count(row_len, self.metadata.col_count());
+        loop {
+            // acquire insert page from block index.
+            let mut page_guard = self
+                .blk_idx
+                .get_insert_page_exclusive(data_pool, row_count, &self.metadata)
+                .await;
+            let page = page_guard.page_mut();
+            debug_assert!(self.metadata.col_count() == page.header.col_count as usize);
+            debug_assert!(cols.len() == page.header.col_count as usize);
+            let var_len = var_len_for_insert(&self.metadata, cols);
+            let (row_idx, var_offset) =
+                if let Some((row_idx, var_offset)) = page.request_row_idx_and_free_space(var_len) {
+                    (row_idx, var_offset)
+                } else {
+                    // we just ignore this page and retry.
+                    continue;
+                };
+            let row_id = page.header.start_row_id + row_idx as RowID;
+            let mut row = page.row_mut_exclusive(row_idx, var_offset, var_offset + var_len);
+            debug_assert!(row.is_deleted());
+            for (col_idx, user_col) in cols.iter().enumerate() {
+                row.update_col(col_idx, user_col, false);
+            }
+            // update index
+            for key in keys {
+                self.insert_index_no_trx(key, row_id).await;
+            }
+            row.finish_insert();
+            // Cache insert page.
+            self.blk_idx.cache_exclusive_insert_page(page_guard);
+            return;
+        }
+    }
+
+    async fn update_unique_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &mut Statement,
+        key: &SelectKey,
+        update: Vec<UpdateCol>,
+        disable_inplace: bool,
+    ) -> UpdateMvcc {
+        debug_assert!(key.index_no < self.sec_idx.len());
+        debug_assert!(self.metadata.index_specs[key.index_no].unique());
+        debug_assert!(self.metadata.index_layout_match(key.index_no, &key.vals));
+        let index = self.sec_idx[key.index_no].unique().unwrap();
+        let (page_guard, row_id) = match index.lookup(&key.vals, stmt.trx.sts).await {
+            None => return UpdateMvcc::NotFound,
+            Some((row_id, _)) => match self.blk_idx.find_row(row_id).await {
+                RowLocation::NotFound => return UpdateMvcc::NotFound,
+                RowLocation::ColSegment(..) => todo!(),
+                RowLocation::RowPage(page_id) => {
+                    let page_guard = data_pool
+                        .get_page::<RowPage>(page_id, LatchFallbackMode::Shared)
+                        .await
+                        .shared_async()
+                        .await;
+                    (page_guard, row_id)
+                }
+            },
+        };
+        if disable_inplace {
+            todo!()
+        }
+        let res = self
+            .update_row_inplace(stmt, page_guard, key, row_id, update)
+            .await;
+        match res {
+            UpdateRowInplace::Ok(new_row_id, index_change_cols, page_guard) => {
+                debug_assert!(row_id == new_row_id);
+                if !index_change_cols.is_empty() {
+                    // Index may change, we should check whether each index key change and update correspondingly.
+                    let res = self
+                        .update_indexes_only_key_change(
+                            data_pool,
+                            stmt,
+                            row_id,
+                            &page_guard,
+                            &index_change_cols,
+                        )
+                        .await;
+                    page_guard.set_dirty(); // mark as dirty page.
+                    return match res {
+                        UpdateIndex::Ok => UpdateMvcc::Ok(new_row_id),
+                        UpdateIndex::DuplicateKey => UpdateMvcc::DuplicateKey,
+                        UpdateIndex::WriteConflict => UpdateMvcc::WriteConflict,
+                    };
+                } // otherwise, do nothing
+                page_guard.set_dirty(); // mark as dirty page.
+                UpdateMvcc::Ok(row_id)
+            }
+            UpdateRowInplace::RowDeleted | UpdateRowInplace::RowNotFound => UpdateMvcc::NotFound,
+            UpdateRowInplace::WriteConflict => UpdateMvcc::WriteConflict,
+            UpdateRowInplace::NoFreeSpace(old_row_id, old_row, update, old_guard) => {
+                // in-place update failed, we transfer update into
+                // move+update.
+                let (new_row_id, index_change_cols, new_guard) = self
+                    .move_update_for_space(data_pool, stmt, old_row, update, old_row_id, old_guard)
+                    .await;
+                if !index_change_cols.is_empty() {
+                    let res = self
+                        .update_indexes_may_both_change(
+                            data_pool,
+                            stmt,
+                            old_row_id,
+                            new_row_id,
+                            &index_change_cols,
+                            &new_guard,
+                        )
+                        .await;
+                    // old guard is already marked inside.
+                    new_guard.set_dirty(); // mark as dirty page.
+                    match res {
+                        UpdateIndex::Ok => UpdateMvcc::Ok(new_row_id),
+                        UpdateIndex::DuplicateKey => UpdateMvcc::DuplicateKey,
+                        UpdateIndex::WriteConflict => UpdateMvcc::WriteConflict,
+                    }
+                } else {
+                    let res = self
+                        .update_indexes_only_row_id_change(stmt, old_row_id, new_row_id, &new_guard)
+                        .await;
+                    new_guard.set_dirty(); // mark as dirty page.
+                    match res {
+                        UpdateIndex::Ok => UpdateMvcc::Ok(new_row_id),
+                        UpdateIndex::DuplicateKey => UpdateMvcc::DuplicateKey,
+                        UpdateIndex::WriteConflict => UpdateMvcc::WriteConflict,
+                    }
+                }
+            }
+        }
+    }
+
+    async fn delete_unique_mvcc<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        stmt: &mut Statement,
+        key: &SelectKey,
+        log_by_key: bool,
+    ) -> DeleteMvcc {
+        debug_assert!(key.index_no < self.sec_idx.len());
+        debug_assert!(self.metadata.index_specs[key.index_no].unique());
+        debug_assert!(self.metadata.index_layout_match(key.index_no, &key.vals));
+        let index = self.sec_idx[key.index_no].unique().unwrap();
+        let (page_guard, row_id) = match index.lookup(&key.vals, stmt.trx.sts).await {
+            None => return DeleteMvcc::NotFound,
+            Some((row_id, _)) => match self.blk_idx.find_row(row_id).await {
+                RowLocation::NotFound => return DeleteMvcc::NotFound,
+                RowLocation::ColSegment(..) => todo!(),
+                RowLocation::RowPage(page_id) => {
+                    let page_guard = data_pool
+                        .get_page::<RowPage>(page_id, LatchFallbackMode::Shared)
+                        .await
+                        .shared_async()
+                        .await;
+                    (page_guard, row_id)
+                }
+            },
+        };
+        match self
+            .delete_row_internal(stmt, page_guard, row_id, key, log_by_key)
+            .await
+        {
+            DeleteInternal::NotFound => DeleteMvcc::NotFound,
+            DeleteInternal::WriteConflict => DeleteMvcc::WriteConflict,
+            DeleteInternal::Ok(page_guard) => {
+                // defer index deletion with index undo log.
+                self.defer_delete_indexes(stmt, row_id, &page_guard).await;
+                page_guard.set_dirty(); // mark as dirty.
+                DeleteMvcc::Ok
+            }
+        }
+    }
+
+    async fn delete_unique_no_trx<P: BufferPool>(&self, data_pool: &'static P, key: &SelectKey) {
+        debug_assert!(key.index_no < self.sec_idx.len());
+        debug_assert!(self.metadata.index_specs[key.index_no].unique());
+        debug_assert!(self.metadata.index_layout_match(key.index_no, &key.vals));
+        let index = self.sec_idx[key.index_no].unique().unwrap();
+        let (mut page_guard, row_id) = match index.lookup(&key.vals, MIN_SNAPSHOT_TS).await {
+            None => unreachable!(),
+            Some((row_id, _)) => match self.blk_idx.find_row(row_id).await {
+                RowLocation::NotFound => unreachable!(),
+                RowLocation::ColSegment(..) => todo!(),
+                RowLocation::RowPage(page_id) => {
+                    let page_guard = data_pool
+                        .get_page::<RowPage>(page_id, LatchFallbackMode::Exclusive)
+                        .await
+                        .exclusive_async()
+                        .await;
+                    (page_guard, row_id)
+                }
+            },
+        };
+        let page = page_guard.page_mut();
+        let row_idx = page.row_idx(row_id);
+        debug_assert!(!page.is_deleted(row_idx));
+        let row = page.row(row_idx);
+        let keys = self.metadata.keys_for_delete(row);
+        // delete index immediately.
+        for key in keys {
+            let res = self.delete_index_directly(&key, row_id).await;
+            assert!(res);
+        }
+        page.set_deleted_exclusive(row_idx, true);
+    }
+
+    async fn delete_index<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        key: &SelectKey,
+        row_id: RowID,
+        unique: bool,
+    ) -> bool {
+        // todo: consider index drop.
+        let index_schema = &self.metadata.index_specs[key.index_no];
+        debug_assert_eq!(unique, index_schema.unique());
+        if unique {
+            let index = self.sec_idx[key.index_no].unique().unwrap();
+            self.delete_unique_index(data_pool, index, key, row_id)
+                .await
+        } else {
+            let index = self.sec_idx[key.index_no].non_unique().unwrap();
+            self.delete_non_unique_index(data_pool, index, key, row_id)
+                .await
+        }
+    }
+}

--- a/doradb-storage/src/table/recover.rs
+++ b/doradb-storage/src/table/recover.rs
@@ -1,0 +1,248 @@
+use crate::buffer::page::PageID;
+use crate::buffer::BufferPool;
+use crate::index::{IndexInsert, NonUniqueIndex, UniqueIndex};
+use crate::latch::LatchFallbackMode;
+use crate::row::ops::{ReadRow, SelectKey, UpdateCol};
+use crate::row::{RowID, RowPage, RowRead};
+use crate::table::{
+    index_key_is_changed, index_key_replace, read_latest_index_key, RecoverIndex, Table,
+};
+use crate::trx::TrxID;
+use crate::trx::MIN_SNAPSHOT_TS;
+use crate::value::Val;
+use std::collections::HashMap;
+use std::future::Future;
+
+pub trait TableRecover {
+    /// Recover row insert from redo log.
+    fn recover_row_insert<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+        row_id: RowID,
+        cols: &[Val],
+        cts: TrxID,
+        disable_index: bool,
+    ) -> impl Future<Output = ()>;
+
+    /// Recover row update from redo log.
+    fn recover_row_update<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+        row_id: RowID,
+        update: &[UpdateCol],
+        cts: TrxID,
+        disable_index: bool,
+    ) -> impl Future<Output = ()>;
+
+    /// Recover row delete from redo log.
+    fn recover_row_delete<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+        row_id: RowID,
+        cts: TrxID,
+        disable_index: bool,
+    ) -> impl Future<Output = ()>;
+
+    /// Populate index using data on row page.
+    fn populate_index_via_row_page<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+    ) -> impl Future<Output = ()>;
+}
+
+impl TableRecover for Table {
+    async fn recover_row_insert<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+        row_id: RowID,
+        cols: &[Val],
+        cts: TrxID,
+        disable_index: bool,
+    ) {
+        debug_assert!(cols.len() == self.metadata.col_count());
+        debug_assert!({
+            cols.iter()
+                .enumerate()
+                .all(|(idx, val)| self.metadata.col_type_match(idx, val))
+        });
+        // Since we always dispatch rows of one page to same thread,
+        // we can just hold exclusive lock on this page and process all rows in it.
+        let mut page_guard = data_pool
+            .get_page::<RowPage>(page_id, LatchFallbackMode::Exclusive)
+            .await
+            .exclusive_async()
+            .await;
+
+        let res = self.recover_row_insert_to_page(&mut page_guard, row_id, cols, cts);
+        assert!(res.is_ok());
+        page_guard.set_dirty(); // mark as dirty page.
+
+        if !disable_index {
+            let keys = self.metadata.keys_for_insert(cols);
+            for key in keys {
+                match self.recover_index_insert(data_pool, key, row_id, cts).await {
+                    RecoverIndex::Ok | RecoverIndex::InsertOutdated => (),
+                    RecoverIndex::DeleteOutdated => unreachable!(),
+                }
+            }
+        }
+    }
+
+    async fn recover_row_update<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+        row_id: RowID,
+        update: &[UpdateCol],
+        cts: TrxID,
+        disable_index: bool,
+    ) {
+        let mut page_guard = data_pool
+            .get_page::<RowPage>(page_id, LatchFallbackMode::Exclusive)
+            .await
+            .exclusive_async()
+            .await;
+
+        if disable_index {
+            let res = self.recover_row_update_to_page(&mut page_guard, row_id, update, cts, None);
+            assert!(res.is_ok());
+            page_guard.set_dirty(); // mark as dirty page.
+        } else {
+            let mut index_change_cols = HashMap::new();
+            let res = self.recover_row_update_to_page(
+                &mut page_guard,
+                row_id,
+                update,
+                cts,
+                Some(&mut index_change_cols),
+            );
+            assert!(res.is_ok());
+            page_guard.set_dirty(); // mark as dirty page.
+
+            if !index_change_cols.is_empty() {
+                // There is index change, we need to update index.
+                let page_guard = data_pool
+                    .get_page::<RowPage>(page_id, LatchFallbackMode::Shared)
+                    .await
+                    .shared_async()
+                    .await;
+
+                for (index, index_schema) in self.sec_idx.iter().zip(&self.metadata.index_specs) {
+                    debug_assert!(index.is_unique() == index_schema.unique());
+                    if index_key_is_changed(index_schema, &index_change_cols) {
+                        let new_key = read_latest_index_key(
+                            &self.metadata,
+                            index.index_no,
+                            &page_guard,
+                            row_id,
+                        );
+                        let old_key = index_key_replace(index_schema, &new_key, &index_change_cols);
+                        // insert new index entry.
+                        match self
+                            .recover_index_insert(data_pool, new_key, row_id, cts)
+                            .await
+                        {
+                            RecoverIndex::Ok | RecoverIndex::InsertOutdated => (),
+                            RecoverIndex::DeleteOutdated => unreachable!(),
+                        }
+                        // delete old index entry.
+                        match self.recover_index_delete(old_key, row_id).await {
+                            RecoverIndex::Ok | RecoverIndex::DeleteOutdated => (),
+                            RecoverIndex::InsertOutdated => unreachable!(),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn recover_row_delete<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+        row_id: RowID,
+        cts: TrxID,
+        disable_index: bool,
+    ) {
+        let mut page_guard = data_pool
+            .get_page::<RowPage>(page_id, LatchFallbackMode::Exclusive)
+            .await
+            .exclusive_async()
+            .await;
+
+        if disable_index {
+            let res = self.recover_row_delete_to_page(&mut page_guard, row_id, cts, None);
+            assert!(res.is_ok());
+            page_guard.set_dirty(); // mark as dirty page.
+        } else {
+            let mut index_cols = HashMap::new();
+            let res = self.recover_row_delete_to_page(
+                &mut page_guard,
+                row_id,
+                cts,
+                Some(&mut index_cols),
+            );
+            assert!(res.is_ok());
+            page_guard.set_dirty(); // mark as dirty page.
+            for (index, index_schema) in self.sec_idx.iter().zip(&self.metadata.index_specs) {
+                debug_assert!(index.is_unique() == index_schema.unique());
+                let vals: Vec<Val> = index_schema
+                    .index_cols
+                    .iter()
+                    .map(|ik| index_cols[&(ik.col_no as usize)].clone())
+                    .collect();
+                let key = SelectKey::new(index.index_no, vals);
+                match self.recover_index_delete(key, row_id).await {
+                    RecoverIndex::Ok | RecoverIndex::DeleteOutdated => (),
+                    RecoverIndex::InsertOutdated => unreachable!(),
+                }
+            }
+        }
+    }
+
+    async fn populate_index_via_row_page<P: BufferPool>(
+        &self,
+        data_pool: &'static P,
+        page_id: PageID,
+    ) {
+        let page_guard = data_pool
+            .get_page::<RowPage>(page_id, LatchFallbackMode::Shared)
+            .await
+            .shared_async()
+            .await;
+        for (index_spec, sec_idx) in self.metadata.index_specs.iter().zip(&*self.sec_idx) {
+            let read_set: Vec<_> = index_spec
+                .index_cols
+                .iter()
+                .map(|c| c.col_no as usize)
+                .collect();
+            for row_access in page_guard.read_all_rows() {
+                let row_id = row_access.row().row_id();
+                match row_access.read_row_latest(&self.metadata, &read_set, None) {
+                    ReadRow::Ok(vals) => {
+                        if index_spec.unique() {
+                            let index = sec_idx.unique().unwrap();
+                            let res = index
+                                .insert_if_not_exists(&vals, row_id, false, MIN_SNAPSHOT_TS)
+                                .await;
+                            debug_assert!(matches!(res, IndexInsert::Ok(_)));
+                        } else {
+                            let index = sec_idx.non_unique().unwrap();
+                            let res = index
+                                .insert_if_not_exists(&vals, row_id, false, MIN_SNAPSHOT_TS)
+                                .await;
+                            debug_assert!(matches!(res, IndexInsert::Ok(_)));
+                        }
+                    }
+                    ReadRow::NotFound => (),
+                    ReadRow::InvalidIndex => unreachable!(),
+                }
+            }
+        }
+    }
+}

--- a/doradb-storage/src/trx/purge.rs
+++ b/doradb-storage/src/trx/purge.rs
@@ -3,6 +3,7 @@ use crate::buffer::BufferPool;
 use crate::catalog::{Catalog, TableCache};
 use crate::latch::LatchFallbackMode;
 use crate::row::{RowID, RowPage};
+use crate::table::TableAccess;
 use crate::thread;
 use crate::trx::log::LogPartition;
 use crate::trx::sys::TransactionSystem;
@@ -146,7 +147,10 @@ impl TransactionSystem {
                 for ip in index_gc {
                     if let Some(table) = table_cache.get_table(ip.table_id).await {
                         // todo: index should stored in index pool, instead of data pool.
-                        if table.delete_index(buf_pool, &ip.key, ip.row_id).await {
+                        if table
+                            .delete_index(buf_pool, &ip.key, ip.row_id, ip.unique)
+                            .await
+                        {
                             purge_index_count += 1;
                         }
                     }


### PR DESCRIPTION
The basic idea is to pack row id at end of user-defined key.
This will make the non-unique index has "unique" key again.
This PR also contains the integration of non-unique index with transaction, and other refactoring.