### PR TITLE
refactor: split log commit enqueue path

### DIFF
--- a/doradb-storage/src/index/util.rs
+++ b/doradb-storage/src/index/util.rs
@@ -88,7 +88,6 @@ impl RedoLogPageCommitter {
         trx.create_row_page(table_id, page_id, start_row_id, end_row_id);
         self.trx_sys
             .commit_sys(trx)
-            .await
             .expect("commit system transaction for row page")
     }
 }

--- a/doradb-storage/src/trx/sys.rs
+++ b/doradb-storage/src/trx/sys.rs
@@ -187,7 +187,7 @@ impl TransactionSystem {
     }
 
     #[inline]
-    pub async fn commit_sys(&self, trx: SysTrx) -> Result<TrxID> {
+    pub fn commit_sys(&self, trx: SysTrx) -> Result<TrxID> {
         if trx.redo.is_empty() {
             // System transaction does not hold any active start timestamp
             // so we can just drop it if there is no change to replay.
@@ -197,7 +197,7 @@ impl TransactionSystem {
         const LOG_NO: usize = 0;
         let partition = &*self.log_partitions[LOG_NO];
         let prepared_trx = trx.prepare();
-        partition.commit(prepared_trx, &self.ts, false).await
+        partition.commit_no_wait(prepared_trx, &self.ts)
     }
 
     /// Rollback active transaction.


### PR DESCRIPTION
### Motivation

- Reduce code duplication in the log commit path by extracting the enqueue logic for grouped commits.  
- Avoid creating and awaiting `EventListener`s when callers do not require fsync waiting (no-wait system commits).  
- Make system transaction commits synchronous at the call site to simplify control flow for internal transactions.  

### Description

- Extracted enqueue logic into a new `enqueue_commit` helper and added `commit_no_wait` in `doradb-storage/src/trx/log.rs` to return `(TrxID, Option<Session>, Option<EventListener>)` for reuse.  
- Updated `create_new_group` and `CommitGroup::join` signatures to accept a `wait_sync: bool` and return an `Option<EventListener>` so listeners are only created when needed.  
- Changed `commit_sys` in `doradb-storage/src/trx/sys.rs` to be synchronous and to call `commit_no_wait` so system transactions do not create listeners or await fsync.  
- Removed the `.await` at the `commit_sys` call site in `doradb-storage/src/index/util.rs` to match the new synchronous `commit_sys` API.  

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962f7fe7dac832f9ea3a54771371aaf)