### PR TITLE
fix: document DirectBuf truncate clamping

### DIFF
--- a/doradb-storage/src/io/buf.rs
+++ b/doradb-storage/src/io/buf.rs
@@ -123,6 +123,8 @@ impl DirectBuf {
     }
 
     /// Truncate length to given number.
+    ///
+    /// If the provided length exceeds capacity, it will be clamped to capacity.
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         if len <= self.capacity() {
@@ -212,6 +214,15 @@ mod tests {
         buf.reset();
         assert_eq!(buf.len(), 0);
         assert!(buf.data().iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_direct_buf_truncate_clamps_to_capacity() {
+        let mut buf = DirectBuf::uninit(32);
+        let capacity = buf.capacity();
+
+        buf.truncate(capacity + 1);
+        assert_eq!(buf.len(), capacity);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Clarify behavior of `DirectBuf::truncate` when the requested length exceeds the buffer capacity.
- Avoid ambiguity for callers who might expect an error instead of silent clamping.
- Provide a unit test to lock in the documented behavior and prevent regressions.

### Description
- Update the doc comment for `DirectBuf::truncate` in `doradb-storage/src/io/buf.rs` to state that an oversize `len` is clamped to `capacity`.
- Add unit test `test_direct_buf_truncate_clamps_to_capacity` to validate that truncating with `len > capacity` sets the length to `capacity`.
- No changes to runtime implementation semantics were made; only documentation and tests were added.

### Testing
- Ran `cargo test -p doradb-storage -- --test-threads=1` to run the crate tests.
- The build progressed but the test run failed at link time with a missing library error: the linker reported `cannot find -laio`.
- Due to the linker error the test binary could not be produced and the new unit test was not executed locally; CI or local environment should provide `libaio` (or adjust build flags) to run the tests successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695df03625d8832fadb0f8e08f885465)