### PR TITLE
reorder MetaPage fields to match Ser/Deser order

### DIFF
--- a/doradb-storage/src/file/meta_page.rs
+++ b/doradb-storage/src/file/meta_page.rs
@@ -1,0 +1,220 @@
+use crate::bitmap::AllocMap;
+use crate::buffer::page::PageID;
+use crate::catalog::table::{TableBriefMetadata, TableBriefMetadataSerView, TableMetadata};
+use crate::error::Result;
+use crate::file::table_file::BlockIndexArray;
+use crate::lwc::{LwcPrimitiveDeser, LwcPrimitiveSer};
+use crate::row::RowID;
+use crate::serde::{Deser, Ser, SerdeCtx};
+use crate::trx::TrxID;
+use std::mem;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaPage {
+    pub pivot_row_id: RowID,
+    pub last_checkpoint_cts: TrxID,
+    pub schema: TableMetadata,
+    pub block_index: BlockIndexArray,
+    pub space_map: AllocMap,
+    pub gc_page_list: Vec<PageID>,
+}
+
+impl Deser for MetaPage {
+    #[inline]
+    fn deser(ctx: &mut SerdeCtx, input: &[u8], start_idx: usize) -> Result<(usize, Self)> {
+        let (idx, pivot_row_id) = ctx.deser_u64(input, start_idx)?;
+        let (idx, last_checkpoint_cts) = ctx.deser_u64(input, idx)?;
+        let (idx, space_map) = AllocMap::deser(ctx, input, idx)?;
+        let (idx, gc_page_list) = LwcPrimitiveDeser::<PageID>::deser(ctx, input, idx)?;
+        let (idx, meta) = TableBriefMetadata::deser(ctx, input, idx)?;
+        let (idx, block_index) = MetaPageBlockIndexDeser::deser(ctx, input, idx)?;
+        Ok((
+            idx,
+            MetaPage {
+                pivot_row_id,
+                last_checkpoint_cts,
+                schema: TableMetadata::from(meta),
+                block_index: block_index.into(),
+                space_map,
+                gc_page_list: gc_page_list.0,
+            },
+        ))
+    }
+}
+
+pub struct MetaPageSerView<'a> {
+    pub pivot_row_id: RowID,
+    pub last_checkpoint_cts: TrxID,
+    pub schema: TableBriefMetadataSerView<'a>,
+    pub block_index: MetaPageBlockIndexSerView<'a>,
+    pub space_map: &'a AllocMap,
+    pub gc_page_list: MetaPageGcListSerView<'a>,
+}
+
+impl<'a> MetaPageSerView<'a> {
+    #[inline]
+    pub fn new(
+        schema: TableBriefMetadataSerView<'a>,
+        block_index: &'a BlockIndexArray,
+        space_map: &'a AllocMap,
+        gc_page_list: &'a [PageID],
+        pivot_row_id: RowID,
+        last_checkpoint_cts: TrxID,
+    ) -> Self {
+        MetaPageSerView {
+            pivot_row_id,
+            last_checkpoint_cts,
+            schema,
+            block_index: MetaPageBlockIndexSerView::new(block_index),
+            space_map,
+            gc_page_list: MetaPageGcListSerView::new(gc_page_list),
+        }
+    }
+}
+
+impl<'a> Ser<'a> for MetaPageSerView<'a> {
+    #[inline]
+    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
+        mem::size_of::<RowID>()
+            + mem::size_of::<TrxID>()
+            + self.space_map.ser_len(ctx)
+            + self.gc_page_list.ser_len(ctx)
+            + self.schema.ser_len(ctx)
+            + self.block_index.ser_len(ctx)
+    }
+
+    #[inline]
+    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
+        let idx = ctx.ser_u64(out, start_idx, self.pivot_row_id);
+        let idx = ctx.ser_u64(out, idx, self.last_checkpoint_cts);
+        let idx = self.space_map.ser(ctx, out, idx);
+        let idx = self.gc_page_list.ser(ctx, out, idx);
+        let idx = self.schema.ser(ctx, out, idx);
+        self.block_index.ser(ctx, out, idx)
+    }
+}
+
+pub struct MetaPageGcListSerView<'a>(LwcPrimitiveSer<'a>);
+
+impl<'a> MetaPageGcListSerView<'a> {
+    #[inline]
+    pub fn new(data: &'a [PageID]) -> Self {
+        MetaPageGcListSerView(LwcPrimitiveSer::new_u64(data))
+    }
+}
+
+impl<'a> Ser<'a> for MetaPageGcListSerView<'a> {
+    #[inline]
+    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
+        self.0.ser_len(ctx)
+    }
+
+    #[inline]
+    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
+        self.0.ser(ctx, out, start_idx)
+    }
+}
+
+pub struct MetaPageBlockIndexSerView<'a> {
+    s: LwcPrimitiveSer<'a>,
+    d: LwcPrimitiveSer<'a>,
+    p: LwcPrimitiveSer<'a>,
+}
+
+impl<'a> MetaPageBlockIndexSerView<'a> {
+    #[inline]
+    pub fn new(block_index: &'a BlockIndexArray) -> Self {
+        MetaPageBlockIndexSerView {
+            s: LwcPrimitiveSer::new_u64(&block_index.starts),
+            d: LwcPrimitiveSer::new_u64(&block_index.deltas),
+            p: LwcPrimitiveSer::new_u64(&block_index.pages),
+        }
+    }
+}
+
+impl<'a> Ser<'a> for MetaPageBlockIndexSerView<'a> {
+    #[inline]
+    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
+        self.s.ser_len(ctx) + self.d.ser_len(ctx) + self.p.ser_len(ctx)
+    }
+
+    #[inline]
+    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
+        let idx = self.s.ser(ctx, out, start_idx);
+        let idx = self.d.ser(ctx, out, idx);
+        self.p.ser(ctx, out, idx)
+    }
+}
+
+pub struct MetaPageBlockIndexDeser {
+    s: Vec<RowID>,
+    d: Vec<RowID>,
+    p: Vec<PageID>,
+}
+
+impl From<MetaPageBlockIndexDeser> for BlockIndexArray {
+    #[inline]
+    fn from(value: MetaPageBlockIndexDeser) -> Self {
+        BlockIndexArray {
+            starts: value.s.into_boxed_slice(),
+            deltas: value.d.into_boxed_slice(),
+            pages: value.p.into_boxed_slice(),
+        }
+    }
+}
+
+impl Deser for MetaPageBlockIndexDeser {
+    #[inline]
+    fn deser(ctx: &mut SerdeCtx, input: &[u8], start_idx: usize) -> Result<(usize, Self)> {
+        let (idx, s) = LwcPrimitiveDeser::<RowID>::deser(ctx, input, start_idx)?;
+        let (idx, d) = LwcPrimitiveDeser::<RowID>::deser(ctx, input, idx)?;
+        let (idx, p) = LwcPrimitiveDeser::<PageID>::deser(ctx, input, idx)?;
+        Ok((
+            idx,
+            MetaPageBlockIndexDeser {
+                s: s.0,
+                d: d.0,
+                p: p.0,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::{ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec};
+    use crate::file::table_file::ActiveRoot;
+    use crate::value::ValKind;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_meta_page_serde() {
+        let metadata = Arc::new(TableMetadata::new(
+            vec![
+                ColumnSpec::new("c0", ValKind::U32, ColumnAttributes::empty()),
+                ColumnSpec::new("c1", ValKind::U64, ColumnAttributes::NULLABLE),
+            ],
+            vec![IndexSpec::new(
+                "idx1",
+                vec![IndexKey::new(0)],
+                IndexAttributes::PK,
+            )],
+        ));
+        let active_root = ActiveRoot::new(7, 1024, Arc::clone(&metadata));
+        let mut ctx = SerdeCtx::default();
+        let ser_view = active_root.meta_page_ser_view();
+        let ser_len = ser_view.ser_len(&ctx);
+        let mut data = vec![0u8; ser_len];
+        let res_idx = ser_view.ser(&ctx, &mut data, 0);
+        assert_eq!(res_idx, ser_len);
+
+        let (_, meta_page) = MetaPage::deser(&mut ctx, &data, 0).unwrap();
+        assert_eq!(meta_page.schema, *active_root.metadata);
+        assert_eq!(meta_page.block_index, active_root.block_index);
+        assert_eq!(meta_page.space_map, active_root.alloc_map);
+        assert_eq!(meta_page.gc_page_list, active_root.gc_page_list);
+        assert_eq!(meta_page.pivot_row_id, active_root.row_id_bound);
+        assert_eq!(meta_page.last_checkpoint_cts, active_root.trx_id);
+    }
+}

--- a/doradb-storage/src/file/mod.rs
+++ b/doradb-storage/src/file/mod.rs
@@ -1,3 +1,4 @@
+pub mod meta_page;
 pub mod super_page;
 pub mod table_file;
 pub mod table_fs;

--- a/doradb-storage/src/file/super_page.rs
+++ b/doradb-storage/src/file/super_page.rs
@@ -1,41 +1,39 @@
-use crate::bitmap::AllocMap;
 use crate::buffer::page::PageID;
-use crate::catalog::table::{TableBriefMetadata, TableBriefMetadataSerView, TableMetadata};
 use crate::error::Result;
-use crate::file::table_file::{BlockIndexArray, TABLE_FILE_SUPER_PAGE_FOOTER_SIZE};
-use crate::lwc::{LwcPrimitiveDeser, LwcPrimitiveSer};
-use crate::row::RowID;
+use crate::file::table_file::TABLE_FILE_SUPER_PAGE_FOOTER_SIZE;
 use crate::serde::{Deser, Ser, SerdeCtx};
 use crate::trx::TrxID;
 use std::mem;
+
+pub const SUPER_PAGE_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuperPageHeader {
     /// Magic word of table file, by default 'DORA\0\0\0\0'
     pub magic_word: [u8; 8],
+    /// Version of super page format.
+    pub version: u16,
     /// Page number of this super page.
     pub page_no: PageID,
     /// transaction id of this super page.
     pub trx_id: TrxID,
-    /// pivot row id.
-    pub pivot_row_id: RowID,
 }
 
 impl Ser<'_> for SuperPageHeader {
     #[inline]
     fn ser_len(&self, _ctx: &SerdeCtx) -> usize {
         mem::size_of::<[u8; 8]>() // magic word
+            + mem::size_of::<u16>() // version
             + mem::size_of::<PageID>() // page no
             + mem::size_of::<TrxID>() // transaction id
-            + mem::size_of::<RowID>() // row id bound
     }
 
     #[inline]
     fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
         let idx = ctx.ser_byte_array(out, start_idx, &self.magic_word);
+        let idx = ctx.ser_u16(out, idx, self.version);
         let idx = ctx.ser_u64(out, idx, self.page_no);
-        let idx = ctx.ser_u64(out, idx, self.trx_id);
-        ctx.ser_u64(out, idx, self.pivot_row_id)
+        ctx.ser_u64(out, idx, self.trx_id)
     }
 }
 
@@ -43,14 +41,14 @@ impl Deser for SuperPageHeader {
     #[inline]
     fn deser(ctx: &mut SerdeCtx, input: &[u8], start_idx: usize) -> Result<(usize, Self)> {
         let (idx, magic_word) = ctx.deser_byte_array::<8>(input, start_idx)?;
+        let (idx, version) = ctx.deser_u16(input, idx)?;
         let (idx, page_no) = ctx.deser_u64(input, idx)?;
         let (idx, trx_id) = ctx.deser_u64(input, idx)?;
-        let (idx, pivot_row_id) = ctx.deser_u64(input, idx)?;
         let res = SuperPageHeader {
             magic_word,
+            version,
             page_no,
             trx_id,
-            pivot_row_id,
         };
         Ok((idx, res))
     }
@@ -58,56 +56,26 @@ impl Deser for SuperPageHeader {
 
 #[derive(PartialEq, Eq)]
 pub struct SuperPageBody {
-    pub alloc: SuperPageAlloc,
-    pub free: SuperPageFree,
-    pub meta: SuperPageMeta,
-    pub block_index: SuperPageBlockIndex,
+    pub meta_page_id: PageID,
+}
+
+impl Ser<'_> for SuperPageBody {
+    #[inline]
+    fn ser_len(&self, _ctx: &SerdeCtx) -> usize {
+        mem::size_of::<PageID>()
+    }
+
+    #[inline]
+    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
+        ctx.ser_u64(out, start_idx, self.meta_page_id)
+    }
 }
 
 impl Deser for SuperPageBody {
     #[inline]
     fn deser(ctx: &mut SerdeCtx, input: &[u8], start_idx: usize) -> Result<(usize, Self)> {
-        // alloc map
-        let (idx, alloc_page_no) = ctx.deser_u64(input, start_idx)?;
-        let (idx, alloc) = if alloc_page_no == 0 {
-            let (idx, alloc_map) = AllocMap::deser(ctx, input, idx)?;
-            (idx, SuperPageAlloc::Inline(alloc_map))
-        } else {
-            (idx, SuperPageAlloc::PageNo(alloc_page_no))
-        };
-        // free list
-        let (idx, free_page_no) = ctx.deser_u64(input, idx)?;
-        let (idx, free) = if free_page_no == 0 {
-            let (idx, free_list) = LwcPrimitiveDeser::<PageID>::deser(ctx, input, idx)?;
-            (idx, SuperPageFree::Inline(free_list.0))
-        } else {
-            (idx, SuperPageFree::PageNo(free_page_no))
-        };
-        // metadata
-        let (idx, meta_page_no) = ctx.deser_u64(input, idx)?;
-        let (idx, meta) = if meta_page_no == 0 {
-            let (idx, meta) = TableBriefMetadata::deser(ctx, input, idx)?;
-            (idx, SuperPageMeta::Inline(TableMetadata::from(meta)))
-        } else {
-            (idx, SuperPageMeta::PageNo(meta_page_no))
-        };
-        // block index
-        let (idx, block_index_page_no) = ctx.deser_u64(input, idx)?;
-        let (idx, block_index) = if block_index_page_no == 0 {
-            let (idx, block_index) = SuperPageBlockIndexDeser::deser(ctx, input, idx)?;
-            (idx, SuperPageBlockIndex::Inline(block_index.into()))
-        } else {
-            (idx, SuperPageBlockIndex::PageNo(block_index_page_no))
-        };
-        Ok((
-            idx,
-            SuperPageBody {
-                alloc,
-                free,
-                meta,
-                block_index,
-            },
-        ))
+        let (idx, meta_page_id) = ctx.deser_u64(input, start_idx)?;
+        Ok((idx, SuperPageBody { meta_page_id }))
     }
 }
 
@@ -146,36 +114,12 @@ pub struct SuperPage {
     pub footer: SuperPageFooter,
 }
 
-#[derive(PartialEq, Eq)]
-pub enum SuperPageAlloc {
-    Inline(AllocMap),
-    PageNo(PageID),
-}
-
-#[derive(PartialEq, Eq)]
-pub enum SuperPageFree {
-    Inline(Vec<PageID>),
-    PageNo(PageID),
-}
-
-#[derive(PartialEq, Eq)]
-pub enum SuperPageMeta {
-    Inline(TableMetadata),
-    PageNo(PageID),
-}
-
-#[derive(PartialEq, Eq)]
-pub enum SuperPageBlockIndex {
-    Inline(BlockIndexArray),
-    PageNo(PageID),
-}
-
-pub struct SuperPageSerView<'a> {
+pub struct SuperPageSerView {
     pub header: SuperPageHeader,
-    pub body: SuperPageBodySerView<'a>,
+    pub body: SuperPageBody,
 }
 
-impl<'a> Ser<'a> for SuperPageSerView<'a> {
+impl Ser<'_> for SuperPageSerView {
     #[inline]
     fn ser_len(&self, ctx: &SerdeCtx) -> usize {
         self.header.ser_len(ctx) + self.body.ser_len(ctx)
@@ -188,280 +132,33 @@ impl<'a> Ser<'a> for SuperPageSerView<'a> {
     }
 }
 
-pub struct SuperPageBodySerView<'a> {
-    pub alloc: SuperPageAllocSerView<'a>,
-    pub free: SuperPageFreeSerView<'a>,
-    pub meta: SuperPageMetaSerView<'a>,
-    pub block_index: SuperPageBlockIndexSerView<'a>,
-}
-
-impl<'a> SuperPageBodySerView<'a> {
-    #[inline]
-    pub fn new(
-        alloc: &'a AllocMap,
-        free: &'a [PageID],
-        meta: TableBriefMetadataSerView<'a>,
-        block_index: &'a BlockIndexArray,
-    ) -> Self {
-        SuperPageBodySerView {
-            alloc: SuperPageAllocSerView::Inline(alloc),
-            free: SuperPageFreeSerView::new(free),
-            meta: SuperPageMetaSerView::Inline(meta),
-            block_index: SuperPageBlockIndexSerView::new(block_index),
-        }
-    }
-}
-
-impl<'a> Ser<'a> for SuperPageBodySerView<'a> {
-    #[inline]
-    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
-        self.alloc.ser_len(ctx)
-            + self.free.ser_len(ctx)
-            + self.meta.ser_len(ctx)
-            + self.block_index.ser_len(ctx)
-    }
-
-    #[inline]
-    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
-        let idx = self.alloc.ser(ctx, out, start_idx);
-        let idx = self.free.ser(ctx, out, idx);
-        let idx = self.meta.ser(ctx, out, idx);
-        self.block_index.ser(ctx, out, idx)
-    }
-}
-
-pub enum SuperPageAllocSerView<'a> {
-    Inline(&'a AllocMap),
-    PageNo(PageID),
-}
-
-impl<'a> Ser<'a> for SuperPageAllocSerView<'a> {
-    #[inline]
-    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
-        match self {
-            SuperPageAllocSerView::Inline(alloc) => {
-                mem::size_of::<PageID>() // inline(0)
-                    + alloc.ser_len(ctx) // alloc map
-            }
-            SuperPageAllocSerView::PageNo(_) => mem::size_of::<PageID>(),
-        }
-    }
-
-    #[inline]
-    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
-        match self {
-            SuperPageAllocSerView::Inline(alloc) => {
-                let idx = ctx.ser_u64(out, start_idx, 0);
-                alloc.ser(ctx, out, idx)
-            }
-            SuperPageAllocSerView::PageNo(page_no) => ctx.ser_u64(out, start_idx, *page_no),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SuperPageFreeSerView<'a> {
-    Inline(LwcPrimitiveSer<'a>),
-    PageNo(PageID),
-}
-
-impl<'a> SuperPageFreeSerView<'a> {
-    #[inline]
-    pub fn new(data: &'a [PageID]) -> Self {
-        SuperPageFreeSerView::Inline(LwcPrimitiveSer::new_u64(data))
-    }
-}
-
-impl<'a> Ser<'a> for SuperPageFreeSerView<'a> {
-    #[inline]
-    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
-        match self {
-            SuperPageFreeSerView::Inline(encoder) => {
-                mem::size_of::<PageID>() // always 0
-                    + encoder.ser_len(ctx)
-            }
-            SuperPageFreeSerView::PageNo(_) => mem::size_of::<PageID>(),
-        }
-    }
-
-    #[inline]
-    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
-        match self {
-            SuperPageFreeSerView::PageNo(page_id) => {
-                debug_assert!(*page_id != 0);
-                ctx.ser_u64(out, start_idx, *page_id)
-            }
-            SuperPageFreeSerView::Inline(bp) => {
-                let idx = ctx.ser_u64(out, start_idx, 0);
-                bp.ser(ctx, out, idx)
-            }
-        }
-    }
-}
-
-pub enum SuperPageMetaSerView<'a> {
-    Inline(TableBriefMetadataSerView<'a>),
-    PageNo(PageID),
-}
-
-impl<'a> Ser<'a> for SuperPageMetaSerView<'a> {
-    #[inline]
-    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
-        match self {
-            SuperPageMetaSerView::Inline(meta) => {
-                mem::size_of::<PageID>() // inline(0)
-                    + meta.ser_len(ctx) // alloc map
-            }
-            SuperPageMetaSerView::PageNo(_) => mem::size_of::<PageID>(),
-        }
-    }
-
-    #[inline]
-    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
-        match self {
-            SuperPageMetaSerView::Inline(meta) => {
-                let idx = ctx.ser_u64(out, start_idx, 0);
-                meta.ser(ctx, out, idx)
-            }
-            SuperPageMetaSerView::PageNo(page_no) => ctx.ser_u64(out, start_idx, *page_no),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SuperPageBlockIndexSerView<'a> {
-    Inline {
-        s: LwcPrimitiveSer<'a>,
-        d: LwcPrimitiveSer<'a>,
-        p: LwcPrimitiveSer<'a>,
-    },
-    PageNo(PageID),
-}
-
-impl<'a> SuperPageBlockIndexSerView<'a> {
-    #[inline]
-    pub fn new(block_index: &'a BlockIndexArray) -> Self {
-        let s = LwcPrimitiveSer::new_u64(&block_index.starts);
-        let d = LwcPrimitiveSer::new_u64(&block_index.deltas);
-        let p = LwcPrimitiveSer::new_u64(&block_index.pages);
-        SuperPageBlockIndexSerView::Inline { s, d, p }
-    }
-}
-
-impl<'a> Ser<'a> for SuperPageBlockIndexSerView<'a> {
-    #[inline]
-    fn ser_len(&self, ctx: &SerdeCtx) -> usize {
-        match self {
-            SuperPageBlockIndexSerView::Inline { s, d, p } => {
-                mem::size_of::<PageID>() // always 0
-                    + s.ser_len(ctx) // start row ids
-                    + d.ser_len(ctx) // deltas
-                    + p.ser_len(ctx) // pages
-            }
-            SuperPageBlockIndexSerView::PageNo(_) => mem::size_of::<PageID>(),
-        }
-    }
-
-    #[inline]
-    fn ser(&self, ctx: &SerdeCtx, out: &mut [u8], start_idx: usize) -> usize {
-        match self {
-            SuperPageBlockIndexSerView::PageNo(page_id) => {
-                debug_assert!(*page_id != 0);
-                ctx.ser_u64(out, start_idx, *page_id)
-            }
-            SuperPageBlockIndexSerView::Inline { s, d, p } => {
-                let idx = ctx.ser_u64(out, start_idx, 0);
-                let idx = s.ser(ctx, out, idx);
-                let idx = d.ser(ctx, out, idx);
-                p.ser(ctx, out, idx)
-            }
-        }
-    }
-}
-
-pub struct SuperPageBlockIndexDeser {
-    s: Vec<RowID>,
-    d: Vec<RowID>,
-    p: Vec<PageID>,
-}
-
-impl From<SuperPageBlockIndexDeser> for BlockIndexArray {
-    #[inline]
-    fn from(value: SuperPageBlockIndexDeser) -> Self {
-        BlockIndexArray {
-            starts: value.s.into_boxed_slice(),
-            deltas: value.d.into_boxed_slice(),
-            pages: value.p.into_boxed_slice(),
-        }
-    }
-}
-
-impl Deser for SuperPageBlockIndexDeser {
-    #[inline]
-    fn deser(ctx: &mut SerdeCtx, input: &[u8], start_idx: usize) -> Result<(usize, Self)> {
-        let (idx, s) = LwcPrimitiveDeser::<RowID>::deser(ctx, input, start_idx)?;
-        let (idx, d) = LwcPrimitiveDeser::<RowID>::deser(ctx, input, idx)?;
-        let (idx, p) = LwcPrimitiveDeser::<PageID>::deser(ctx, input, idx)?;
-        Ok((
-            idx,
-            SuperPageBlockIndexDeser {
-                s: s.0,
-                d: d.0,
-                p: p.0,
-            },
-        ))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::{ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec};
-    use crate::file::table_file::ActiveRoot;
-    use crate::value::ValKind;
-    use std::sync::Arc;
+    use crate::file::table_file::TABLE_FILE_MAGIC_WORD;
 
     #[test]
-    fn test_active_root_serde() {
-        let metadata = Arc::new(TableMetadata::new(
-            vec![
-                ColumnSpec::new("c0", ValKind::U32, ColumnAttributes::empty()),
-                ColumnSpec::new("c1", ValKind::U64, ColumnAttributes::NULLABLE),
-            ],
-            vec![IndexSpec::new(
-                "idx1",
-                vec![IndexKey::new(0)],
-                IndexAttributes::PK,
-            )],
-        ));
-        let active_root = ActiveRoot::new(1, 1024, Arc::clone(&metadata));
+    fn test_super_page_serde() {
+        let header = SuperPageHeader {
+            magic_word: TABLE_FILE_MAGIC_WORD,
+            version: SUPER_PAGE_VERSION,
+            page_no: 1,
+            trx_id: 12,
+        };
+        let body = SuperPageBody { meta_page_id: 7 };
         let mut ctx = SerdeCtx::default();
-        let ser_view = active_root.ser_view();
+        let ser_view = SuperPageSerView {
+            header: header.clone(),
+            body,
+        };
         let ser_len = ser_view.ser_len(&ctx);
         let mut data = vec![0u8; ser_len];
         let res_idx = ser_view.ser(&ctx, &mut data, 0);
-        assert!(res_idx == ser_len);
+        assert_eq!(res_idx, ser_len);
 
-        let (header_idx, header) = SuperPageHeader::deser(&mut ctx, &data, 0).unwrap();
-        let (body_idx, body) = SuperPageBody::deser(&mut ctx, &data, header_idx).unwrap();
-        assert!(body_idx == ser_len);
-        assert_eq!(header.page_no, active_root.page_no);
-        assert_eq!(header.trx_id, active_root.trx_id);
-        if let SuperPageAlloc::Inline(alloc_map) = &body.alloc {
-            assert_eq!(alloc_map, &active_root.alloc_map);
-        } else {
-            panic!("invalid super page");
-        }
-        if let SuperPageFree::Inline(free_list) = &body.free {
-            assert_eq!(free_list, &active_root.free_list);
-        } else {
-            panic!("invalid super page");
-        }
-
-        if let SuperPageMeta::Inline(metadata) = &body.meta {
-            assert_eq!(metadata, &*active_root.metadata);
-        } else {
-            panic!("invalid super page");
-        }
+        let (idx, deser_header) = SuperPageHeader::deser(&mut ctx, &data, 0).unwrap();
+        let (_, deser_body) = SuperPageBody::deser(&mut ctx, &data, idx).unwrap();
+        assert_eq!(deser_header, header);
+        assert_eq!(deser_body.meta_page_id, 7);
     }
 }

--- a/doradb-storage/src/serde.rs
+++ b/doradb-storage/src/serde.rs
@@ -1177,8 +1177,7 @@ mod tests {
         let mut res = vec![0u8; bp.ser_len(&ctx)];
         let ser_idx = bp.ser(&ctx, &mut res, 0);
         assert_eq!(ser_idx, res.len());
-        let (de_idx, decompressed) =
-            ForBitpackingDeser::<i16>::deser(&mut ctx, &res, 0).unwrap();
+        let (de_idx, decompressed) = ForBitpackingDeser::<i16>::deser(&mut ctx, &res, 0).unwrap();
         assert_eq!(de_idx, res.len());
         assert_eq!(decompressed.0, input);
 
@@ -1187,8 +1186,7 @@ mod tests {
         let mut res = vec![0u8; bp.ser_len(&ctx)];
         let ser_idx = bp.ser(&ctx, &mut res, 0);
         assert_eq!(ser_idx, res.len());
-        let (de_idx, decompressed) =
-            ForBitpackingDeser::<i32>::deser(&mut ctx, &res, 0).unwrap();
+        let (de_idx, decompressed) = ForBitpackingDeser::<i32>::deser(&mut ctx, &res, 0).unwrap();
         assert_eq!(de_idx, res.len());
         assert_eq!(decompressed.0, input);
     }


### PR DESCRIPTION
### Motivation

- Ensure the in-memory layout of `MetaPage` matches the serialized layout to avoid mismatches during (de)serialization.
- Place `pivot_row_id` and `last_checkpoint_cts` at the front so their order is consistent with the `Ser`/`Deser` logic.

### Description

- Reordered `MetaPage` struct fields in `doradb-storage/src/file/meta_page.rs` so `pivot_row_id` and `last_checkpoint_cts` come before `schema`, `block_index`, `space_map`, and `gc_page_list`.
- Updated `MetaPage::deser`, `MetaPageSerView`, and `MetaPageSerView::new` to reflect the new field order and ensure `ser`/`ser_len` emit the same sequence.
- Adjusted the serialization/deserialization sequences to write/read `pivot_row_id` and `last_checkpoint_cts` first.

### Testing

- Ran `cargo fmt` to format the code and it completed successfully.
- No automated unit or integration tests (`cargo test`) were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4cc4c98c832f896f3cb319101f5f)