### PR TITLE
fix: unordered redo and internal panic of commit row page

### DIFF
--- a/doradb-storage/src/index/row_page_index.rs
+++ b/doradb-storage/src/index/row_page_index.rs
@@ -9,7 +9,7 @@ use crate::error::{
     Validation::{Invalid, Valid},
 };
 use crate::file::block_integrity::BLOCK_INTEGRITY_TRAILER_SIZE;
-use crate::id::{BlockID, PageID, RowID};
+use crate::id::{BlockID, PageID, RowID, TrxID};
 use crate::index::util::{Maskable, ParentPosition, RowPageCreateRedoCtx};
 use crate::latch::LatchFallbackMode;
 use crate::layout;
@@ -92,6 +92,40 @@ enum InsertFreeListProbe<T> {
 enum InsertFreeListMiss {
     Empty,
     BufferPageGenerationMismatch,
+}
+
+struct RowPageIndexInsert {
+    start_row_id: RowID,
+    end_row_id: RowID,
+    create_cts: Option<TrxID>,
+}
+
+#[derive(Clone, Copy)]
+struct RowPageIndexAppend<'a> {
+    start_row_id: RowID,
+    count: u64,
+    page_id: PageID,
+    redo_ctx: Option<RowPageCreateRedoCtx<'a>>,
+}
+
+impl RowPageIndexAppend<'_> {
+    #[inline]
+    fn end_row_id(&self) -> RowID {
+        self.start_row_id + self.count
+    }
+
+    #[inline]
+    fn finish(self) -> RowPageIndexInsert {
+        let end_row_id = self.end_row_id();
+        let create_cts = self
+            .redo_ctx
+            .map(|redo_ctx| redo_ctx.commit_row_page(self.page_id, self.start_row_id, end_row_id));
+        RowPageIndexInsert {
+            start_row_id: self.start_row_id,
+            end_row_id,
+            create_cts,
+        }
+    }
 }
 
 /// RowPageIndexNode is one B-tree node of the row-page index.
@@ -553,12 +587,14 @@ impl<P: BufferPool> RowPageIndex<P> {
         let new_page_id = new_page.page_id();
         loop {
             match self
-                .insert_row_page(meta_pool_guard, count as u64, new_page_id)
+                .insert_row_page(meta_pool_guard, count as u64, new_page_id, redo_ctx)
                 .await?
             {
                 Invalid => (),
-                Valid((start_row_id, end_row_id)) => {
+                Valid(inserted) => {
                     // initialize row page.
+                    let start_row_id = inserted.start_row_id;
+                    let end_row_id = inserted.end_row_id;
                     debug_assert!(end_row_id == start_row_id + count as u64);
                     new_page
                         .page_mut()
@@ -568,14 +604,11 @@ impl<P: BufferPool> RowPageIndex<P> {
                         .bf_mut()
                         .init_undo_map(Arc::clone(col_layout), count);
 
-                    if let Some(redo_ctx) = redo_ctx {
-                        let create_cts =
-                            redo_ctx.commit_row_page(new_page_id, start_row_id, end_row_id);
-                        if let Some(row_ver) =
+                    if let Some(create_cts) = inserted.create_cts
+                        && let Some(row_ver) =
                             new_page.bf().ctx.as_ref().and_then(|ctx| ctx.row_ver())
-                        {
-                            row_ver.set_create_cts(create_cts);
-                        }
+                    {
+                        row_ver.set_create_cts(create_cts);
                     }
                     // finally, we downgrade the page lock for shared mode.
                     return Ok(());
@@ -675,10 +708,8 @@ impl<P: BufferPool> RowPageIndex<P> {
         &self,
         pool_guard: &PoolGuard,
         mut p_guard: PageExclusiveGuard<RowPageIndexNode>,
-        row_id: RowID,
-        count: u64,
-        insert_page_id: PageID,
-    ) -> Result<(RowID, RowID)> {
+        append: RowPageIndexAppend<'_>,
+    ) -> Result<RowPageIndexInsert> {
         debug_assert!(p_guard.page_id() == self.root_page_id);
         debug_assert!({
             let p = p_guard.page();
@@ -687,14 +718,13 @@ impl<P: BufferPool> RowPageIndex<P> {
         let root = p_guard.page();
         let new_height = root.header.height + 1;
         let l_row_id = root.header.start_row_id;
-        let r_row_id = row_id;
-        let max_row_id = r_row_id + count;
+        let r_row_id = append.start_row_id;
 
         // create left child and copy all contents to it.
         let mut l_guard = self.allocate_node_page(pool_guard).await?;
         let l_page_id = l_guard.page_id();
         l_guard.page_mut().clone_from(p_guard.page());
-        l_guard.page_mut().header.end_row_id = row_id; // update original page's end row id
+        l_guard.page_mut().header.end_row_id = r_row_id; // update original page's end row id
         drop(l_guard);
 
         // We may need to create a sub-tree on the right side.
@@ -702,15 +732,17 @@ impl<P: BufferPool> RowPageIndex<P> {
         // as same height as left.
         let r_page_id = if root.header.height == 0 {
             let mut r_guard = self.allocate_node_page(pool_guard).await?;
-            r_guard.page_mut().init(0, r_row_id, count, insert_page_id);
+            r_guard
+                .page_mut()
+                .init(0, r_row_id, append.count, append.page_id);
             r_guard.page_id()
         } else {
             self.create_sub_tree(
                 pool_guard,
                 root.header.height,
                 r_row_id,
-                count,
-                insert_page_id,
+                append.count,
+                append.page_id,
             )
             .await?
         };
@@ -734,7 +766,7 @@ impl<P: BufferPool> RowPageIndex<P> {
             });
             self.height.store(new_height as usize, Ordering::Relaxed);
         }
-        Ok((r_row_id, max_row_id))
+        Ok(append.finish())
     }
 
     #[inline]
@@ -777,10 +809,8 @@ impl<P: BufferPool> RowPageIndex<P> {
         pool_guard: &PoolGuard,
         stack: &mut Vec<PageOptimisticGuard<RowPageIndexNode>>,
         c_guard: PageExclusiveGuard<RowPageIndexNode>,
-        row_id: RowID,
-        count: u64,
-        insert_page_id: PageID,
-    ) -> Result<Validation<(RowID, RowID)>> {
+        append: RowPageIndexAppend<'_>,
+    ) -> Result<Validation<RowPageIndexInsert>> {
         debug_assert!(!stack.is_empty());
         let mut p_guard;
         // Block index is a special type of B+ tree, which does not implement
@@ -804,7 +834,7 @@ impl<P: BufferPool> RowPageIndex<P> {
             } else if stack.is_empty() {
                 // root is full, should split.
                 let res = self
-                    .insert_row_page_split_root(pool_guard, p_guard, row_id, count, insert_page_id)
+                    .insert_row_page_split_root(pool_guard, p_guard, append)
                     .await?;
                 return Ok(Valid(res));
             } // do not split branch node.
@@ -815,18 +845,25 @@ impl<P: BufferPool> RowPageIndex<P> {
         debug_assert!(p_height >= 1);
         let c_page_id = if p_height == 1 {
             let mut leaf = self.allocate_node_page(pool_guard).await?;
-            leaf.page_mut().init(0, row_id, count, insert_page_id);
-            debug_assert!(leaf.page_mut().header.end_row_id == row_id + count);
+            leaf.page_mut()
+                .init(0, append.start_row_id, append.count, append.page_id);
+            debug_assert!(leaf.page_mut().header.end_row_id == append.end_row_id());
             leaf.page_id()
         } else {
-            self.create_sub_tree(pool_guard, p_height - 1, row_id, count, insert_page_id)
-                .await?
+            self.create_sub_tree(
+                pool_guard,
+                p_height - 1,
+                append.start_row_id,
+                append.count,
+                append.page_id,
+            )
+            .await?
         };
         p_guard
             .page_mut()
-            .branch_add_entry(PageEntry::new(row_id, c_page_id));
+            .branch_add_entry(PageEntry::new(append.start_row_id, c_page_id));
         drop(c_guard);
-        Ok(Valid((row_id, row_id + count)))
+        Ok(Valid(append.finish()))
     }
 
     /// Inserts a row page id into the row-page index.
@@ -836,7 +873,8 @@ impl<P: BufferPool> RowPageIndex<P> {
         pool_guard: &PoolGuard,
         count: u64,
         insert_page_id: PageID,
-    ) -> Result<Validation<(RowID, RowID)>> {
+        redo_ctx: Option<RowPageCreateRedoCtx<'_>>,
+    ) -> Result<Validation<RowPageIndexInsert>> {
         // Stack holds the path from root to leaf.
         let mut stack = vec![];
         let mut p_guard = {
@@ -855,42 +893,41 @@ impl<P: BufferPool> RowPageIndex<P> {
         debug_assert!(p_guard.page().is_leaf());
         if p_guard.page().leaf_is_empty() {
             let start_row_id = p_guard.page().header.start_row_id;
+            let append = RowPageIndexAppend {
+                start_row_id,
+                count,
+                page_id: insert_page_id,
+                redo_ctx,
+            };
             p_guard
                 .page_mut()
                 .leaf_add_entry(start_row_id, count, insert_page_id);
-            return Ok(Valid((start_row_id, start_row_id + count)));
+            return Ok(Valid(append.finish()));
         }
         let end_row_id = p_guard.page().header.end_row_id;
+        let append = RowPageIndexAppend {
+            start_row_id: end_row_id,
+            count,
+            page_id: insert_page_id,
+            redo_ctx,
+        };
         if p_guard.page().leaf_is_full() {
             // Leaf is full, so we must add a new leaf to the row-page index.
             if stack.is_empty() {
                 // root is full and already exclusive locked
                 let res = self
-                    .insert_row_page_split_root(
-                        pool_guard,
-                        p_guard,
-                        end_row_id,
-                        count,
-                        insert_page_id,
-                    )
+                    .insert_row_page_split_root(pool_guard, p_guard, append)
                     .await?;
                 return Ok(Valid(res));
             }
             return self
-                .insert_row_page_to_new_leaf(
-                    pool_guard,
-                    &mut stack,
-                    p_guard,
-                    end_row_id,
-                    count,
-                    insert_page_id,
-                )
+                .insert_row_page_to_new_leaf(pool_guard, &mut stack, p_guard, append)
                 .await;
         }
         p_guard
             .page_mut()
             .leaf_add_entry(end_row_id, count, insert_page_id);
-        Ok(Valid((end_row_id, end_row_id + count)))
+        Ok(Valid(append.finish()))
     }
 
     #[inline]
@@ -1214,6 +1251,7 @@ mod tests {
     use crate::quiescent::{QuiescentBox, QuiescentGuard};
     use crate::recovery::stream::RedoReplayPlanner;
     use crate::value::ValKind;
+    use futures::future::join_all;
     use semistr::SemiStr;
     use std::future::Future;
     use std::io::Error as StdIoError;
@@ -1798,7 +1836,7 @@ mod tests {
             for row_page_id in 0..row_pages {
                 loop {
                     if let Valid(_) = blk_idx
-                        .insert_row_page(&pool_guard, 1, PageID::from(row_page_id))
+                        .insert_row_page(&pool_guard, 1, PageID::from(row_page_id), None)
                         .await
                         .expect("test row-page insertion should succeed")
                     {
@@ -1867,7 +1905,7 @@ mod tests {
             for i in 0..row_pages {
                 loop {
                     if let Valid(_) = blk_idx
-                        .insert_row_page(&pool_guard, rows_per_page as u64, PageID::from(i))
+                        .insert_row_page(&pool_guard, rows_per_page as u64, PageID::from(i), None)
                         .await
                         .expect("test row-page insertion should succeed")
                     {
@@ -1929,7 +1967,7 @@ mod tests {
             for row_page_id in 0..10000 {
                 loop {
                     if let Valid(_) = blk_idx
-                        .insert_row_page(&pool_guard, 100, test_page_id(row_page_id))
+                        .insert_row_page(&pool_guard, 100, test_page_id(row_page_id), None)
                         .await
                         .expect("test row-page insertion should succeed")
                     {
@@ -1969,7 +2007,7 @@ mod tests {
 
             loop {
                 if let Valid(_) = blk_idx
-                    .insert_row_page(&pool_guard, 100, test_page_id(20000))
+                    .insert_row_page(&pool_guard, 100, test_page_id(20000), None)
                     .await
                     .expect("test row-page insertion should succeed")
                 {
@@ -2067,6 +2105,90 @@ mod tests {
                 }
             }
             assert_eq!(create_row_page_logs, 1);
+        })
+    }
+
+    #[test]
+    fn test_row_page_index_create_row_page_redo_follows_append_order() {
+        smol::block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let main_dir = temp_dir.path().to_path_buf();
+            let table_id = TableID::new(205);
+            let engine = EngineConfig::default()
+                .storage_root(main_dir)
+                .trx(TrxSysConfig::default().log_file_stem("redo_row_page_order"))
+                .build()
+                .await
+                .unwrap();
+            {
+                let meta_pool = &engine.inner().meta_pool;
+                let meta_guard = meta_pool.pool_guard();
+                let blk_idx =
+                    RowPageIndex::new(meta_pool.clone_inner(), &meta_guard, RowID::new(0))
+                        .await
+                        .expect("test row-page-index construction should succeed");
+                let redo_ctx = RowPageCreateRedoCtx::new(&engine.inner().trx_sys, table_id);
+                let total_pages = NBR_ROW_PAGE_ENTRIES_IN_LEAF + 64;
+                let worker_count = 8usize;
+                let pages_per_worker = total_pages.div_ceil(worker_count);
+                let jobs = (0..worker_count).map(|worker| {
+                    let blk_idx = &blk_idx;
+                    let meta_pool_ref = meta_pool;
+                    async move {
+                        let pool_guard = meta_pool_ref.pool_guard();
+                        let start = worker * pages_per_worker;
+                        let end = (start + pages_per_worker).min(total_pages);
+                        for page_no in start..end {
+                            loop {
+                                match blk_idx
+                                    .insert_row_page(
+                                        &pool_guard,
+                                        1,
+                                        test_page_id(10_000 + page_no as i32),
+                                        Some(redo_ctx),
+                                    )
+                                    .await
+                                    .expect("test row-page insertion should succeed")
+                                {
+                                    Valid(inserted) => {
+                                        assert!(inserted.create_cts.is_some());
+                                        break;
+                                    }
+                                    Invalid => {}
+                                }
+                            }
+                        }
+                    }
+                });
+                join_all(jobs).await;
+            }
+            engine.shutdown().unwrap();
+
+            let file_prefix = temp_dir.path().join("redo_row_page_order");
+            let file_prefix = file_prefix.to_str().unwrap();
+            let logs = discover_redo_log_files(file_prefix, 0, false).unwrap();
+            let planner = RedoReplayPlanner::new(logs);
+            let mut stream = planner.plan_recovery(TrxID::new(0), 1).unwrap().stream;
+            let mut expected_start = RowID::new(0);
+            let mut create_row_page_logs = 0usize;
+            while let Some(log) = stream.try_next().await.unwrap() {
+                let Some(DDLRedo::CreateRowPage {
+                    table_id: redo_table_id,
+                    start_row_id,
+                    end_row_id,
+                    ..
+                }) = log.payload.ddl.as_deref()
+                else {
+                    continue;
+                };
+                if *redo_table_id != table_id {
+                    continue;
+                }
+                assert_eq!(*start_row_id, expected_start);
+                expected_start = *end_row_id;
+                create_row_page_logs += 1;
+            }
+            assert_eq!(create_row_page_logs, NBR_ROW_PAGE_ENTRIES_IN_LEAF + 64);
         })
     }
 

--- a/doradb-storage/src/index/row_page_index.rs
+++ b/doradb-storage/src/index/row_page_index.rs
@@ -5,7 +5,7 @@ use crate::buffer::page::{BufferPage, BufferPageKind, PAGE_SIZE, assert_buffer_p
 use crate::buffer::{BufferPool, PoolGuard};
 use crate::catalog::TableColumnLayout;
 use crate::error::{
-    InternalError, Result, Validation,
+    Error, InternalError, Result, Validation,
     Validation::{Invalid, Valid},
 };
 use crate::file::block_integrity::BLOCK_INTEGRITY_TRAILER_SIZE;
@@ -19,6 +19,7 @@ use either::Either::{Left, Right};
 use error_stack::Report;
 use parking_lot::Mutex;
 use std::mem;
+use std::result::Result as StdResult;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -94,10 +95,20 @@ enum InsertFreeListMiss {
     BufferPageGenerationMismatch,
 }
 
+enum InsertPageGuardError {
+    // The row-page index did not publish the new page id. The caller still
+    // owns an unlinked allocation and can deallocate it before returning.
+    Unpublished(Error),
+    // The row-page index already points at the new page id. The caller must
+    // keep the initialized empty page allocated so the index never contains a
+    // dangling page reference, even though the create-redo commit failed.
+    Published(Error),
+}
+
 struct RowPageIndexInsert {
     start_row_id: RowID,
     end_row_id: RowID,
-    create_cts: Option<TrxID>,
+    create_redo: Result<Option<TrxID>>,
 }
 
 #[derive(Clone, Copy)]
@@ -117,13 +128,16 @@ impl RowPageIndexAppend<'_> {
     #[inline]
     fn finish(self) -> RowPageIndexInsert {
         let end_row_id = self.end_row_id();
-        let create_cts = self
-            .redo_ctx
-            .map(|redo_ctx| redo_ctx.commit_row_page(self.page_id, self.start_row_id, end_row_id));
+        let create_redo = match self.redo_ctx {
+            Some(redo_ctx) => redo_ctx
+                .commit_row_page(self.page_id, self.start_row_id, end_row_id)
+                .map(Some),
+            None => Ok(None),
+        };
         RowPageIndexInsert {
             start_row_id: self.start_row_id,
             end_row_id,
-            create_cts,
+            create_redo,
         }
     }
 }
@@ -508,10 +522,7 @@ impl<P: BufferPool> RowPageIndex<P> {
             .insert_page_guard(meta_pool_guard, col_layout, count, redo_ctx, &mut new_page)
             .await
         {
-            // The row page was allocated locally and never published, so reclaim it
-            // before surfacing the metadata-side insertion failure.
-            mem_pool.deallocate_page(new_page);
-            return Err(err);
+            return Err(cleanup_failed_insert_page(mem_pool, new_page, err));
         }
         Ok(new_page.downgrade_shared())
     }
@@ -544,8 +555,7 @@ impl<P: BufferPool> RowPageIndex<P> {
             .insert_page_guard(meta_pool_guard, col_layout, count, redo_ctx, &mut new_page)
             .await
         {
-            mem_pool.deallocate_page(new_page);
-            return Err(err);
+            return Err(cleanup_failed_insert_page(mem_pool, new_page, err));
         }
         Ok(new_page)
     }
@@ -569,8 +579,7 @@ impl<P: BufferPool> RowPageIndex<P> {
             .insert_page_guard(meta_pool_guard, col_layout, count, None, &mut new_page)
             .await
         {
-            mem_pool.deallocate_page(new_page);
-            return Err(err);
+            return Err(cleanup_failed_insert_page(mem_pool, new_page, err));
         }
         Ok(new_page)
     }
@@ -583,12 +592,13 @@ impl<P: BufferPool> RowPageIndex<P> {
         count: usize,
         redo_ctx: Option<RowPageCreateRedoCtx<'_>>,
         new_page: &mut PageExclusiveGuard<RowPage>,
-    ) -> Result<()> {
+    ) -> StdResult<(), InsertPageGuardError> {
         let new_page_id = new_page.page_id();
         loop {
             match self
                 .insert_row_page(meta_pool_guard, count as u64, new_page_id, redo_ctx)
-                .await?
+                .await
+                .map_err(InsertPageGuardError::Unpublished)?
             {
                 Invalid => (),
                 Valid(inserted) => {
@@ -604,11 +614,21 @@ impl<P: BufferPool> RowPageIndex<P> {
                         .bf_mut()
                         .init_undo_map(Arc::clone(col_layout), count);
 
-                    if let Some(create_cts) = inserted.create_cts
-                        && let Some(row_ver) =
-                            new_page.bf().ctx.as_ref().and_then(|ctx| ctx.row_ver())
-                    {
-                        row_ver.set_create_cts(create_cts);
+                    match inserted.create_redo {
+                        Ok(Some(create_cts)) => {
+                            if let Some(row_ver) =
+                                new_page.bf().ctx.as_ref().and_then(|ctx| ctx.row_ver())
+                            {
+                                row_ver.set_create_cts(create_cts);
+                            }
+                        }
+                        Ok(None) => (),
+                        Err(err) => {
+                            // The append became visible before the create-redo
+                            // commit failed. Keep the page initialized so the
+                            // published index entry points at a valid empty page.
+                            return Err(InsertPageGuardError::Published(err));
+                        }
                     }
                     // finally, we downgrade the page lock for shared mode.
                     return Ok(());
@@ -1230,6 +1250,28 @@ impl<P: BufferPool> RowPageIndexMemCursor<'_, P> {
     }
 }
 
+#[inline]
+fn cleanup_failed_insert_page<B: BufferPool>(
+    mem_pool: &B,
+    new_page: PageExclusiveGuard<RowPage>,
+    err: InsertPageGuardError,
+) -> Error {
+    match err {
+        InsertPageGuardError::Unpublished(err) => {
+            // The row page was allocated locally and never published, so
+            // reclaim it before surfacing the metadata-side failure.
+            mem_pool.deallocate_page(new_page);
+            err
+        }
+        InsertPageGuardError::Published(err) => {
+            // The index entry is already visible. Leave the initialized empty
+            // page allocated; dropping the guard only releases the latch.
+            drop(new_page);
+            err
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1242,7 +1284,7 @@ mod tests {
         ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, TableMetadata,
     };
     use crate::conf::{EngineConfig, EvictableBufferPoolConfig, TrxSysConfig};
-    use crate::error::{ErrorKind, IoError, ResourceError, Validation};
+    use crate::error::{ErrorKind, FatalError, IoError, ResourceError, Validation};
     use crate::file::block_integrity::BLOCK_INTEGRITY_TRAILER_SIZE;
     use crate::id::{TableID, TrxID};
     use crate::latch::LatchFallbackMode;
@@ -2109,6 +2151,76 @@ mod tests {
     }
 
     #[test]
+    fn test_row_page_index_redo_failure_keeps_published_page_initialized() {
+        smol::block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let engine = EngineConfig::default()
+                .storage_root(temp_dir.path().to_path_buf())
+                .data_buffer(
+                    EvictableBufferPoolConfig::default()
+                        .role(PoolRole::Mem)
+                        .max_mem_size(64usize * 1024 * 1024)
+                        .max_file_size(128usize * 1024 * 1024),
+                )
+                .trx(TrxSysConfig::default().log_file_stem("redo_row_page_failure"))
+                .build()
+                .await
+                .unwrap();
+            let metadata = make_test_metadata();
+            let meta_guard = engine.inner().meta_pool.pool_guard();
+            let blk_idx = RowPageIndex::new(
+                engine.inner().meta_pool.clone_inner(),
+                &meta_guard,
+                RowID::new(0),
+            )
+            .await
+            .expect("test row-page-index construction should succeed");
+            let mem_guard = engine.inner().mem_pool.pool_guard();
+            let redo_ctx = RowPageCreateRedoCtx::new(&engine.inner().trx_sys, TableID::new(206));
+            let _ = engine.inner().trx_sys.poison_storage(FatalError::RedoWrite);
+
+            let err = match blk_idx
+                .get_insert_page(
+                    &meta_guard,
+                    &*engine.inner().mem_pool,
+                    &mem_guard,
+                    &metadata.col,
+                    100,
+                    Some(redo_ctx),
+                )
+                .await
+            {
+                Ok(_) => panic!("poisoned row-page create redo should fail"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.kind(), ErrorKind::Fatal);
+            let page_id = match blk_idx
+                .find_row(&meta_guard, RowID::new(0))
+                .await
+                .expect("published row-page index entry should remain readable")
+            {
+                RowLocation::RowPage(page_id) => page_id,
+                RowLocation::LwcBlock { .. } | RowLocation::NotFound => {
+                    panic!("expected published row page")
+                }
+            };
+            let page = engine
+                .inner()
+                .mem_pool
+                .get_page::<RowPage>(&mem_guard, page_id, LatchFallbackMode::Shared)
+                .await
+                .expect("published row page should remain allocated")
+                .lock_shared_async()
+                .await
+                .expect("published row page generation should remain current");
+            assert_eq!(page.page().header.start_row_id, RowID::new(0));
+            assert_eq!(page.page().header.max_row_count, 100);
+            assert_eq!(page.page().header.row_count(), 0);
+        })
+    }
+
+    #[test]
     fn test_row_page_index_create_row_page_redo_follows_append_order() {
         smol::block_on(async {
             let temp_dir = TempDir::new().unwrap();
@@ -2151,7 +2263,7 @@ mod tests {
                                     .expect("test row-page insertion should succeed")
                                 {
                                     Valid(inserted) => {
-                                        assert!(inserted.create_cts.is_some());
+                                        assert!(matches!(inserted.create_redo, Ok(Some(_))));
                                         break;
                                     }
                                     Invalid => {}

--- a/doradb-storage/src/index/util.rs
+++ b/doradb-storage/src/index/util.rs
@@ -1,3 +1,4 @@
+use crate::error::{LifecycleError, Result};
 use crate::id::{PageID, RowID, TableID, TrxID};
 use crate::row::INVALID_ROW_ID;
 use crate::trx::sys::TransactionSystem;
@@ -80,15 +81,21 @@ impl RowPageCreateRedoCtx<'_> {
         page_id: PageID,
         start_row_id: RowID,
         end_row_id: RowID,
-    ) -> TrxID {
+    ) -> Result<TrxID> {
         let mut trx = self.trx_sys.begin_sys_trx();
         let table_id = self.table_id;
         // Safety relies on callers serializing this no-wait commit with the
         // row-page-index append path. Later row-page creation and user redo
         // must not persist ahead of this CreateRowPage record.
         trx.create_row_page(table_id, page_id, start_row_id, end_row_id);
-        self.trx_sys
-            .commit_sys(trx)
-            .expect("commit system transaction for row page")
+        let res = self.trx_sys.commit_sys(trx);
+        if let Err(err) = &res {
+            debug_assert!(
+                self.trx_sys.storage_poison_error().is_some()
+                    || err.lifecycle_error() == Some(LifecycleError::Shutdown),
+                "row-page create redo failed while transaction system is still healthy: {err:?}"
+            );
+        }
+        res
     }
 }

--- a/doradb-storage/src/index/util.rs
+++ b/doradb-storage/src/index/util.rs
@@ -83,9 +83,9 @@ impl RowPageCreateRedoCtx<'_> {
     ) -> TrxID {
         let mut trx = self.trx_sys.begin_sys_trx();
         let table_id = self.table_id;
-        // Safety currently relies on single-stream redo ordering plus
-        // commit_no_wait: later user redo that reuses this page must not
-        // persist ahead of the earlier CreateRowPage record.
+        // Safety relies on callers serializing this no-wait commit with the
+        // row-page-index append path. Later row-page creation and user redo
+        // must not persist ahead of this CreateRowPage record.
         trx.create_row_page(table_id, page_id, start_row_id, end_row_id);
         self.trx_sys
             .commit_sys(trx)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row-page insertion safety when redo logging fails, keeping already-published pages readable instead of rolling them back incorrectly.
  * Preserved page metadata and generation state during failed insert attempts.
  * Reduced hard failures by returning errors from commit handling instead of panicking.

* **Tests**
  * Updated insertion tests for the revised call flow.
  * Added coverage for redo-write failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->