### PR TITLE
fix: correct documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The storage engine is designed as a hybrid engine with both in-memory row store 
 - [Index Design](./docs/index-design.md)
 - [Checkpoint and Recovery](./docs/checkpoint-and-recovery.md)
 
-Some ideas are different from tranditional database system.
+Some ideas are different from traditional database system.
 I'm glad to have discussions if someone is interested in details.
 
 ## Code Structure
@@ -44,7 +44,7 @@ Code structure of storage engine:
 - [row](./doradb-storage/src/row): In-memory row store and operations.
 - [stmt](./doradb-storage/src/stmt): Statements.
 - [table](./doradb-storage/src/table): Table of data, composite of block index, secondary index, buffer pool and table file. Support operations like index lookup, index scan, table scan, insert, delete, update, etc.
-- [trx](./doradb-storage/src/trx): Transaction system, including trasaction lifecycle, redo log, undo log, recovery, garbage collect, etc.
+- [trx](./doradb-storage/src/trx): Transaction system, including transaction lifecycle, redo log, undo log, recovery, garbage collect, etc.
 
 ## License
 

--- a/docs/transaction-system.md
+++ b/docs/transaction-system.md
@@ -11,7 +11,7 @@ The system is designed to decouple foreground transaction processing from backgr
 
 The system employs a unique persistence and recovery model that fundamentally differs from traditional ARIES algorithms (Steal / No-Force).
 
-| Feature | This System (No-Steal / No-Force) | Tranditional ARIES (Steal / No-Force) |
+| Feature | This System (No-Steal / No-Force) | Traditional ARIES (Steal / No-Force) |
 |----|----|----|
 | **Dirty Page Policy** | **Strict No-Steal**: Disk data structures (DiskTree/ColumnStore) are immutable or CoW, containing only committed data. No dirty pages are flushed. | **Steal**: Dirty pages from uncommitted transactions can be flushed to disk, requiring Undo Logs for rollback. |
 | **Persistence** | **No-Force**: Only commit log is forced to disk at commit. Data pages remain in memory until checkpoint. | **No-Force**: Only WAL is forced. |


### PR DESCRIPTION
### Motivation

- Fix spelling errors to improve documentation clarity and correctness.
- Correct the table header in `docs/transaction-system.md` to reflect the intended comparison with Traditional ARIES.
- Ensure the Markdown table and surrounding paragraphs remain well-formed after edits.

### Description

- Updated `README.md` to replace "tranditional" with "traditional" and "trasaction" with "transaction" in the transaction system line.
- Updated `docs/transaction-system.md` to change the table column header from "Tranditional ARIES" to "Traditional ARIES".
- Verified that the Markdown table alignment and line breaks were preserved after the edits.
- This is a documentation-only change and does not modify runtime code.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695defd75d08832f9521417c2672b1fc)