### PR TITLE
add frozen flag in row page

### DIFF
--- a/doradb-storage/src/row/ops.rs
+++ b/doradb-storage/src/row/ops.rs
@@ -318,7 +318,7 @@ impl UndoVal for UndoCol {
 
 pub enum UpdateRow<'a> {
     Ok(RowMut<'a>),
-    NoFreeSpace(Vec<(Val, Option<u16>)>),
+    NoFreeSpaceOrFrozen(Vec<(Val, Option<u16>)>),
 }
 
 pub enum Delete {

--- a/doradb-storage/src/stmt/mod.rs
+++ b/doradb-storage/src/stmt/mod.rs
@@ -40,7 +40,7 @@ impl Statement {
     }
 
     #[inline]
-    pub fn update_last_undo(&mut self, kind: RowUndoKind) {
+    pub fn update_last_row_undo(&mut self, kind: RowUndoKind) {
         let last_undo = self.row_undo.last_mut().unwrap();
         // Currently the update can only be applied on LOCK entry.
         debug_assert!(matches!(last_undo.kind, RowUndoKind::Lock));

--- a/doradb-storage/src/trx/purge.rs
+++ b/doradb-storage/src/trx/purge.rs
@@ -138,7 +138,7 @@ impl TransactionSystem {
             let (ctx, page) = page_guard.ctx_and_page();
             for row_id in row_ids {
                 let row_idx = page.row_idx(row_id);
-                let mut access = RowWriteAccess::new(page, ctx, row_idx, None);
+                let mut access = RowWriteAccess::new(page, ctx, row_idx, None, false);
                 access.purge_undo_chain(min_active_sts);
             }
         }

--- a/doradb-storage/src/trx/undo/row.rs
+++ b/doradb-storage/src/trx/undo/row.rs
@@ -192,7 +192,7 @@ impl RowUndoLogs {
             let (ctx, page) = page_guard.ctx_and_page();
             let metadata = &*ctx.row_ver().unwrap().metadata;
             let row_idx = page.row_idx(entry.row_id);
-            let mut access = RowWriteAccess::new(page, ctx, row_idx, sts);
+            let mut access = RowWriteAccess::new(page, ctx, row_idx, sts, false);
             access.rollback_first_undo(metadata, entry);
         }
     }


### PR DESCRIPTION
- add frozen flag in row page's version map.
- change behavior of insert and update upon frozen row page.
- add details about data checkpoint in document.
