### PR TITLE
fix btree optimistic lookup panic

### DIFF
--- a/doradb-storage/src/buffer/guard.rs
+++ b/doradb-storage/src/buffer/guard.rs
@@ -402,6 +402,12 @@ impl<T: 'static> FacadePageGuard<T> {
     ///
     /// This helper keeps optimistic access scoped to a closure and only returns
     /// owned/copied data (`R` cannot borrow from page because of HRTB).
+    ///
+    /// Note that validation happens after `f` returns. For optimistic guards,
+    /// `f` may observe transient intermediate state if a concurrent writer
+    /// acquires exclusive latch during the closure. Callers must treat such
+    /// inconsistent observations as retryable by returning `Validation::Invalid`
+    /// from inside `R` when needed.
     #[inline]
     pub fn with_page_ref_validated<R, F>(&self, f: F) -> Validation<R>
     where

--- a/doradb-storage/src/index/btree.rs
+++ b/doradb-storage/src/index/btree.rs
@@ -432,16 +432,19 @@ impl BTree {
         }
     }
 
-    /// Try to lookup a key in the tree, break if any of optimistic validation fails.
+    /// Try to lookup a key in the tree, break if any optimistic validation fails.
+    ///
+    /// The leaf is read under optimistic mode. A concurrent writer can change
+    /// node content between `search_key` and value read in the same closure.
+    /// We convert such stale observations to `Validation::Invalid`, then rely on
+    /// final guard validation in `with_page_ref_validated` to retry safely.
     #[inline]
     async fn try_lookup_optimistic<V: BTreeValue>(&self, key: &[u8]) -> Validation<Option<V>> {
         let g = self.find_leaf::<OptimisticStrategy>(key).await;
         let value = verify!(
             g.with_page_ref_validated(|leaf| match leaf.search_key(key) {
                 Ok(idx) => {
-                    // In optimistic mode, a writer can change node layout between
-                    // `search_key` and value read in this same closure. If `idx`
-                    // becomes stale, treat it as validation failure and retry.
+                    // If `idx` becomes stale, treat it as validation failure and retry.
                     match leaf.value_checked::<V>(idx) {
                         Some(v) => Valid(Some(v)),
                         None => Invalid,

--- a/doradb-storage/src/index/btree_node.rs
+++ b/doradb-storage/src/index/btree_node.rs
@@ -998,8 +998,10 @@ impl BTreeNode {
     /// Returns value at `idx` without asserting.
     ///
     /// This is intended for optimistic-read paths where another thread may
-    /// modify the node between two reads in the same closure. In that case,
-    /// the caller should treat `None` as an optimistic inconsistency and retry.
+    /// modify the node between two reads in the same closure.
+    ///
+    /// Returning `None` lets caller mark the optimistic read as invalid and
+    /// retry, instead of panicking on transient `idx` stale cases.
     #[inline]
     pub(super) fn value_checked<V: BTreeValue>(&self, idx: usize) -> Option<V> {
         self.slots().get(idx).map(|slot| self.slot_value(slot))


### PR DESCRIPTION
In optimistic mode, btree node can be modified between `search_key()` and `value()`, and `debug_assert!` fails.
add new checked method and treat inconsistency as invalid and retry.