### PR TITLE
doc: update README with quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,120 @@ Build a modern and fast storage engine.
 
 The storage engine is designed as a hybrid engine managing both in-memory row store and on-disk column store, with full transactional support across all data.
 
+## Quick Start
+
+The snippets below assume an async function returning `doradb_storage::Result<()>`.
+DoraDB is runtime agnostic, so you can run these futures on whichever async runtime your application already uses.
+For a complete runnable version, see [quick_start.rs](./doradb-storage/examples/quick_start.rs) or run `cargo run -p doradb-storage --example quick_start`.
+
+Create a table with a schema and indexes, then drop it from an idle session.
+
+```rust
+use doradb_storage::{
+    ColumnAttributes, ColumnSpec, EngineConfig, IndexAttributes, IndexKey, IndexSpec, TableSpec,
+    ValKind,
+};
+
+let engine = EngineConfig::default()
+    .storage_root("target/doradb-quick-start")
+    .build()
+    .await?;
+let mut session = engine.new_session()?;
+
+let table_id = session
+    .create_table(
+        TableSpec::new(vec![
+            ColumnSpec::new("id", ValKind::I32, ColumnAttributes::empty()),
+            ColumnSpec::new("name", ValKind::VarByte, ColumnAttributes::empty()),
+        ]),
+        vec![
+            IndexSpec::new(vec![IndexKey::new(0)], IndexAttributes::UK),
+            IndexSpec::new(vec![IndexKey::new(1)], IndexAttributes::empty()),
+        ],
+    )
+    .await?;
+
+session.drop_table(table_id).await?;
+session.close().await?;
+engine.shutdown()?;
+```
+
+Insert, update, and delete rows by executing statements inside a transaction.
+
+```rust
+use doradb_storage::{SelectKey, UpdateCol, Val};
+
+let mut trx = session.begin_trx()?;
+
+trx.exec(async |stmt| {
+    stmt.table_insert_mvcc(table_id, vec![Val::from(1i32), Val::from("alice")])
+        .await?;
+    Ok(())
+})
+.await?;
+
+let key = SelectKey::new(0, vec![Val::from(1i32)]);
+trx.exec(async |stmt| {
+    stmt.table_update_unique_mvcc(
+        table_id,
+        &key,
+        vec![UpdateCol {
+            idx: 1,
+            val: Val::from("ada"),
+        }],
+    )
+    .await?;
+    Ok(())
+})
+.await?;
+
+trx.exec(async |stmt| {
+    stmt.table_delete_unique_mvcc(table_id, &key, false).await?;
+    Ok(())
+})
+.await?;
+
+trx.commit().await?;
+```
+
+Scan rows, read one unique-key row, and scan matching rows through a secondary index.
+
+```rust
+use doradb_storage::{SelectKey, Val};
+
+let mut trx = session.begin_trx()?;
+let mut rows = Vec::new();
+
+trx.exec(async |stmt| {
+    stmt.table_scan_mvcc(table_id, &[0, 1], |vals| {
+        rows.push(vals);
+        true
+    })
+    .await?;
+    Ok(())
+})
+.await?;
+
+let id_key = SelectKey::new(0, vec![Val::from(1i32)]);
+let _row = trx
+    .exec(async |stmt| {
+        stmt.table_lookup_unique_mvcc(table_id, &id_key, &[0, 1])
+            .await
+    })
+    .await?;
+
+let name_key = SelectKey::new(1, vec![Val::from("ada")]);
+let _matching_rows = trx
+    .exec(async |stmt| {
+        stmt.table_index_scan_mvcc(table_id, &name_key, &[0, 1])
+            .await
+    })
+    .await?
+    .unwrap_rows();
+
+trx.rollback().await?;
+```
+
 ## Design 
 
 - [Storage Architecture](./docs/architecture.md)

--- a/doradb-storage/examples/quick_start.rs
+++ b/doradb-storage/examples/quick_start.rs
@@ -1,0 +1,141 @@
+use doradb_storage::{
+    ColumnAttributes, ColumnSpec, EngineConfig, IndexAttributes, IndexKey, IndexSpec, SelectKey,
+    TableSpec, UpdateCol, Val, ValKind,
+};
+use futures::executor;
+use std::error::Error;
+use tempfile::TempDir;
+
+type ExampleResult<T> = std::result::Result<T, Box<dyn Error>>;
+
+fn main() {
+    if let Err(err) = executor::block_on(run()) {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> ExampleResult<()> {
+    // Build an engine using a temporary storage root for this example run.
+    let temp_dir = TempDir::new()?;
+    let engine = EngineConfig::default()
+        .storage_root(temp_dir.path())
+        .build()
+        .await?;
+    let mut session = engine.new_session()?;
+
+    // Create a table with a unique id index and a secondary name index.
+    let table_id = session
+        .create_table(
+            TableSpec::new(vec![
+                ColumnSpec::new("id", ValKind::I32, ColumnAttributes::empty()),
+                ColumnSpec::new("name", ValKind::VarByte, ColumnAttributes::empty()),
+            ]),
+            vec![
+                IndexSpec::new(vec![IndexKey::new(0)], IndexAttributes::UK),
+                IndexSpec::new(vec![IndexKey::new(1)], IndexAttributes::empty()),
+            ],
+        )
+        .await?;
+
+    let mut write_trx = session.begin_trx()?;
+    // Insert two rows in one statement.
+    write_trx
+        .exec(async |stmt| {
+            stmt.table_insert_mvcc(table_id, vec![Val::from(1i32), Val::from("alice")])
+                .await?;
+            stmt.table_insert_mvcc(table_id, vec![Val::from(2i32), Val::from("bob")])
+                .await?;
+            Ok(())
+        })
+        .await?;
+
+    let id_one = SelectKey::new(0, vec![Val::from(1i32)]);
+    // Update one row by its unique id key.
+    write_trx
+        .exec(async |stmt| {
+            let res = stmt
+                .table_update_unique_mvcc(
+                    table_id,
+                    &id_one,
+                    vec![UpdateCol {
+                        idx: 1,
+                        val: Val::from("ada"),
+                    }],
+                )
+                .await?;
+            assert!(res.is_updated());
+            Ok(())
+        })
+        .await?;
+
+    let id_two = SelectKey::new(0, vec![Val::from(2i32)]);
+    // Delete one row by its unique id key.
+    write_trx
+        .exec(async |stmt| {
+            let res = stmt
+                .table_delete_unique_mvcc(table_id, &id_two, false)
+                .await?;
+            assert!(res.is_deleted());
+            Ok(())
+        })
+        .await?;
+    write_trx.commit().await?;
+
+    let mut read_trx = session.begin_trx()?;
+    let mut scanned_rows = Vec::new();
+    // Scan visible rows from the table.
+    read_trx
+        .exec(async |stmt| {
+            stmt.table_scan_mvcc(table_id, &[0, 1], |vals| {
+                scanned_rows.push(row_pair(vals));
+                true
+            })
+            .await?;
+            Ok(())
+        })
+        .await?;
+    scanned_rows.sort_unstable();
+    assert_eq!(scanned_rows, vec![(1, String::from("ada"))]);
+
+    // Lookup one row through the unique id index.
+    let found = read_trx
+        .exec(async |stmt| {
+            stmt.table_lookup_unique_mvcc(table_id, &id_one, &[0, 1])
+                .await
+        })
+        .await?
+        .unwrap_found();
+    assert_eq!(row_pair(found), (1, String::from("ada")));
+
+    let name_key = SelectKey::new(1, vec![Val::from("ada")]);
+    // Scan rows that match one secondary-index key.
+    let mut matching_rows = read_trx
+        .exec(async |stmt| {
+            stmt.table_index_scan_mvcc(table_id, &name_key, &[0, 1])
+                .await
+        })
+        .await?
+        .unwrap_rows()
+        .into_iter()
+        .map(row_pair)
+        .collect::<Vec<_>>();
+    matching_rows.sort_unstable();
+    assert_eq!(matching_rows, vec![(1, String::from("ada"))]);
+    read_trx.rollback().await?;
+
+    // Drop the table after all transactions are finished.
+    session.drop_table(table_id).await?;
+    assert!(!session.list_table_ids()?.contains(&table_id));
+    session.close().await?;
+    engine.shutdown()?;
+
+    println!("quick start example completed");
+    Ok(())
+}
+
+fn row_pair(vals: Vec<Val>) -> (i32, String) {
+    let id = vals[0].as_i32().expect("id must be i32");
+    let name = vals[1].as_str().expect("name must be UTF-8").to_string();
+    (id, name)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Rust quick-start example demonstrating end-to-end storage usage.
  * Shows creating a table, adding indexes, inserting, updating, deleting, and reading data.
  * Includes examples of scanning rows, unique lookups, and secondary-index queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->