### PR TITLE
test: add LwcBuilder rollback and full-type coverage; fix LwcPage nullable row_id layout

### DIFF
--- a/doradb-storage/src/lwc/page.rs
+++ b/doradb-storage/src/lwc/page.rs
@@ -485,6 +485,10 @@ mod tests {
             vec![],
         );
         let ctx = SerdeCtx::default();
+        let row_ids = [1u64, 2, 3, 4];
+        let row_id_ser = LwcPrimitiveSer::new_u64(&row_ids);
+        let mut row_id_bytes = vec![0u8; row_id_ser.ser_len(&ctx)];
+        row_id_ser.ser(&ctx, &mut row_id_bytes, 0);
         let values = [10u8, 20, 30, 40];
         let lwc_ser = LwcPrimitiveSer::new_u8(&values);
         let mut values_bytes = vec![0u8; lwc_ser.ser_len(&ctx)];
@@ -499,10 +503,11 @@ mod tests {
         let mut bytes = [0u8; TABLE_FILE_PAGE_SIZE];
         let page = unsafe { std::mem::transmute::<&mut [u8; 65536], &mut LwcPage>(&mut bytes) };
         let col_offsets_len = mem::size_of::<u16>();
-        let col_start = col_offsets_len;
+        let col_start = col_offsets_len + row_id_bytes.len();
         let col_end = col_start + column_bytes.len();
         page.header = LwcPageHeader::new(1, 4, values.len() as u16, 1, col_start as u16);
         page.body[..col_offsets_len].copy_from_slice(&(col_end as u16).to_le_bytes());
+        page.body[col_offsets_len..col_start].copy_from_slice(&row_id_bytes);
         page.body[col_start..col_end].copy_from_slice(&column_bytes);
 
         let column = page.column(&metadata, 0).unwrap();


### PR DESCRIPTION
### Motivation
- Validate that `LwcBuilder::rollback` correctly restores the builder state (row count, `row_ids`, and per-column stats) after a failed append. 
- Exercise `LwcBuilder` with every supported column `ValKind` (i8..i64, u8..u64, `f32`, `f64`, `VarByte`) to ensure serialization/deserialization and page building handle all types. 
- Ensure `LwcPage` nullable-column unit test models the on-disk layout when a `row_id` segment is present so offsets are computed consistently. 

### Description
- Added `test_lwc_builder_rollback` in `doradb-storage/src/lwc/mod.rs` which constructs a `RowPage`, appends to `LwcBuilder`, mutates state, calls `rollback(snapshot)`, and asserts restored `row_count`, `row_ids.len()` and column stats snapshots. 
- Added `test_lwc_builder_all_column_types` in `doradb-storage/src/lwc/mod.rs` which builds a page covering all `ValKind`s, uses `MemVar::inline` and `OrderedFloat` for bytes and floats, runs `LwcBuilder::build`, transmutes the output to `LwcPage`, and validates each column `data().value()` matches inputs. 
- Updated imports in the test module to include `MemVar` and `OrderedFloat` for constructing test values. 
- Adjusted `test_lwc_page_nullable_column` in `doradb-storage/src/lwc/page.rs` to serialize a `row_id` payload with `LwcPrimitiveSer::new_u64`, include it in `page.body`, and move `col_start` calculation to account for the `row_id` bytes so column offsets match the real on-disk layout. 

### Testing
- Added two unit tests (`test_lwc_builder_rollback` and `test_lwc_builder_all_column_types`) and updated an existing page test (`test_lwc_page_nullable_column`) under the module tests. 
- No automated test suite (e.g., `cargo test`) was executed locally as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f82273c94832fae49d553b3f65845)