### PR TITLE
feat: add column block index scaffolding

### DIFF
--- a/doradb-storage/src/file/table_file.rs
+++ b/doradb-storage/src/file/table_file.rs
@@ -309,6 +309,22 @@ impl MutableTableFile {
         }
     }
 
+    /// Allocate a new page id for copy-on-write updates.
+    #[inline]
+    pub fn allocate_page_id(&mut self) -> Result<PageID> {
+        self.active_root
+            .alloc_map
+            .try_allocate()
+            .map(|page_id| page_id as PageID)
+            .ok_or(Error::InvalidState)
+    }
+
+    /// Record an obsolete page id to be reclaimed on commit.
+    #[inline]
+    pub fn record_gc_page(&mut self, page_id: PageID) {
+        self.active_root.gc_page_list.push(page_id);
+    }
+
     /// Commit the modification of table file.
     /// Returns the new table file and previous
     /// active root if exists.

--- a/doradb-storage/src/index/column_block_index.rs
+++ b/doradb-storage/src/index/column_block_index.rs
@@ -1,0 +1,202 @@
+use crate::buffer::page::PageID;
+use crate::error::{Error, Result};
+use crate::file::table_file::{MutableTableFile, TableFile, TABLE_FILE_PAGE_SIZE};
+use crate::row::RowID;
+use std::mem;
+use std::slice;
+use std::sync::Arc;
+
+pub const COLUMN_BLOCK_PAGE_SIZE: usize = TABLE_FILE_PAGE_SIZE;
+pub const COLUMN_BLOCK_HEADER_SIZE: usize = mem::size_of::<ColumnBlockNodeHeader>();
+pub const COLUMN_BLOCK_DATA_SIZE: usize = COLUMN_BLOCK_PAGE_SIZE - COLUMN_BLOCK_HEADER_SIZE;
+pub const COLUMN_PAGE_PAYLOAD_SIZE: usize = mem::size_of::<ColumnPagePayload>();
+pub const COLUMN_BLOCK_MAX_ENTRIES: usize =
+    COLUMN_BLOCK_DATA_SIZE / (mem::size_of::<RowID>() + COLUMN_PAGE_PAYLOAD_SIZE);
+
+const _: () = assert!(
+    COLUMN_BLOCK_HEADER_SIZE
+        + COLUMN_BLOCK_MAX_ENTRIES * (mem::size_of::<RowID>() + COLUMN_PAGE_PAYLOAD_SIZE)
+        <= COLUMN_BLOCK_PAGE_SIZE,
+    "ColumnBlockNode should fit into 64KB pages"
+);
+
+const _: () = assert!(
+    mem::size_of::<ColumnBlockNode>() == COLUMN_BLOCK_PAGE_SIZE,
+    "ColumnBlockNode size must match table file page size"
+);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ColumnBlockNodeHeader {
+    pub height: u32,
+    pub count: u32,
+    pub start_row_id: RowID,
+    pub create_ts: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ColumnPagePayload {
+    pub block_id: u64,
+    pub deletion_field: [u8; 120],
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct ColumnBlockNode {
+    pub header: ColumnBlockNodeHeader,
+    data: [u8; COLUMN_BLOCK_DATA_SIZE],
+}
+
+impl ColumnBlockNode {
+    #[inline]
+    pub fn new(height: u32, start_row_id: RowID, create_ts: u64) -> Self {
+        ColumnBlockNode {
+            header: ColumnBlockNodeHeader {
+                height,
+                count: 0,
+                start_row_id,
+                create_ts,
+            },
+            data: [0u8; COLUMN_BLOCK_DATA_SIZE],
+        }
+    }
+
+    #[inline]
+    pub fn is_leaf(&self) -> bool {
+        self.header.height == 0
+    }
+
+    #[inline]
+    fn data_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
+    #[inline]
+    fn data_ptr_mut(&mut self) -> *mut u8 {
+        self.data.as_mut_ptr()
+    }
+
+    #[inline]
+    pub fn leaf_start_row_ids(&self) -> &[RowID] {
+        debug_assert!(self.is_leaf());
+        unsafe { slice::from_raw_parts(self.data_ptr() as *const RowID, self.header.count as usize) }
+    }
+
+    #[inline]
+    pub fn leaf_start_row_ids_mut(&mut self) -> &mut [RowID] {
+        debug_assert!(self.is_leaf());
+        unsafe {
+            slice::from_raw_parts_mut(self.data_ptr_mut() as *mut RowID, self.header.count as usize)
+        }
+    }
+
+    #[inline]
+    pub fn leaf_payloads(&self) -> &[ColumnPagePayload] {
+        debug_assert!(self.is_leaf());
+        let count = self.header.count as usize;
+        let payload_ptr = unsafe {
+            self.data_ptr()
+                .add(count * mem::size_of::<RowID>())
+                as *const ColumnPagePayload
+        };
+        unsafe { slice::from_raw_parts(payload_ptr, count) }
+    }
+
+    #[inline]
+    pub fn leaf_payloads_mut(&mut self) -> &mut [ColumnPagePayload] {
+        debug_assert!(self.is_leaf());
+        let count = self.header.count as usize;
+        let payload_ptr = unsafe {
+            self.data_ptr_mut()
+                .add(count * mem::size_of::<RowID>())
+                as *mut ColumnPagePayload
+        };
+        unsafe { slice::from_raw_parts_mut(payload_ptr, count) }
+    }
+}
+
+pub struct ColumnBlockIndex {
+    table_file: Arc<TableFile>,
+    root_page_id: PageID,
+}
+
+impl ColumnBlockIndex {
+    #[inline]
+    pub fn new(table_file: Arc<TableFile>, root_page_id: PageID) -> Self {
+        ColumnBlockIndex {
+            table_file,
+            root_page_id,
+        }
+    }
+
+    #[inline]
+    pub fn table_file(&self) -> &Arc<TableFile> {
+        &self.table_file
+    }
+
+    #[inline]
+    pub fn root_page_id(&self) -> PageID {
+        self.root_page_id
+    }
+
+    /// Allocate a new node page for copy-on-write updates.
+    #[inline]
+    pub fn allocate_node(
+        &self,
+        table_file: &mut MutableTableFile,
+        height: u32,
+        start_row_id: RowID,
+        create_ts: u64,
+    ) -> Result<(PageID, ColumnBlockNode)> {
+        let page_id = table_file.allocate_page_id()?;
+        let node = ColumnBlockNode::new(height, start_row_id, create_ts);
+        Ok((page_id, node))
+    }
+
+    /// Record an obsolete node page to be reclaimed after commit.
+    #[inline]
+    pub fn record_obsolete_node(
+        &self,
+        table_file: &mut MutableTableFile,
+        page_id: PageID,
+    ) -> Result<()> {
+        if page_id == 0 {
+            return Err(Error::InvalidState);
+        }
+        table_file.record_gc_page(page_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_column_block_node_size() {
+        assert_eq!(mem::size_of::<ColumnBlockNode>(), COLUMN_BLOCK_PAGE_SIZE);
+        assert_eq!(mem::size_of::<ColumnPagePayload>(), 128);
+    }
+
+    #[test]
+    fn test_leaf_layout_offsets() {
+        let mut node = ColumnBlockNode::new(0, 0, 0);
+        node.header.count = 2;
+
+        let start_ptr = node.leaf_start_row_ids().as_ptr() as usize;
+        let payload_ptr = node.leaf_payloads().as_ptr() as usize;
+        assert_eq!(payload_ptr - start_ptr, 2 * mem::size_of::<RowID>());
+
+        let start_mut = node.leaf_start_row_ids_mut();
+        start_mut[0] = 10;
+        start_mut[1] = 20;
+        let payloads = node.leaf_payloads_mut();
+        payloads[0].block_id = 1;
+        payloads[1].block_id = 2;
+
+        assert_eq!(node.leaf_start_row_ids(), &[10, 20]);
+        assert_eq!(node.leaf_payloads()[0].block_id, 1);
+        assert_eq!(node.leaf_payloads()[1].block_id, 2);
+    }
+}

--- a/doradb-storage/src/index/mod.rs
+++ b/doradb-storage/src/index/mod.rs
@@ -1,4 +1,5 @@
 mod block_index;
+mod column_block_index;
 mod btree;
 mod btree_hint;
 mod btree_key;
@@ -11,6 +12,7 @@ mod unique_index;
 pub(crate) mod util;
 
 pub use block_index::*;
+pub use column_block_index::*;
 pub use btree::*;
 pub use btree_key::*;
 pub use btree_node::*;


### PR DESCRIPTION
### Motivation
- Implement Phase 1 scaffolding for the persistent Copy-on-Write ColumnBlockIndex per RFC-0002 and `docs/tasks/000015-column-block-index-cow-btree.md` to provide on-disk node layout and allocation hooks for future CoW B+Tree work. 
- Provide basic on-disk structs and layout assertions so later phases can safely implement insert/find and deletion-field logic.

### Description
- Add a new module `doradb-storage/src/index/column_block_index.rs` defining `ColumnBlockNodeHeader`, `ColumnBlockNode`, and `ColumnPagePayload` with `#[repr(C)]`, fixed-size layout constants, layout `assert!` checks, accessors for the leaf layout (contiguous `start_row_id` array followed by payloads), and a `ColumnBlockIndex` type exposing `allocate_node` and `record_obsolete_node` helpers. 
- Add CoW-aware helpers on `MutableTableFile`: `allocate_page_id` for allocating a new page id and `record_gc_page` to register obsolete pages for reclamation during commit. 
- Export the new module from `doradb-storage/src/index/mod.rs` so the index API exposes `ColumnBlockIndex`. 
- Add unit tests in the new module verifying `ColumnBlockNode` and `ColumnPagePayload` sizes and the leaf layout offsets (`test_column_block_node_size` and `test_leaf_layout_offsets`).

### Testing
- Unit tests were added: `test_column_block_node_size` and `test_leaf_layout_offsets` in `doradb-storage/src/index/column_block_index.rs` which assert page-size layout and basic read/write of the leaf layout. 
- No automated test suite was executed as part of this change, so test results are not available from this PR. 
- To validate locally run `cargo test -p doradb-storage` (or `cargo test -p doradb-storage --no-default-features` if `libaio` is not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e43590b1c832fba07fd3209eb2665)