### PR TITLE
fix: PK misconfiguration in example

### DIFF
--- a/doradb-storage/examples/weak_handle_baseline.rs
+++ b/doradb-storage/examples/weak_handle_baseline.rs
@@ -342,7 +342,7 @@ async fn create_baseline_table(engine: &doradb_storage::Engine) -> StorageResult
                 ColumnSpec::new("id", ValKind::I32, ColumnAttributes::empty()),
                 ColumnSpec::new("payload", ValKind::I32, ColumnAttributes::empty()),
             ]),
-            vec![IndexSpec::new(vec![IndexKey::new(0)], IndexAttributes::PK)],
+            vec![IndexSpec::new(vec![IndexKey::new(0)], IndexAttributes::UK)],
         )
         .await?;
     session.close().await?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a baseline example so the `id` column uses a unique key instead of a primary key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->