### PR TITLE
feat: add libaio feature gate

### DIFF
--- a/doradb-storage/Cargo.toml
+++ b/doradb-storage/Cargo.toml
@@ -36,7 +36,8 @@ blake3 = "1.8"
 ordered-float = {version = "5.1", features = ["serde"] }
 
 [features]
-default = []
+default = ["libaio"]
+libaio = []
 mlock = []
 
 [dev-dependencies]

--- a/doradb-storage/src/io/libaio_abi.rs
+++ b/doradb-storage/src/io/libaio_abi.rs
@@ -109,6 +109,7 @@ pub struct iovec {
     pub iov_len: usize,
 }
 
+#[cfg(feature = "libaio")]
 #[link(name = "aio")]
 unsafe extern "C" {
     pub fn io_queue_init(maxevents: c_int, ctxp: *mut io_context_t) -> c_int;
@@ -132,6 +133,58 @@ unsafe extern "C" {
         events: *mut io_event,
         timeout: *mut timespec,
     ) -> c_int;
+}
+
+#[cfg(not(feature = "libaio"))]
+#[inline]
+fn libaio_stub_error() -> c_int {
+    -(libc::ENOSYS as c_int)
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_queue_init(_maxevents: c_int, _ctxp: *mut io_context_t) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_queue_release(_ctx: io_context_t) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_queue_run(_ctx: io_context_t) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_setup(_maxevents: c_int, _ctxp: *mut io_context_t) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_destroy(_ctx: io_context_t) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_submit(_ctx: io_context_t, _nr: c_long, _ios: *mut *mut iocb) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_cancel(_ctx: io_context_t, _iocb: *mut iocb, _evt: *mut io_event) -> c_int {
+    libaio_stub_error()
+}
+
+#[cfg(not(feature = "libaio"))]
+pub unsafe fn io_getevents(
+    _ctx_id: io_context_t,
+    _min_nr: c_long,
+    _nr: c_long,
+    _events: *mut io_event,
+    _timeout: *mut timespec,
+) -> c_int {
+    libaio_stub_error()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Make linking against the system `libaio` optional so the storage crate can be built in environments without `libaio` installed.  
- Preserve the current behavior by enabling the `libaio` feature by default.  
- Ensure tests and tooling that do not require native AIO can run in constrained CI/sandbox environments.

### Description
- Add a `libaio` feature to `doradb-storage/Cargo.toml` and include it in the `default` features list.  
- Gate the `#[link(name = "aio")]` extern block in `doradb-storage/src/io/libaio_abi.rs` with `#[cfg(feature = "libaio")]`.  
- Provide `#[cfg(not(feature = "libaio"))]` stub implementations for the exported ABI functions (`io_setup`, `io_submit`, `io_getevents`, `io_destroy`, `io_cancel`, `io_queue_*`) that return a negative error code (`-ENOSYS`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609917b78c832fb2d0459f5bc74dc2)