### PR TITLE
fix: replace Move undo with Delete+Insert and index-branch linking

### DIFF
--- a/doradb-storage/src/table/access.rs
+++ b/doradb-storage/src/table/access.rs
@@ -339,7 +339,7 @@ impl TableAccess for Table {
         let keys = self.metadata().keys_for_insert(&cols);
         // insert row into page with undo log linked.
         let (row_id, page_guard) = self
-            .insert_row_internal(data_pool, stmt, cols, RowUndoKind::Insert, None)
+            .insert_row_internal(data_pool, stmt, cols, RowUndoKind::Insert, Vec::new())
             .await;
         // insert index
         for key in keys {


### PR DESCRIPTION
### Motivation
- Eliminate the special `RowUndoKind::Move` variant to simplify undo logic and avoid duplicate reads during MVCC scans. 
- Treat out-of-place updates as `Delete` (old row) + `Insert` (new row) to reuse existing undo kinds and index-branch mechanism. 
- Use `IndexBranch` links for unique-index version linking so unique-key lookups still follow the correct old version. 
- Reduce special-case handling in version traversal and rollback by normalizing to existing undo kinds.

### Description
- Removed `RowUndoKind::Move` from `doradb-storage/src/trx/undo/row.rs` and updated its `Debug` formatting to drop `Move`.
- Reworked MVCC traversal and related helpers in `doradb-storage/src/trx/row.rs` to stop handling `Move` and to treat `Delete`/`Insert` semantics correctly during visibility/backtrace.
- Converted the out-of-place update path in `doradb-storage/src/table/mod.rs` (`move_update_for_space`, `insert_row_internal`, and `insert_row_to_page`) to: mark the old row `Delete`, build `IndexBranch` entries for unique indexes, and insert the new row with attached index branches instead of linking via `Move`.
- Adjusted `doradb-storage/src/table/access.rs` call sites to use the new `insert_row_internal` signature (empty `Vec<IndexBranch>` for normal inserts).

### Testing
- No automated tests were executed as part of this change.
- (Note) Compilation and CI checks were not run in this rollout; please run `cargo test -p doradb-storage` or `cargo build -p doradb-storage` to verify.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696384455e30832f9233093a1a086223)