### PR TITLE
feat: expose log-sync knob for doradb-bench

### DIFF
--- a/docs/benchmark-tool.md
+++ b/docs/benchmark-tool.md
@@ -78,6 +78,7 @@ all sessions.
 | `--index`, `-i` | `prepare`, `run insert` | `prepare`: `none`; `run insert`: prepared index | Controls or validates the benchmark table's index shape. `none` creates no secondary indexes and allows duplicate logical key values. `unique` creates one unique secondary index on the logical key column. |
 | `--threads`, `-t` | `run insert` | `1` | Number of operating-system worker threads that drive the benchmark executor. It is not an async task count. |
 | `--sessions`, `-s` | `run insert` | `--threads` | Number of independent DoraDB public sessions, meaning logical benchmark clients scheduled on the worker threads. Both values must be positive, and `--threads > --sessions` is rejected. |
+| `--log-sync` | `run insert` | `fsync` | Redo-log durability sync method. `fsync` and `fdatasync` submit the matching native file-sync operation; `none` skips durable sync and is crash-unsafe. |
 Non-unique indexes and multiple indexes are deferred to later work.
 
 ## Key Ranges
@@ -112,7 +113,8 @@ errors are written to stderr.
 `run` prints three stdout sections in this order:
 
 - `Configuration`: workload, random-key mode, storage root, row count, value
-  size, batch size, seed, index mode, threads, sessions, and table id.
+  size, batch size, seed, index mode, threads, sessions, log sync mode, and
+  table id.
 - `Internal Stats`: public transaction-system, storage-IO, and buffer-pool stats
   deltas when available.
 - `Final Result`: operation count, elapsed time, operations per second, average

--- a/doradb-bench/src/cli.rs
+++ b/doradb-bench/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::error::{BenchError, Result};
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use doradb_storage::LogSync;
 use serde::{Deserialize, Serialize};
 use std::env::var_os;
 use std::fmt;
@@ -73,6 +74,40 @@ impl fmt::Display for IndexMode {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+pub(super) enum LogSyncMode {
+    #[serde(rename = "fsync")]
+    #[value(name = "fsync")]
+    Fsync,
+    #[serde(rename = "fdatasync")]
+    #[value(name = "fdatasync")]
+    Fdatasync,
+    #[serde(rename = "none")]
+    #[value(name = "none")]
+    None,
+}
+
+impl LogSyncMode {
+    #[inline]
+    pub(super) fn as_storage(self) -> LogSync {
+        match self {
+            Self::Fsync => LogSync::Fsync,
+            Self::Fdatasync => LogSync::Fdatasync,
+            Self::None => LogSync::None,
+        }
+    }
+}
+
+impl fmt::Display for LogSyncMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fsync => f.write_str("fsync"),
+            Self::Fdatasync => f.write_str("fdatasync"),
+            Self::None => f.write_str("none"),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Workload {
     Insert,
@@ -130,6 +165,9 @@ struct LoadCommonArgs {
     /// Independent DoraDB public sessions; defaults to --threads.
     #[arg(long, short = 's')]
     sessions: Option<NonZeroUsize>,
+    /// Redo-log durability sync method.
+    #[arg(long, value_enum, default_value_t = LogSyncMode::Fsync)]
+    log_sync: LogSyncMode,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -179,6 +217,7 @@ impl InsertArgs {
             index,
             threads,
             sessions,
+            log_sync: self.common.log_sync,
         })
     }
 }
@@ -195,6 +234,7 @@ pub(super) struct LoadConfig {
     pub(super) index: IndexMode,
     pub(super) threads: usize,
     pub(super) sessions: usize,
+    pub(super) log_sync: LogSyncMode,
 }
 
 #[cfg(test)]
@@ -287,6 +327,7 @@ mod tests {
                     index: None,
                     threads: NonZeroUsize::new(2).unwrap(),
                     sessions: None,
+                    log_sync: LogSyncMode::Fsync,
                 },
                 num: NonZeroU64::new(1).unwrap(),
                 value_size: NonZeroUsize::new(128).unwrap(),
@@ -331,6 +372,7 @@ mod tests {
             .unwrap();
         assert_eq!(config.workload, Workload::Insert);
         assert_eq!(config.batch_size, 1);
+        assert_eq!(config.log_sync, LogSyncMode::Fsync);
         assert!(!config.rand);
     }
 
@@ -376,6 +418,8 @@ mod tests {
             "2",
             "-s",
             "4",
+            "--log-sync",
+            "fdatasync",
         ])
         .unwrap();
         let Command::Run(args) = cli.command else {
@@ -391,6 +435,7 @@ mod tests {
         assert_eq!(config.index, IndexMode::Unique);
         assert_eq!(config.threads, 2);
         assert_eq!(config.sessions, 4);
+        assert_eq!(config.log_sync, LogSyncMode::Fdatasync);
     }
 
     #[test]

--- a/doradb-bench/src/output.rs
+++ b/doradb-bench/src/output.rs
@@ -1,4 +1,4 @@
-use crate::cli::{IndexMode, Workload};
+use crate::cli::{IndexMode, LogSyncMode, Workload};
 use crate::error::{BenchError, Result};
 use crate::manifest::{internal_stats_csv_path, result_csv_path, result_markdown_path};
 use doradb_storage::{
@@ -44,6 +44,7 @@ pub(super) struct OutputConfig {
     pub(super) index: IndexMode,
     pub(super) threads: usize,
     pub(super) sessions: usize,
+    pub(super) log_sync: LogSyncMode,
     pub(super) table_id: u64,
 }
 
@@ -252,6 +253,7 @@ fn render_result_csv(config: &OutputConfig, result: &BenchmarkResult) -> String 
         "index",
         "threads",
         "sessions",
+        "log_sync",
         "table_id",
         "operations",
         "elapsed_nanos",
@@ -270,6 +272,7 @@ fn render_result_csv(config: &OutputConfig, result: &BenchmarkResult) -> String 
         config.index.to_string(),
         config.threads.to_string(),
         config.sessions.to_string(),
+        config.log_sync.to_string(),
         config.table_id.to_string(),
         result.operations.to_string(),
         result.elapsed.as_nanos().to_string(),
@@ -299,6 +302,7 @@ fn configuration_pairs(config: &OutputConfig) -> Vec<(String, String)> {
         ("index".to_owned(), config.index.to_string()),
         ("threads".to_owned(), config.threads.to_string()),
         ("sessions".to_owned(), config.sessions.to_string()),
+        ("log_sync".to_owned(), config.log_sync.to_string()),
         ("table_id".to_owned(), config.table_id.to_string()),
     ]
 }
@@ -568,6 +572,7 @@ mod tests {
             index: IndexMode::None,
             threads: 1,
             sessions: 1,
+            log_sync: LogSyncMode::Fsync,
             table_id: 7,
         }
     }
@@ -726,6 +731,11 @@ mod tests {
             pairs
                 .iter()
                 .any(|(name, value)| name == "rand" && value == "false")
+        );
+        assert!(
+            pairs
+                .iter()
+                .any(|(name, value)| name == "log_sync" && value == "fsync")
         );
     }
 

--- a/doradb-bench/src/runner.rs
+++ b/doradb-bench/src/runner.rs
@@ -1,4 +1,4 @@
-use crate::cli::{IndexMode, LoadArgs, LoadConfig, PrepareArgs};
+use crate::cli::{IndexMode, LoadArgs, LoadConfig, LogSyncMode, PrepareArgs};
 use crate::error::{BenchError, Result};
 use crate::manifest::{
     KeyRange, Manifest, read_manifest, write_manifest, write_manifest_exclusive,
@@ -10,7 +10,7 @@ use crate::workload::{SessionPlan, build_session_plans, generate_keys, payload_b
 use doradb_storage::id::TableID;
 use doradb_storage::{
     ColumnAttributes, ColumnSpec, Engine, EngineConfig, IndexAttributes, IndexKey, IndexSpec,
-    Session, TableSpec, Val, ValKind,
+    Session, TableSpec, TrxSysConfig, Val, ValKind,
 };
 use easy_parallel::Parallel;
 use std::fs;
@@ -29,7 +29,7 @@ struct WorkerSummary {
 pub async fn prepare(storage_root: PathBuf, args: PrepareArgs) -> Result<()> {
     prepare_storage_root(&storage_root)?;
 
-    let engine = open_engine(&storage_root).await?;
+    let engine = open_engine(&storage_root, LogSyncMode::Fsync).await?;
     let mut session = engine.new_session()?;
     let table_id = session
         .create_table(benchmark_table_spec(), benchmark_index_specs(args.index))
@@ -56,7 +56,7 @@ pub async fn run_load(storage_root: PathBuf, args: LoadArgs, command_context: &s
     let key_range = manifest.key_range(config.num)?;
     let table_id = TableID::new(manifest.table_id);
 
-    let engine = open_engine(&config.storage_root).await?;
+    let engine = open_engine(&config.storage_root, config.log_sync).await?;
     let mut stats_session = engine.new_session()?;
     let before = InternalStatsSnapshot::capture(&stats_session)?;
     let started = Instant::now();
@@ -81,6 +81,7 @@ pub async fn run_load(storage_root: PathBuf, args: LoadArgs, command_context: &s
         index: config.index,
         threads: config.threads,
         sessions: config.sessions,
+        log_sync: config.log_sync,
         table_id: manifest.table_id,
     };
     write_benchmark_outputs(&output_config, &metrics, &result, command_context)?;
@@ -118,9 +119,10 @@ fn prepare_storage_root(storage_root: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn open_engine(storage_root: &Path) -> Result<Engine> {
+async fn open_engine(storage_root: &Path, log_sync: LogSyncMode) -> Result<Engine> {
     Ok(EngineConfig::default()
         .storage_root(storage_root)
+        .trx(TrxSysConfig::default().log_sync(log_sync.as_storage()))
         .build()
         .await?)
 }
@@ -432,6 +434,7 @@ mod tests {
             index: IndexMode::None,
             threads: 1,
             sessions: 1,
+            log_sync: LogSyncMode::Fsync,
         }
     }
 }

--- a/doradb-bench/tests/lifecycle.rs
+++ b/doradb-bench/tests/lifecycle.rs
@@ -92,8 +92,9 @@ mod tests {
         assert_eq!(columns[1], "false");
         assert_eq!(columns[3], "3");
         assert_eq!(columns[5], "2");
-        assert_eq!(columns[11], "3");
-        assert_eq!(columns[15], "0");
+        assert_eq!(columns[10], "fsync");
+        assert_eq!(columns[12], "3");
+        assert_eq!(columns[16], "0");
 
         let cleanup_stdout = assert_success(run_bench(&root, &["cleanup"]));
         assert!(cleanup_stdout.contains("removed storage_root="));

--- a/doradb-storage/src/conf/mod.rs
+++ b/doradb-storage/src/conf/mod.rs
@@ -14,3 +14,4 @@ pub use self::consts::{
 pub use self::engine::EngineConfig;
 pub use self::fs::FileSystemConfig;
 pub use self::trx::TrxSysConfig;
+pub use crate::log::LogSync;

--- a/doradb-storage/src/lib.rs
+++ b/doradb-storage/src/lib.rs
@@ -39,7 +39,7 @@ pub use catalog::{
     CatalogCheckpointOutcome, ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexNo,
     IndexOrder, IndexSpec, TableSpec,
 };
-pub use conf::{EngineConfig, EvictableBufferPoolConfig, FileSystemConfig, TrxSysConfig};
+pub use conf::{EngineConfig, EvictableBufferPoolConfig, FileSystemConfig, LogSync, TrxSysConfig};
 pub use engine::Engine;
 pub use error::{Error, ErrorKind, Result};
 pub use lock::LockMode;


### PR DESCRIPTION
Expose log sync mode on `doradb-bench`.
Simple insert case benchmarked on MacBook Air M4.
160000 rows, 4 threads, 64 sessions, 1 row per transaction.

| mode | elapsed | ops/sec | groups | syncs | avg sync |
|-------|---------|---------|--------|-------|----------|
| fsync | 2.843s | 56,279.599 | 12,606 | 5,025 | 508.002 us |
| fdatasync | 2.957s | 54,115.695 | 12,744 | 5,003 | 537.652 us |
| none | 0.427s | 375,145.450 | 13,429 | 0 | 0 us |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI option to choose redo-log sync behavior, including `fsync`, `fdatasync`, and `none`.
  * Benchmark results and configuration output now show the selected log-sync setting, including in CSV exports.

* **Bug Fixes**
  * Load and benchmark runs now consistently apply the chosen log-sync setting instead of relying on a fixed default.

* **Tests**
  * Updated benchmark lifecycle checks to validate the new output column and sync value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->