### PR TITLE
feat: implement ColumnBlockIndex batch-insert and find (CoW B+Tree)

### DIFF
--- a/doradb-storage/src/index/column_block_index.rs
+++ b/doradb-storage/src/index/column_block_index.rs
@@ -1,6 +1,7 @@
 use crate::buffer::page::PageID;
 use crate::error::{Error, Result};
 use crate::file::table_file::{MutableTableFile, TABLE_FILE_PAGE_SIZE, TableFile};
+use crate::io::DirectBuf;
 use crate::row::RowID;
 use std::mem;
 use std::slice;
@@ -10,8 +11,11 @@ pub const COLUMN_BLOCK_PAGE_SIZE: usize = TABLE_FILE_PAGE_SIZE;
 pub const COLUMN_BLOCK_HEADER_SIZE: usize = mem::size_of::<ColumnBlockNodeHeader>();
 pub const COLUMN_BLOCK_DATA_SIZE: usize = COLUMN_BLOCK_PAGE_SIZE - COLUMN_BLOCK_HEADER_SIZE;
 pub const COLUMN_PAGE_PAYLOAD_SIZE: usize = mem::size_of::<ColumnPagePayload>();
+pub const COLUMN_BRANCH_ENTRY_SIZE: usize = mem::size_of::<ColumnBlockBranchEntry>();
 pub const COLUMN_BLOCK_MAX_ENTRIES: usize =
     COLUMN_BLOCK_DATA_SIZE / (mem::size_of::<RowID>() + COLUMN_PAGE_PAYLOAD_SIZE);
+pub const COLUMN_BLOCK_MAX_BRANCH_ENTRIES: usize =
+    COLUMN_BLOCK_DATA_SIZE / COLUMN_BRANCH_ENTRY_SIZE;
 
 const _: () = assert!(
     COLUMN_BLOCK_HEADER_SIZE
@@ -42,6 +46,13 @@ pub struct ColumnPagePayload {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ColumnBlockBranchEntry {
+    pub start_row_id: RowID,
+    pub page_id: PageID,
+}
+
+#[repr(C)]
 #[derive(Clone)]
 pub struct ColumnBlockNode {
     pub header: ColumnBlockNodeHeader,
@@ -65,6 +76,11 @@ impl ColumnBlockNode {
     #[inline]
     pub fn is_leaf(&self) -> bool {
         self.header.height == 0
+    }
+
+    #[inline]
+    pub fn is_branch(&self) -> bool {
+        !self.is_leaf()
     }
 
     #[inline]
@@ -115,19 +131,55 @@ impl ColumnBlockNode {
         };
         unsafe { slice::from_raw_parts_mut(payload_ptr, count) }
     }
+
+    #[inline]
+    pub fn branch_entries(&self) -> &[ColumnBlockBranchEntry] {
+        debug_assert!(self.is_branch());
+        unsafe {
+            slice::from_raw_parts(
+                self.data_ptr() as *const ColumnBlockBranchEntry,
+                self.header.count as usize,
+            )
+        }
+    }
+
+    #[inline]
+    pub fn branch_entries_mut(&mut self) -> &mut [ColumnBlockBranchEntry] {
+        debug_assert!(self.is_branch());
+        unsafe {
+            slice::from_raw_parts_mut(
+                self.data_ptr_mut() as *mut ColumnBlockBranchEntry,
+                self.header.count as usize,
+            )
+        }
+    }
+
+    #[inline]
+    pub fn branch_add_entry(&mut self, start_row_id: RowID, page_id: PageID) {
+        debug_assert!(self.is_branch());
+        debug_assert!((self.header.count as usize) < COLUMN_BLOCK_MAX_BRANCH_ENTRIES);
+        let idx = self.header.count as usize;
+        self.header.count += 1;
+        self.branch_entries_mut()[idx] = ColumnBlockBranchEntry {
+            start_row_id,
+            page_id,
+        };
+    }
 }
 
 pub struct ColumnBlockIndex {
     table_file: Arc<TableFile>,
     root_page_id: PageID,
+    end_row_id: RowID,
 }
 
 impl ColumnBlockIndex {
     #[inline]
-    pub fn new(table_file: Arc<TableFile>, root_page_id: PageID) -> Self {
+    pub fn new(table_file: Arc<TableFile>, root_page_id: PageID, end_row_id: RowID) -> Self {
         ColumnBlockIndex {
             table_file,
             root_page_id,
+            end_row_id,
         }
     }
 
@@ -139,6 +191,90 @@ impl ColumnBlockIndex {
     #[inline]
     pub fn root_page_id(&self) -> PageID {
         self.root_page_id
+    }
+
+    #[inline]
+    pub fn end_row_id(&self) -> RowID {
+        self.end_row_id
+    }
+
+    pub async fn find(&self, row_id: RowID) -> Result<Option<ColumnPagePayload>> {
+        if self.root_page_id == 0 || row_id >= self.end_row_id {
+            return Ok(None);
+        }
+        let mut page_id = self.root_page_id;
+        loop {
+            let node = self.read_node(page_id).await?;
+            if node.is_leaf() {
+                let start_row_ids = node.leaf_start_row_ids();
+                let idx = match search_start_row_id(start_row_ids, row_id) {
+                    Some(idx) => idx,
+                    None => return Ok(None),
+                };
+                return Ok(Some(node.leaf_payloads()[idx]));
+            }
+            let entries = node.branch_entries();
+            let idx = match search_branch_entry(entries, row_id) {
+                Some(idx) => idx,
+                None => return Ok(None),
+            };
+            page_id = entries[idx].page_id;
+        }
+    }
+
+    pub async fn batch_insert(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        entries: &[(RowID, u64)],
+        new_end_row_id: RowID,
+        create_ts: u64,
+    ) -> Result<PageID> {
+        debug_assert!(entries_sorted(entries));
+        debug_assert!(
+            entries
+                .first()
+                .map_or(true, |entry| entry.0 >= self.end_row_id)
+        );
+        debug_assert!(
+            entries
+                .last()
+                .map_or(true, |entry| entry.0 < new_end_row_id)
+        );
+        debug_assert!(new_end_row_id >= self.end_row_id);
+        if entries.is_empty() {
+            return Ok(self.root_page_id);
+        }
+
+        if self.root_page_id == 0 {
+            return self
+                .build_tree_from_entries(mutable_file, entries, create_ts)
+                .await;
+        }
+
+        let root_node = self.read_node(self.root_page_id).await?;
+        let root_height = root_node.header.height;
+        let append_result = self
+            .append_to_node(
+                mutable_file,
+                self.root_page_id,
+                root_node,
+                entries,
+                create_ts,
+            )
+            .await?;
+        if append_result.extra_entries.is_empty() {
+            return Ok(append_result.new_page_id);
+        }
+        let mut root_entries = Vec::with_capacity(1 + append_result.extra_entries.len());
+        root_entries.push(ColumnBlockBranchEntry {
+            start_row_id: append_result.start_row_id,
+            page_id: append_result.new_page_id,
+        });
+        root_entries.extend_from_slice(&append_result.extra_entries);
+        let new_root_page_id = self
+            .build_branch_levels(mutable_file, root_entries, root_height + 1, create_ts)
+            .await?;
+        Ok(new_root_page_id)
     }
 
     /// Allocate a new node page for copy-on-write updates.
@@ -168,11 +304,301 @@ impl ColumnBlockIndex {
         table_file.record_gc_page(page_id);
         Ok(())
     }
+
+    async fn read_node(&self, page_id: PageID) -> Result<ColumnBlockNode> {
+        let buf = self.table_file.read_page(page_id).await?;
+        let node =
+            unsafe { std::ptr::read_unaligned(buf.as_bytes().as_ptr() as *const ColumnBlockNode) };
+        Ok(node)
+    }
+
+    async fn write_node(&self, page_id: PageID, node: &ColumnBlockNode) -> Result<()> {
+        let mut buf = DirectBuf::zeroed(COLUMN_BLOCK_PAGE_SIZE);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                node as *const ColumnBlockNode as *const u8,
+                buf.data_mut().as_mut_ptr(),
+                COLUMN_BLOCK_PAGE_SIZE,
+            );
+        }
+        self.table_file.write_page(page_id, buf).await
+    }
+
+    async fn build_tree_from_entries(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        entries: &[(RowID, u64)],
+        create_ts: u64,
+    ) -> Result<PageID> {
+        let leaf_entries = self
+            .build_leaf_nodes(mutable_file, entries, create_ts)
+            .await?;
+        if leaf_entries.len() == 1 {
+            return Ok(leaf_entries[0].page_id);
+        }
+        self.build_branch_levels(mutable_file, leaf_entries, 1, create_ts)
+            .await
+    }
+
+    async fn build_leaf_nodes(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        entries: &[(RowID, u64)],
+        create_ts: u64,
+    ) -> Result<Vec<ColumnBlockBranchEntry>> {
+        let mut leaf_entries = Vec::new();
+        for chunk in entries.chunks(COLUMN_BLOCK_MAX_ENTRIES) {
+            let (page_id, mut node) = self.allocate_node(mutable_file, 0, chunk[0].0, create_ts)?;
+            node.header.count = chunk.len() as u32;
+            {
+                let row_ids = node.leaf_start_row_ids_mut();
+                let payloads = node.leaf_payloads_mut();
+                for (idx, entry) in chunk.iter().enumerate() {
+                    row_ids[idx] = entry.0;
+                    payloads[idx] = ColumnPagePayload {
+                        block_id: entry.1,
+                        deletion_field: [0u8; 120],
+                    };
+                }
+            }
+            self.write_node(page_id, &node).await?;
+            leaf_entries.push(ColumnBlockBranchEntry {
+                start_row_id: chunk[0].0,
+                page_id,
+            });
+        }
+        Ok(leaf_entries)
+    }
+
+    async fn build_branch_levels(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        mut entries: Vec<ColumnBlockBranchEntry>,
+        mut height: u32,
+        create_ts: u64,
+    ) -> Result<PageID> {
+        loop {
+            if entries.len() <= COLUMN_BLOCK_MAX_BRANCH_ENTRIES {
+                let (page_id, mut node) =
+                    self.allocate_node(mutable_file, height, entries[0].start_row_id, create_ts)?;
+                node.header.count = entries.len() as u32;
+                node.branch_entries_mut().copy_from_slice(&entries);
+                self.write_node(page_id, &node).await?;
+                return Ok(page_id);
+            }
+            let mut next_entries = Vec::new();
+            for chunk in entries.chunks(COLUMN_BLOCK_MAX_BRANCH_ENTRIES) {
+                let (page_id, mut node) =
+                    self.allocate_node(mutable_file, height, chunk[0].start_row_id, create_ts)?;
+                node.header.count = chunk.len() as u32;
+                node.branch_entries_mut().copy_from_slice(chunk);
+                self.write_node(page_id, &node).await?;
+                next_entries.push(ColumnBlockBranchEntry {
+                    start_row_id: chunk[0].start_row_id,
+                    page_id,
+                });
+            }
+            entries = next_entries;
+            height += 1;
+        }
+    }
+
+    async fn append_to_node(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        page_id: PageID,
+        node: ColumnBlockNode,
+        entries: &[(RowID, u64)],
+        create_ts: u64,
+    ) -> Result<NodeAppendResult> {
+        if node.is_leaf() {
+            return self
+                .append_to_leaf(mutable_file, page_id, node, entries, create_ts)
+                .await;
+        }
+        self.append_to_branch(mutable_file, page_id, node, entries, create_ts)
+            .await
+    }
+
+    async fn append_to_leaf(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        page_id: PageID,
+        node: ColumnBlockNode,
+        entries: &[(RowID, u64)],
+        create_ts: u64,
+    ) -> Result<NodeAppendResult> {
+        let old_count = node.header.count as usize;
+        let capacity = COLUMN_BLOCK_MAX_ENTRIES;
+        let mut remaining = entries;
+
+        let take = remaining.len().min(capacity.saturating_sub(old_count));
+        let new_count = old_count + take;
+        let start_row_id = if old_count == 0 {
+            remaining
+                .first()
+                .map(|entry| entry.0)
+                .unwrap_or(node.header.start_row_id)
+        } else {
+            node.header.start_row_id
+        };
+        let (new_page_id, mut new_node) =
+            self.allocate_node(mutable_file, 0, start_row_id, create_ts)?;
+        new_node.header.count = new_count as u32;
+        {
+            let row_ids = new_node.leaf_start_row_ids_mut();
+            let payloads = new_node.leaf_payloads_mut();
+            if old_count > 0 {
+                row_ids[..old_count].copy_from_slice(node.leaf_start_row_ids());
+                payloads[..old_count].copy_from_slice(node.leaf_payloads());
+            }
+            for (idx, entry) in remaining.iter().take(take).enumerate() {
+                row_ids[old_count + idx] = entry.0;
+                payloads[old_count + idx] = ColumnPagePayload {
+                    block_id: entry.1,
+                    deletion_field: [0u8; 120],
+                };
+            }
+        }
+        self.write_node(new_page_id, &new_node).await?;
+        self.record_obsolete_node(mutable_file, page_id)?;
+
+        remaining = &remaining[take..];
+        let mut extra_entries = Vec::new();
+        while !remaining.is_empty() {
+            let chunk_len = remaining.len().min(capacity);
+            let chunk = &remaining[..chunk_len];
+            let (page_id, mut leaf_node) =
+                self.allocate_node(mutable_file, 0, chunk[0].0, create_ts)?;
+            leaf_node.header.count = chunk_len as u32;
+            {
+                let row_ids = leaf_node.leaf_start_row_ids_mut();
+                let payloads = leaf_node.leaf_payloads_mut();
+                for (idx, entry) in chunk.iter().enumerate() {
+                    row_ids[idx] = entry.0;
+                    payloads[idx] = ColumnPagePayload {
+                        block_id: entry.1,
+                        deletion_field: [0u8; 120],
+                    };
+                }
+            }
+            self.write_node(page_id, &leaf_node).await?;
+            extra_entries.push(ColumnBlockBranchEntry {
+                start_row_id: chunk[0].0,
+                page_id,
+            });
+            remaining = &remaining[chunk_len..];
+        }
+
+        Ok(NodeAppendResult {
+            new_page_id,
+            start_row_id,
+            extra_entries,
+        })
+    }
+
+    async fn append_to_branch(
+        &self,
+        mutable_file: &mut MutableTableFile,
+        page_id: PageID,
+        node: ColumnBlockNode,
+        entries: &[(RowID, u64)],
+        create_ts: u64,
+    ) -> Result<NodeAppendResult> {
+        let old_entries = node.branch_entries();
+        if old_entries.is_empty() {
+            return Err(Error::InvalidState);
+        }
+        let last_idx = old_entries.len() - 1;
+        let child_page_id = old_entries[last_idx].page_id;
+        let child_node = self.read_node(child_page_id).await?;
+        let child_result = self
+            .append_to_node(mutable_file, child_page_id, child_node, entries, create_ts)
+            .await?;
+
+        let mut new_entries =
+            Vec::with_capacity(old_entries.len() + child_result.extra_entries.len());
+        new_entries.extend_from_slice(old_entries);
+        new_entries[last_idx].page_id = child_result.new_page_id;
+        new_entries.extend_from_slice(&child_result.extra_entries);
+
+        let mut remaining = new_entries.as_slice();
+        let first_len = remaining.len().min(COLUMN_BLOCK_MAX_BRANCH_ENTRIES);
+        let (new_page_id, mut new_node) = self.allocate_node(
+            mutable_file,
+            node.header.height,
+            node.header.start_row_id,
+            create_ts,
+        )?;
+        new_node.header.count = first_len as u32;
+        new_node
+            .branch_entries_mut()
+            .copy_from_slice(&remaining[..first_len]);
+        self.write_node(new_page_id, &new_node).await?;
+        self.record_obsolete_node(mutable_file, page_id)?;
+
+        remaining = &remaining[first_len..];
+        let mut extra_entries = Vec::new();
+        while !remaining.is_empty() {
+            let chunk_len = remaining.len().min(COLUMN_BLOCK_MAX_BRANCH_ENTRIES);
+            let chunk = &remaining[..chunk_len];
+            let (page_id, mut branch_node) = self.allocate_node(
+                mutable_file,
+                node.header.height,
+                chunk[0].start_row_id,
+                create_ts,
+            )?;
+            branch_node.header.count = chunk_len as u32;
+            branch_node.branch_entries_mut().copy_from_slice(chunk);
+            self.write_node(page_id, &branch_node).await?;
+            extra_entries.push(ColumnBlockBranchEntry {
+                start_row_id: chunk[0].start_row_id,
+                page_id,
+            });
+            remaining = &remaining[chunk_len..];
+        }
+
+        Ok(NodeAppendResult {
+            new_page_id,
+            start_row_id: node.header.start_row_id,
+            extra_entries,
+        })
+    }
+}
+
+struct NodeAppendResult {
+    new_page_id: PageID,
+    start_row_id: RowID,
+    extra_entries: Vec<ColumnBlockBranchEntry>,
+}
+
+fn entries_sorted(entries: &[(RowID, u64)]) -> bool {
+    entries.windows(2).all(|pair| pair[0].0 <= pair[1].0)
+}
+
+fn search_start_row_id(start_row_ids: &[RowID], row_id: RowID) -> Option<usize> {
+    match start_row_ids.binary_search(&row_id) {
+        Ok(idx) => Some(idx),
+        Err(0) => None,
+        Err(idx) => Some(idx - 1),
+    }
+}
+
+fn search_branch_entry(entries: &[ColumnBlockBranchEntry], row_id: RowID) -> Option<usize> {
+    match entries.binary_search_by_key(&row_id, |entry| entry.start_row_id) {
+        Ok(idx) => Some(idx),
+        Err(0) => None,
+        Err(idx) => Some(idx - 1),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::catalog::{
+        ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, TableMetadata, ValKind,
+    };
+    use crate::file::table_fs::TableFileSystemConfig;
 
     #[test]
     fn test_column_block_node_size() {
@@ -199,5 +625,161 @@ mod tests {
         assert_eq!(node.leaf_start_row_ids(), &[10, 20]);
         assert_eq!(node.leaf_payloads()[0].block_id, 1);
         assert_eq!(node.leaf_payloads()[1].block_id, 2);
+    }
+
+    fn build_test_metadata() -> Arc<TableMetadata> {
+        Arc::new(TableMetadata::new(
+            vec![
+                ColumnSpec::new("c0", ValKind::U32, ColumnAttributes::empty()),
+                ColumnSpec::new("c1", ValKind::U64, ColumnAttributes::NULLABLE),
+            ],
+            vec![IndexSpec::new(
+                "idx1",
+                vec![IndexKey::new(0)],
+                IndexAttributes::PK,
+            )],
+        ))
+    }
+
+    fn build_entries(start: RowID, count: usize, base_block: u64) -> Vec<(RowID, u64)> {
+        (0..count)
+            .map(|idx| (start + idx as RowID, base_block + idx as u64))
+            .collect()
+    }
+
+    #[test]
+    fn test_batch_insert_into_empty_tree_and_find() {
+        smol::block_on(async {
+            let fs = TableFileSystemConfig::default().build().unwrap();
+            let metadata = build_test_metadata();
+            let table_file = fs.create_table_file(200, metadata, false).unwrap();
+            let (table_file, old_root) = table_file.commit(1, false).await.unwrap();
+            drop(old_root);
+
+            let index = ColumnBlockIndex::new(Arc::clone(&table_file), 0, 0);
+            let entries = vec![(10, 100), (20, 200), (30, 300)];
+            let mut mutable = MutableTableFile::fork(&table_file);
+            let new_root = index
+                .batch_insert(&mut mutable, &entries, 40, 2)
+                .await
+                .unwrap();
+            let (table_file, old_root) = mutable.commit(2, false).await.unwrap();
+            drop(old_root);
+
+            let index = ColumnBlockIndex::new(Arc::clone(&table_file), new_root, 40);
+            assert_eq!(index.find(9).await.unwrap(), None);
+            assert_eq!(index.find(10).await.unwrap().unwrap().block_id, 100);
+            assert_eq!(index.find(19).await.unwrap().unwrap().block_id, 100);
+            assert_eq!(index.find(20).await.unwrap().unwrap().block_id, 200);
+            assert_eq!(index.find(39).await.unwrap().unwrap().block_id, 300);
+            assert_eq!(index.find(40).await.unwrap(), None);
+
+            drop(table_file);
+            drop(fs);
+            let _ = std::fs::remove_file("200.tbl");
+        });
+    }
+
+    #[test]
+    fn test_batch_insert_appends_within_leaf() {
+        smol::block_on(async {
+            let fs = TableFileSystemConfig::default().build().unwrap();
+            let metadata = build_test_metadata();
+            let table_file = fs.create_table_file(201, metadata, false).unwrap();
+            let (table_file, old_root) = table_file.commit(1, false).await.unwrap();
+            drop(old_root);
+
+            let entries = build_entries(0, 8, 1000);
+            let index = ColumnBlockIndex::new(Arc::clone(&table_file), 0, 0);
+            let mut mutable = MutableTableFile::fork(&table_file);
+            let root_page = index
+                .batch_insert(&mut mutable, &entries, 8, 2)
+                .await
+                .unwrap();
+            let (table_file, old_root) = mutable.commit(2, false).await.unwrap();
+            drop(old_root);
+
+            let more_entries = build_entries(8, 4, 2000);
+            let index = ColumnBlockIndex::new(Arc::clone(&table_file), root_page, 8);
+            let mut mutable = MutableTableFile::fork(&table_file);
+            let new_root = index
+                .batch_insert(&mut mutable, &more_entries, 12, 3)
+                .await
+                .unwrap();
+            let (table_file, old_root) = mutable.commit(3, false).await.unwrap();
+            drop(old_root);
+
+            let index = ColumnBlockIndex::new(Arc::clone(&table_file), new_root, 12);
+            assert_eq!(index.find(0).await.unwrap().unwrap().block_id, 1000);
+            assert_eq!(index.find(7).await.unwrap().unwrap().block_id, 1007);
+            assert_eq!(index.find(8).await.unwrap().unwrap().block_id, 2000);
+            assert_eq!(index.find(11).await.unwrap().unwrap().block_id, 2003);
+
+            drop(table_file);
+            drop(fs);
+            let _ = std::fs::remove_file("201.tbl");
+        });
+    }
+
+    #[test]
+    fn test_batch_insert_creates_new_leaf_nodes() {
+        smol::block_on(async {
+            let fs = TableFileSystemConfig::default().build().unwrap();
+            let metadata = build_test_metadata();
+            let table_file = fs.create_table_file(202, metadata, false).unwrap();
+            let (table_file, old_root) = table_file.commit(1, false).await.unwrap();
+            drop(old_root);
+
+            let initial_count = COLUMN_BLOCK_MAX_ENTRIES - 1;
+            let entries = build_entries(0, initial_count, 1);
+            let index = ColumnBlockIndex::new(Arc::clone(&table_file), 0, 0);
+            let mut mutable = MutableTableFile::fork(&table_file);
+            let root_page = index
+                .batch_insert(&mut mutable, &entries, initial_count as RowID, 2)
+                .await
+                .unwrap();
+            let (table_file, old_root) = mutable.commit(2, false).await.unwrap();
+            drop(old_root);
+
+            let append_entries = build_entries(initial_count as RowID, 2, 9000);
+            let index =
+                ColumnBlockIndex::new(Arc::clone(&table_file), root_page, initial_count as RowID);
+            let mut mutable = MutableTableFile::fork(&table_file);
+            let new_root = index
+                .batch_insert(&mut mutable, &append_entries, initial_count as RowID + 2, 3)
+                .await
+                .unwrap();
+            let (table_file, old_root) = mutable.commit(3, false).await.unwrap();
+            drop(old_root);
+
+            let index = ColumnBlockIndex::new(
+                Arc::clone(&table_file),
+                new_root,
+                initial_count as RowID + 2,
+            );
+            assert_eq!(index.find(0).await.unwrap().unwrap().block_id, 1);
+            assert_eq!(
+                index
+                    .find(initial_count as RowID)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .block_id,
+                9000
+            );
+            assert_eq!(
+                index
+                    .find(initial_count as RowID + 1)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .block_id,
+                9001
+            );
+
+            drop(table_file);
+            drop(fs);
+            let _ = std::fs::remove_file("202.tbl");
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a persistent, append-only, copy-on-write B+Tree for mapping `RowID` → LWC block (needed for checkpointing cold data). 
- Support efficient batch appends from data checkpoints and enable on-disk lookups for `RowID` via `find`.

### Description
- Add branch entry layout and accessors (`ColumnBlockBranchEntry`, `branch_entries`, `branch_entries_mut`, `branch_add_entry`) and a branch/leaf-aware `ColumnBlockNode` layout to support B+Tree navigation and on-disk serialization.
- Implement `find(&self, row_id: RowID)` to traverse the on-disk tree by reading pages from `TableFile` and returning the matching `ColumnPagePayload` when present.
- Implement append-only CoW batch insertion `batch_insert(&self, mutable_file: &mut MutableTableFile, entries: &[(RowID,u64)], new_end_row_id: RowID, create_ts: u64)` with helpers to read/write nodes, build leaf nodes, build branch levels, and recursively append along the right-most path (with `append_to_node`, `append_to_leaf`, `append_to_branch`) and record obsolete pages for GC.
- Add `end_row_id` to `ColumnBlockIndex` to bound lookups and validate append assertions, plus helper functions `read_node`/`write_node` and small utilities for searching and validation.
- Add unit tests covering node layout and batch-insert/find scenarios (`test_batch_insert_into_empty_tree_and_find`, `test_batch_insert_appends_within_leaf`, `test_batch_insert_creates_new_leaf_nodes`) alongside existing layout tests.

### Testing
- No automated test run was executed as part of this change; only `cargo fmt` was run during development.
- New unit tests were added under `doradb-storage/src/index/column_block_index.rs` to exercise empty-tree insert, in-leaf append, multi-leaf creation, and `find` traversal.  These tests are intended to be executed via `cargo test -p doradb-storage` in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f99d4b848832f9d0a3d740992a4fe)