### PR TITLE
feat: hitchhike system transaction commit

### DIFF
--- a/doradb-storage/src/buffer/frame.rs
+++ b/doradb-storage/src/buffer/frame.rs
@@ -3,6 +3,7 @@ use crate::catalog::TableMetadata;
 use crate::latch::HybridLatch;
 use crate::trx::recover::RecoverMap;
 use crate::trx::ver_map::RowVersionMap;
+use crate::trx::TrxID;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
@@ -76,8 +77,10 @@ impl BufferFrame {
     }
 
     #[inline]
-    pub fn init_recover_map(&mut self) {
-        self.ctx = Some(Box::new(FrameContext::RecoverMap(RecoverMap::empty())));
+    pub fn init_recover_map(&mut self, create_cts: TrxID) {
+        self.ctx = Some(Box::new(FrameContext::RecoverMap(RecoverMap::new(
+            create_cts,
+        ))));
     }
 }
 

--- a/doradb-storage/src/index/block_index.rs
+++ b/doradb-storage/src/index/block_index.rs
@@ -522,9 +522,14 @@ impl BlockIndex {
                         let page_committer_guard = self.page_committer.lock();
                         page_committer_guard.as_ref().cloned()
                     } {
-                        page_committer
+                        let create_cts = page_committer
                             .commit_row_page(new_page_id, start_row_id, end_row_id)
                             .await;
+                        if let Some(row_ver) =
+                            new_page.bf().ctx.as_ref().and_then(|ctx| ctx.row_ver())
+                        {
+                            row_ver.set_create_cts(create_cts);
+                        }
                     }
                     // finally, we downgrade the page lock for shared mode.
                     return;

--- a/doradb-storage/src/index/util.rs
+++ b/doradb-storage/src/index/util.rs
@@ -2,6 +2,7 @@ use crate::buffer::page::PageID;
 use crate::catalog::TableID;
 use crate::row::{INVALID_ROW_ID, RowID};
 use crate::trx::sys::TransactionSystem;
+use crate::trx::TrxID;
 
 /// Value that can be masked as deleted.
 pub trait Maskable: Copy + PartialEq + Eq {
@@ -74,13 +75,20 @@ impl RedoLogPageCommitter {
         RedoLogPageCommitter { trx_sys, table_id }
     }
 
-    pub async fn commit_row_page(&self, page_id: PageID, start_row_id: RowID, end_row_id: RowID) {
+    pub async fn commit_row_page(
+        &self,
+        page_id: PageID,
+        start_row_id: RowID,
+        end_row_id: RowID,
+    ) -> TrxID {
         let mut trx = self.trx_sys.begin_sys_trx();
         let table_id = self.table_id;
         // Once a row page is added to block index, we start
         // a new internal transaction and log its information.
         trx.create_row_page(table_id, page_id, start_row_id, end_row_id);
-        let res = self.trx_sys.commit_sys(trx).await;
-        assert!(res.is_ok());
+        self.trx_sys
+            .commit_sys(trx)
+            .await
+            .expect("commit system transaction for row page")
     }
 }

--- a/doradb-storage/src/trx/sys.rs
+++ b/doradb-storage/src/trx/sys.rs
@@ -183,21 +183,21 @@ impl TransactionSystem {
             return Ok(0);
         }
         // start group commit
-        partition.commit(prepared_trx, &self.ts).await
+        partition.commit(prepared_trx, &self.ts, true).await
     }
 
     #[inline]
-    pub async fn commit_sys(&self, trx: SysTrx) -> Result<()> {
+    pub async fn commit_sys(&self, trx: SysTrx) -> Result<TrxID> {
         if trx.redo.is_empty() {
             // System transaction does not hold any active start timestamp
             // so we can just drop it if there is no change to replay.
-            return Ok(());
+            return Ok(0);
         }
         // system transactions are always submitted to first log partition.
         const LOG_NO: usize = 0;
         let partition = &*self.log_partitions[LOG_NO];
         let prepared_trx = trx.prepare();
-        partition.commit(prepared_trx, &self.ts).await.map(|_| ())
+        partition.commit(prepared_trx, &self.ts, false).await
     }
 
     /// Rollback active transaction.


### PR DESCRIPTION
### Motivation
- Reduce latency of system transactions (e.g., `CreateRowPage`) by returning immediately after enqueuing their redo into the group commit rather than waiting for fsync. 
- Ensure correct visibility/ordering by recording the page creation commit timestamp and restoring it during recovery. 
- Propagate the creation CTS into page-level version maps so subsequent user transactions can reason about visibility without forcing the system commit to block. 

### Description
- Added a `wait_sync: bool` parameter to `LogPartition::commit` and return the assigned CTS immediately when `wait_sync` is `false`, enabling non-blocking system commits via `commit(..., false)`. 
- Changed `TransactionSystem::commit_sys` to return a `TrxID` and call `partition.commit(..., false)` so system transactions (like page creation) can hitchhike instead of waiting for fsync. 
- Extended `RowVersionMap` with a `create_cts: AtomicU64` plus `set_create_cts`/`create_cts` accessors to record the creation CTS for a row page. 
- Reworked `RecoverMap` to carry `create_cts` and `entries: Vec<Option<TrxID>>`, threaded the log header CTS through `LogRecovery::replay_ddl` and used it when initializing recover maps and when refreshing pages during recovery. 
- Updated page creation and recovery paths to propagate creation CTS: `RedoLogPageCommitter::commit_row_page` now returns the CTS, `BlockIndex::insert_page_guard` sets the `RowVersionMap` create CTS after commit, `BufferFrame::init_recover_map` accepts a `create_cts` argument, and recovery restores the CTS into the `RowVersionMap` when switching from recover map to undo map. 

### Testing
- No automated tests were executed for this change. 
- Existing test suites were not run as part of this patch submission. 
- Manual/local integrations were not reported in this rollout. 
- Recommend running `cargo test -p doradb-storage` (or with `--no-default-features` if `libaio` is unavailable) after review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696264bded5c832fb697fb0fd786e7bb)