### PR TITLE
refactor row page version management

### DIFF
--- a/doradb-storage/src/stmt/mod.rs
+++ b/doradb-storage/src/stmt/mod.rs
@@ -65,7 +65,9 @@ impl Statement {
         // rollback row data.
         // todo: group by page level may be better.
         let engine = self.trx.engine().unwrap();
-        self.row_undo.rollback(engine.data_pool).await;
+        self.row_undo
+            .rollback(engine.data_pool, Some(self.trx.sts))
+            .await;
         // rollback index data.
         self.index_undo
             .rollback(engine.data_pool, engine.catalog(), self.trx.sts)

--- a/doradb-storage/src/table/access.rs
+++ b/doradb-storage/src/table/access.rs
@@ -155,7 +155,7 @@ impl TableAccess for Table {
     {
         self.table_scan(data_pool, start_row_id, |page_guard| {
             let (ctx, page) = page_guard.ctx_and_page();
-            let metadata = &*ctx.undo().unwrap().metadata;
+            let metadata = &*ctx.row_ver().unwrap().metadata;
             for row_access in ReadAllRows::new(page, ctx) {
                 if !row_action(metadata, row_access.row()) {
                     return false;
@@ -178,7 +178,7 @@ impl TableAccess for Table {
     {
         self.table_scan(data_pool, start_row_id, |page_guard| {
             let (ctx, page) = page_guard.ctx_and_page();
-            let metadata = &*ctx.undo().unwrap().metadata;
+            let metadata = &*ctx.row_ver().unwrap().metadata;
             for row_access in ReadAllRows::new(page, ctx) {
                 match row_access.read_row_mvcc(&stmt.trx, metadata, read_set, None) {
                     ReadRow::InvalidIndex => unreachable!(),
@@ -262,7 +262,7 @@ impl TableAccess for Table {
         if !page.row_id_in_valid_range(row_id) {
             return None;
         }
-        let metadata = &*ctx.undo().unwrap().metadata;
+        let metadata = &*ctx.row_ver().unwrap().metadata;
         let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
         let row = access.row();
         // latest version in row page.

--- a/doradb-storage/src/trx/mod.rs
+++ b/doradb-storage/src/trx/mod.rs
@@ -25,6 +25,7 @@ pub mod sys;
 pub mod sys_conf;
 pub mod sys_trx;
 pub mod undo;
+pub mod ver_map;
 
 use crate::engine::EngineRef;
 use crate::error::Result;
@@ -216,6 +217,7 @@ impl ActiveTrx {
             debug_assert!(Arc::strong_count(&self.status) == 1);
             debug_assert!(self.index_undo.is_empty());
             return PreparedTrx {
+                sts: Some(self.sts),
                 redo_bin: None,
                 payload: Some(PreparedTrxPayload {
                     status: Arc::clone(&self.status),
@@ -251,6 +253,7 @@ impl ActiveTrx {
         let row_undo = mem::take(&mut self.row_undo);
         let index_undo = mem::take(&mut self.index_undo);
         PreparedTrx {
+            sts: Some(self.sts),
             redo_bin,
             payload: Some(PreparedTrxPayload {
                 status: self.status.clone(),
@@ -326,6 +329,7 @@ pub struct PreparedTrxPayload {
 
 /// PrecommitTrx has been assigned commit timestamp and already prepared redo log binary.
 pub struct PreparedTrx {
+    sts: Option<TrxID>,
     redo_bin: Option<LenPrefixPod<RedoHeader, RedoLogs>>,
     payload: Option<PreparedTrxPayload>,
     session: Option<Arc<SessionState>>,

--- a/doradb-storage/src/trx/purge.rs
+++ b/doradb-storage/src/trx/purge.rs
@@ -138,7 +138,7 @@ impl TransactionSystem {
             let (ctx, page) = page_guard.ctx_and_page();
             for row_id in row_ids {
                 let row_idx = page.row_idx(row_id);
-                let mut access = RowWriteAccess::new(page, ctx, row_idx);
+                let mut access = RowWriteAccess::new(page, ctx, row_idx, None);
                 access.purge_undo_chain(min_active_sts);
             }
         }

--- a/doradb-storage/src/trx/sys.rs
+++ b/doradb-storage/src/trx/sys.rs
@@ -206,7 +206,7 @@ impl TransactionSystem {
         trx.index_undo
             .rollback(buf_pool, &self.catalog, trx.sts)
             .await;
-        trx.row_undo.rollback(buf_pool).await;
+        trx.row_undo.rollback(buf_pool, Some(trx.sts)).await;
         trx.redo.clear();
         self.log_partitions[trx.log_no].gc_buckets[trx.gc_no].gc_analyze_rollback(trx.sts);
         if let Some(s) = trx.session.take() {
@@ -223,7 +223,7 @@ impl TransactionSystem {
         debug_assert!(trx.redo_bin.is_none());
         // Note: rollback can only happens to user transaction, so payload is always non-empty.
         let mut payload = trx.payload.take().unwrap();
-        payload.row_undo.rollback(buf_pool).await;
+        payload.row_undo.rollback(buf_pool, trx.sts).await;
         payload
             .index_undo
             .rollback(buf_pool, &self.catalog, payload.sts)

--- a/doradb-storage/src/trx/sys_trx.rs
+++ b/doradb-storage/src/trx/sys_trx.rs
@@ -49,6 +49,7 @@ impl SysTrx {
             ))
         };
         PreparedTrx {
+            sts: None,
             redo_bin,
             payload: None,
             session: None,

--- a/doradb-storage/src/trx/ver_map.rs
+++ b/doradb-storage/src/trx/ver_map.rs
@@ -1,0 +1,127 @@
+use crate::catalog::TableMetadata;
+use crate::trx::TrxID;
+use crate::trx::undo::RowUndoHead;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// RowVersionMap is a page-level hash map to store
+/// old versions of rows in row page.
+/// It also contains modification counter and max STS
+/// to speed up table scan with MVCC.
+pub struct RowVersionMap {
+    // Fixed size array to store undo chains.
+    // It wastes 16 bytes(one lock and one pointer)
+    // for each row if no undo associated.
+    entries: Box<[RwLock<Option<Box<RowUndoHead>>>]>,
+    // Metadata fixed when the version map is created.
+    // Currently it should be same as metadata of table
+    // file because we do not support change of table
+    // structure.
+    pub metadata: Arc<TableMetadata>,
+    // Monotonically increasing version number.
+    // indicates whether the undo map is changed.
+    mod_counter: AtomicU64,
+    // Maximum STS of transactions that have modified
+    // current page.
+    // This is used to bypass version chain traversal
+    // for fast table scan.
+    // map.len()==0 is more strict than trx.sts > max_sts,
+    // because it depends on efficient GC to remove undo
+    // logs as fast as possible.
+    //
+    // The implementation uses guard to automatically maintain
+    // this field. There might be some cases that this field
+    // does not reflect the actual status and precent fast scan
+    // by mistake, e.g. a transaction modifies one row, then
+    // rollback.
+    max_sts: AtomicU64,
+}
+
+impl RowVersionMap {
+    /// Create a new version map.
+    #[inline]
+    pub fn new(metadata: Arc<TableMetadata>, max_size: usize) -> Self {
+        let vec: Vec<_> = (0..max_size).map(|_| RwLock::new(None)).collect();
+        RowVersionMap {
+            entries: vec.into_boxed_slice(),
+            metadata,
+            mod_counter: AtomicU64::new(0),
+            max_sts: AtomicU64::new(0),
+        }
+    }
+
+    /// Acquire a read latch on given row.
+    #[inline]
+    pub fn read_latch(&self, row_idx: usize) -> RowVersionReadGuard<'_> {
+        let g = self.entries[row_idx].read();
+        RowVersionReadGuard { m: self, g }
+    }
+
+    /// Acquire a write latch on given row.
+    #[inline]
+    pub fn write_latch(&self, row_idx: usize, sts: Option<TrxID>) -> RowVersionWriteGuard<'_> {
+        let g = self.entries[row_idx].write();
+        // If STS is not provided, there should be no modification
+        // on current page, so we don't need to bump the counter.
+        // Currently this is invoked for purge(GC) thread.
+        if sts.is_some() {
+            self.mod_counter.fetch_add(1, Ordering::AcqRel);
+        }
+        RowVersionWriteGuard { m: self, g, sts }
+    }
+
+    /// Acquire exclusive latch as self is exclusive.
+    #[inline]
+    pub fn write_exclusive(&mut self, row_idx: usize) -> &mut Option<Box<RowUndoHead>> {
+        self.entries[row_idx].get_mut()
+    }
+}
+
+pub struct RowVersionReadGuard<'a> {
+    m: &'a RowVersionMap,
+    g: RwLockReadGuard<'a, Option<Box<RowUndoHead>>>,
+}
+
+impl<'a> Deref for RowVersionReadGuard<'a> {
+    type Target = Option<Box<RowUndoHead>>;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.g
+    }
+}
+
+pub struct RowVersionWriteGuard<'a> {
+    m: &'a RowVersionMap,
+    g: RwLockWriteGuard<'a, Option<Box<RowUndoHead>>>,
+    sts: Option<TrxID>,
+}
+
+impl<'a> Drop for RowVersionWriteGuard<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        // Only update sts and counter for user transaction.
+        if let Some(sts) = self.sts {
+            // First we update max sts of this map.
+            self.m.max_sts.fetch_max(sts, Ordering::AcqRel);
+            // Then we bump the modification counter.
+            self.m.mod_counter.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+}
+
+impl<'a> Deref for RowVersionWriteGuard<'a> {
+    type Target = Option<Box<RowUndoHead>>;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.g
+    }
+}
+
+impl<'a> DerefMut for RowVersionWriteGuard<'a> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.g
+    }
+}


### PR DESCRIPTION
- Rename `UndoMap` to `RowVersionMap`.
- Replace `maybe_invisible` with `max_sts`.
- Add `RowVersionReadGuard` and `RowVersionWriteGuard`.
