### PR TITLE
chore: change table id range of user/catalog tables

### DIFF
--- a/docs/checkpoint-and-recovery.md
+++ b/docs/checkpoint-and-recovery.md
@@ -271,7 +271,7 @@ checkpointed cold secondary-index state.
 Startup also removes leftover deterministic user-table files when all of these
 conditions are true:
 
-- the file name decodes to a user table id
+- the file name decodes to a low-half user table id
 - the id is below checkpointed `next_table_id`
 - the id is absent from the checkpointed catalog table list
 

--- a/doradb-storage/src/buffer/readonly.rs
+++ b/doradb-storage/src/buffer/readonly.rs
@@ -1358,7 +1358,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::buffer::page::Page;
     use crate::buffer::test_page_id;
-    use crate::catalog::{ColumnAttributes, ColumnSpec, TableMetadata, USER_OBJ_ID_START};
+    use crate::catalog::{ColumnAttributes, ColumnSpec, TableMetadata, USER_TABLE_ID_START};
     use crate::conf::{EngineConfig, EvictableBufferPoolConfig, FileSystemConfig, TrxSysConfig};
     use crate::error::{CompletionErrorKind, Error, FileKind, LifecycleError, ResourceError};
     use crate::file::block_integrity::{
@@ -2278,7 +2278,7 @@ pub(crate) mod tests {
         let global = owned_global_pool(64 * 1024 * 1024);
         let global_guard = (*global).pool_guard();
         let catalog_key = BlockKey::new(CATALOG_MTB_FILE_ID, test_block_id(42));
-        let user_key = BlockKey::new(FileID::from(USER_OBJ_ID_START), test_block_id(42));
+        let user_key = BlockKey::new(FileID::from(USER_TABLE_ID_START), test_block_id(42));
 
         let mut catalog_frame = global
             .try_lock_page_exclusive(&global_guard, test_page_id(1))

--- a/doradb-storage/src/catalog/mod.rs
+++ b/doradb-storage/src/catalog/mod.rs
@@ -42,8 +42,14 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// First table id reserved for user-managed objects.
-pub(crate) const USER_OBJ_ID_START: TableID = TableID::new(0x0001_0000_0000_0000);
+/// First table id allocated to user-managed tables.
+pub(crate) const USER_TABLE_ID_START: TableID = TableID::new(0);
+
+/// First table id reserved for built-in catalog tables.
+pub(crate) const CATALOG_TABLE_ID_START: TableID = TableID::new(1u64 << 63);
+
+/// Exclusive upper bound of the user table-id range.
+pub(crate) const USER_TABLE_ID_LIMIT: TableID = CATALOG_TABLE_ID_START;
 
 /// Dedicated runtime wrapper for catalog logical tables.
 pub(crate) struct CatalogTable {
@@ -140,7 +146,12 @@ impl Catalog {
     /// Allocate and return the next table id.
     #[inline]
     pub(crate) fn next_table_id(&self) -> TableID {
-        TableID::new(self.next_table_id.fetch_add(1, Ordering::SeqCst))
+        let table_id = TableID::new(self.next_table_id.fetch_add(1, Ordering::SeqCst));
+        assert!(
+            table_id < USER_TABLE_ID_LIMIT,
+            "user table id allocator overflowed into catalog table range: table_id={table_id}, limit={USER_TABLE_ID_LIMIT}"
+        );
+        table_id
     }
 
     #[inline]
@@ -220,7 +231,7 @@ impl Catalog {
             .await?;
 
         // Phase 2 allocator semantics: only table ids consume the global allocator.
-        self.try_update_next_table_id(table.table_id.saturating_add(1).max(USER_OBJ_ID_START));
+        self.try_update_next_table_id(table.table_id.saturating_add(1));
 
         let table_file = table_fs
             .open_table_file(table.table_id, disk_pool.clone())
@@ -1037,13 +1048,29 @@ impl<'a> TableCache<'a> {
 /// Return whether a table id belongs to user-managed catalog space.
 #[inline]
 pub(crate) const fn is_user_table(table_id: TableID) -> bool {
-    table_id.as_u64() >= USER_OBJ_ID_START.as_u64()
+    table_id.as_u64() < USER_TABLE_ID_LIMIT.as_u64()
 }
 
 /// Return whether a table id belongs to built-in catalog table space.
 #[inline]
 pub(crate) const fn is_catalog_table(table_id: TableID) -> bool {
-    !is_user_table(table_id)
+    table_id.as_u64() >= CATALOG_TABLE_ID_START.as_u64()
+}
+
+/// Build a built-in catalog table id from its dense root slot.
+#[inline]
+pub(crate) const fn catalog_table_id_from_slot(slot: usize) -> TableID {
+    TableID::new(CATALOG_TABLE_ID_START.as_u64() + slot as u64)
+}
+
+/// Return the dense root slot for a built-in catalog table id.
+#[inline]
+pub(crate) const fn catalog_table_slot(table_id: TableID) -> Option<usize> {
+    if is_catalog_table(table_id) {
+        Some((table_id.as_u64() - CATALOG_TABLE_ID_START.as_u64()) as usize)
+    } else {
+        None
+    }
 }
 
 /// Combine table-root replay bounds with a checkpoint-durable silent overlay.
@@ -1360,11 +1387,34 @@ pub(crate) mod tests {
 
     #[test]
     fn test_catalog_table_id_boundary_predicates() {
-        let before_user = TableID::new(USER_OBJ_ID_START.as_u64() - 1);
-        assert!(is_catalog_table(before_user));
-        assert!(!is_catalog_table(USER_OBJ_ID_START));
-        assert!(!is_user_table(before_user));
-        assert!(is_user_table(USER_OBJ_ID_START));
+        let last_user = TableID::new(USER_TABLE_ID_LIMIT.as_u64() - 1);
+        assert!(is_user_table(USER_TABLE_ID_START));
+        assert!(!is_catalog_table(USER_TABLE_ID_START));
+        assert!(is_user_table(last_user));
+        assert!(!is_catalog_table(last_user));
+        assert!(!is_user_table(CATALOG_TABLE_ID_START));
+        assert!(is_catalog_table(CATALOG_TABLE_ID_START));
+        assert_eq!(catalog_table_id_from_slot(0), CATALOG_TABLE_ID_START);
+        assert_eq!(catalog_table_slot(CATALOG_TABLE_ID_START), Some(0));
+        assert_eq!(catalog_table_slot(catalog_table_id_from_slot(4)), Some(4));
+    }
+
+    #[test]
+    #[should_panic(expected = "user table id allocator overflowed into catalog table range")]
+    fn test_next_table_id_panics_at_catalog_boundary() {
+        smol::block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let engine = open_catalog_test_engine(
+                temp_dir.path().to_path_buf(),
+                Some("catalog-allocator-overflow"),
+            )
+            .await;
+            engine
+                .catalog()
+                .next_table_id
+                .store(USER_TABLE_ID_LIMIT.as_u64(), Ordering::SeqCst);
+            let _ = engine.catalog().next_table_id();
+        });
     }
 
     #[test]
@@ -1550,7 +1600,7 @@ pub(crate) mod tests {
 
             let engine =
                 open_catalog_test_engine(main_dir.clone(), Some("catalog-allocator")).await;
-            assert_eq!(engine.catalog().curr_next_table_id(), USER_OBJ_ID_START);
+            assert_eq!(engine.catalog().curr_next_table_id(), USER_TABLE_ID_START);
             let mut session = engine.new_session().unwrap();
             let table_spec = TableSpec::new(vec![
                 ColumnSpec::new("id", ValKind::I32, ColumnAttributes::empty()),
@@ -1572,7 +1622,7 @@ pub(crate) mod tests {
             let engine = open_catalog_test_engine(main_dir, Some("catalog-allocator")).await;
             assert_eq!(engine.catalog().curr_next_table_id(), table_id1 + 1);
             let table_id2 = table1(&engine).await;
-            assert!(table_id1 >= USER_OBJ_ID_START);
+            assert!(table_id1 >= USER_TABLE_ID_START);
             assert_eq!(table_id2, table_id1 + 1);
             drop(engine);
         });

--- a/doradb-storage/src/catalog/storage/columns.rs
+++ b/doradb-storage/src/catalog/storage/columns.rs
@@ -3,7 +3,9 @@ use crate::catalog::CatalogTable;
 use crate::catalog::storage::CatalogDefinition;
 use crate::catalog::storage::object::ColumnObject;
 use crate::catalog::table::{TableColumnLayout, TableMetadata};
-use crate::catalog::{ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec};
+use crate::catalog::{
+    ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, catalog_table_id_from_slot,
+};
 use crate::error::Result;
 use crate::id::TableID;
 use crate::row::ops::DeleteMvcc;
@@ -14,7 +16,7 @@ use crate::value::ValKind;
 use semistr::SemiStr;
 use std::sync::OnceLock;
 
-pub(super) const TABLE_ID_COLUMNS: TableID = TableID::new(1);
+pub(super) const TABLE_ID_COLUMNS: TableID = catalog_table_id_from_slot(1);
 const COL_NO_COLUMNS_TABLE_ID: usize = 0;
 const COL_NAME_COLUMNS_TABLE_ID: &str = "table_id";
 const COL_NO_COLUMNS_COLUMN_NO: usize = 1;

--- a/doradb-storage/src/catalog/storage/indexes.rs
+++ b/doradb-storage/src/catalog/storage/indexes.rs
@@ -5,6 +5,7 @@ use crate::catalog::storage::object::{IndexColumnObject, IndexObject};
 use crate::catalog::table::{TableColumnLayout, TableMetadata};
 use crate::catalog::{
     ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexOrder, IndexSpec,
+    catalog_table_id_from_slot,
 };
 use crate::error::Result;
 use crate::id::TableID;
@@ -18,7 +19,7 @@ use std::sync::OnceLock;
 
 /* Indexes table */
 
-pub(super) const TABLE_ID_INDEXES: TableID = TableID::new(2);
+pub(super) const TABLE_ID_INDEXES: TableID = catalog_table_id_from_slot(2);
 const COL_NO_INDEXES_TABLE_ID: usize = 0;
 const COL_NAME_INDEXES_TABLE_ID: &str = "table_id";
 const COL_NO_INDEXES_INDEX_NO: usize = 1;
@@ -29,7 +30,7 @@ const PK_NO_INDEXES: usize = 0;
 
 /* Index columns table */
 
-pub(super) const TABLE_ID_INDEX_COLUMNS: TableID = TableID::new(3);
+pub(super) const TABLE_ID_INDEX_COLUMNS: TableID = catalog_table_id_from_slot(3);
 const COL_NO_INDEX_COLUMNS_TABLE_ID: usize = 0;
 const COL_NAME_INDEX_COLUMNS_TABLE_ID: &str = "table_id";
 const COL_NO_INDEX_COLUMNS_INDEX_NO: usize = 1;

--- a/doradb-storage/src/catalog/storage/merge.rs
+++ b/doradb-storage/src/catalog/storage/merge.rs
@@ -405,7 +405,7 @@ mod tests {
     use super::super::columns::catalog_definition_of_columns;
     use super::super::tables::catalog_definition_of_tables;
     use super::*;
-    use crate::catalog::USER_OBJ_ID_START;
+    use crate::catalog::USER_TABLE_ID_START;
     use crate::error::DataIntegrityError;
     use crate::id::{RowID, TableID};
     use crate::value::ValKind;
@@ -414,7 +414,7 @@ mod tests {
     fn test_catalog_merge_key_builder_encodes_single_and_composite_keys() {
         let tables_metadata = &catalog_definition_of_tables().metadata;
         let tables_key_builder = CatalogMergeKeyBuilder::new(tables_metadata).unwrap();
-        let tables_table_id = USER_OBJ_ID_START + 1;
+        let tables_table_id = USER_TABLE_ID_START + 1;
         let tables_key = tables_key_builder
             .key_from_row(&catalog_table_vals(tables_table_id, 0))
             .unwrap();
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(tables_key, tables_select_key);
 
         let columns_metadata = &catalog_definition_of_columns().metadata;
-        let columns_table_id = USER_OBJ_ID_START + 2;
+        let columns_table_id = USER_TABLE_ID_START + 2;
         let columns_no = 7u16;
         let columns_vals = catalog_column_vals(columns_table_id, columns_no, 8);
         let columns_key_builder = CatalogMergeKeyBuilder::new(columns_metadata).unwrap();
@@ -441,8 +441,8 @@ mod tests {
     #[test]
     fn test_catalog_fold_valid_state_transitions() {
         let metadata = &catalog_definition_of_tables().metadata;
-        let base_table_id = USER_OBJ_ID_START + 1;
-        let new_table_id = USER_OBJ_ID_START + 2;
+        let base_table_id = USER_TABLE_ID_START + 1;
+        let new_table_id = USER_TABLE_ID_START + 2;
         let base_key = SelectKey::new(0, vec![Val::from(base_table_id)]);
         let new_key = SelectKey::new(0, vec![Val::from(new_table_id)]);
 
@@ -499,9 +499,9 @@ mod tests {
     #[test]
     fn test_catalog_fold_materializes_primary_key_order() {
         let metadata = &catalog_definition_of_tables().metadata;
-        let table1_id = USER_OBJ_ID_START + 21;
-        let table2_id = USER_OBJ_ID_START + 22;
-        let table3_id = USER_OBJ_ID_START + 23;
+        let table1_id = USER_TABLE_ID_START + 21;
+        let table2_id = USER_TABLE_ID_START + 22;
+        let table3_id = USER_TABLE_ID_START + 23;
         let mut folded = folded_tables_with_base(vec![(table3_id, 3), (table1_id, 1)]);
 
         folded
@@ -521,8 +521,8 @@ mod tests {
     #[test]
     fn test_catalog_fold_should_rewrite_tracks_final_root_change() {
         let metadata = &catalog_definition_of_tables().metadata;
-        let base_table_id = USER_OBJ_ID_START + 31;
-        let new_table_id = USER_OBJ_ID_START + 32;
+        let base_table_id = USER_TABLE_ID_START + 31;
+        let new_table_id = USER_TABLE_ID_START + 32;
         let base_key = SelectKey::new(0, vec![Val::from(base_table_id)]);
         let new_key = SelectKey::new(0, vec![Val::from(new_table_id)]);
 
@@ -554,8 +554,8 @@ mod tests {
     #[test]
     fn test_catalog_fold_rejects_invalid_state_transitions() {
         let metadata = &catalog_definition_of_tables().metadata;
-        let base_table_id = USER_OBJ_ID_START + 11;
-        let new_table_id = USER_OBJ_ID_START + 12;
+        let base_table_id = USER_TABLE_ID_START + 11;
+        let new_table_id = USER_TABLE_ID_START + 12;
         let base_key = SelectKey::new(0, vec![Val::from(base_table_id)]);
         let new_key = SelectKey::new(0, vec![Val::from(new_table_id)]);
 

--- a/doradb-storage/src/catalog/storage/mod.rs
+++ b/doradb-storage/src/catalog/storage/mod.rs
@@ -15,7 +15,7 @@ use crate::catalog::storage::tables::*;
 use crate::catalog::table::TableMetadata;
 use crate::catalog::{
     CatalogCheckpointBatch, CatalogCheckpointOutcome, CatalogRedoEntry, CatalogTable,
-    USER_OBJ_ID_START,
+    catalog_table_id_from_slot, catalog_table_slot,
 };
 use crate::error::{DataIntegrityError, Error, FileKind, Result};
 use crate::file::cow_file::{MutableCowFile, SUPER_BLOCK_ID};
@@ -84,8 +84,8 @@ impl CatalogStorage {
             catalog_definition_of_index_columns(),
             catalog_definition_of_table_replay_silent_watermarks(),
         ] {
-            // make sure table id matches.
-            assert_eq!(cat.len(), table_id.as_usize());
+            // Make sure catalog table ids match their dense root slots.
+            assert_eq!(cat.len(), must_catalog_table_slot(*table_id));
             let metadata = Arc::new(metadata.clone());
             let blk_idx = BlockIndex::new_catalog(meta_pool.clone(), &meta_pool_guard).await?;
             let table = Arc::new(
@@ -116,7 +116,7 @@ impl CatalogStorage {
     #[inline]
     pub(crate) fn tables(&self) -> Tables<'_> {
         Tables {
-            table: &self.tables[TABLE_ID_TABLES.as_usize()],
+            table: &self.tables[must_catalog_table_slot(TABLE_ID_TABLES)],
         }
     }
 
@@ -124,7 +124,7 @@ impl CatalogStorage {
     #[inline]
     pub(crate) fn columns(&self) -> Columns<'_> {
         Columns {
-            table: &self.tables[TABLE_ID_COLUMNS.as_usize()],
+            table: &self.tables[must_catalog_table_slot(TABLE_ID_COLUMNS)],
         }
     }
 
@@ -132,7 +132,7 @@ impl CatalogStorage {
     #[inline]
     pub(crate) fn indexes(&self) -> Indexes<'_> {
         Indexes {
-            table: &self.tables[TABLE_ID_INDEXES.as_usize()],
+            table: &self.tables[must_catalog_table_slot(TABLE_ID_INDEXES)],
         }
     }
 
@@ -140,7 +140,7 @@ impl CatalogStorage {
     #[inline]
     pub(crate) fn index_columns(&self) -> IndexColumns<'_> {
         IndexColumns {
-            table: &self.tables[TABLE_ID_INDEX_COLUMNS.as_usize()],
+            table: &self.tables[must_catalog_table_slot(TABLE_ID_INDEX_COLUMNS)],
         }
     }
 
@@ -148,7 +148,7 @@ impl CatalogStorage {
     #[inline]
     pub(crate) fn table_replay_silent_watermarks(&self) -> TableReplaySilentWatermarks<'_> {
         TableReplaySilentWatermarks {
-            table: &self.tables[TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS.as_usize()],
+            table: &self.tables[must_catalog_table_slot(TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS)],
         }
     }
 
@@ -168,7 +168,8 @@ impl CatalogStorage {
     /// Return one catalog table runtime by table id.
     #[inline]
     pub(crate) fn get_catalog_table(&self, table_id: TableID) -> Option<Arc<CatalogTable>> {
-        self.tables.get(table_id.as_usize()).map(Arc::clone)
+        let slot = catalog_table_slot(table_id)?;
+        self.tables.get(slot).map(Arc::clone)
     }
 
     /// Return current next table id persisted in catalog snapshot.
@@ -223,7 +224,7 @@ impl CatalogStorage {
             if idx >= self.tables.len() {
                 break;
             }
-            if root.table_id.as_usize() != idx {
+            if catalog_table_slot(root.table_id) != Some(idx) {
                 return Err(invalid_catalog_payload(format!(
                     "catalog root table id mismatch: root_table_id={}, slot_idx={idx}",
                     root.table_id
@@ -250,7 +251,8 @@ impl CatalogStorage {
         let watermarks = self
             .load_checkpointed_table_replay_silent_watermark_map(
                 guards.disk_guard(),
-                snapshot.meta.table_roots[TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS.as_usize()],
+                snapshot.meta.table_roots
+                    [must_catalog_table_slot(TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS)],
             )
             .await?;
         self.install_checkpointed_silent_watermarks(Arc::new(watermarks));
@@ -310,13 +312,7 @@ impl CatalogStorage {
             let mut ops_by_table: Vec<Vec<RowRedoKind>> =
                 (0..self.tables.len()).map(|_| Vec::new()).collect();
             for CatalogRedoEntry { table_id, kind } in catalog_ops {
-                let table_idx = table_id.as_usize();
-                if table_idx >= ops_by_table.len() {
-                    return Err(invalid_catalog_payload(format!(
-                        "catalog checkpoint redo table id out of range: table_id={table_id}, catalog_table_count={}",
-                        ops_by_table.len()
-                    )));
-                }
+                let table_idx = catalog_table_slot_checked(table_id, ops_by_table.len())?;
                 ops_by_table[table_idx].push(kind);
             }
 
@@ -328,7 +324,7 @@ impl CatalogStorage {
                 let (new_root, table_blocks_changed) = self
                     .apply_table_ops(
                         &mut mutable,
-                        TableID::from(idx),
+                        catalog_table_id_from_slot(idx),
                         table.metadata(),
                         current_root,
                         &ops_by_table[idx],
@@ -345,7 +341,7 @@ impl CatalogStorage {
         // heartbeat batches.
         mutable.apply_checkpoint_metadata(
             next_catalog_replay_start_ts,
-            next_table_id.max(USER_OBJ_ID_START),
+            next_table_id,
             new_roots,
         )?;
         if catalog_blocks_changed {
@@ -370,7 +366,7 @@ impl CatalogStorage {
         let checkpointed_silent_watermarks = self
             .load_checkpointed_table_replay_silent_watermark_map(
                 &disk_pool_guard,
-                new_roots[TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS.as_usize()],
+                new_roots[must_catalog_table_slot(TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS)],
             )
             .await?;
         Ok(PreparedCatalogCheckpoint::Published(Box::new(
@@ -407,7 +403,8 @@ impl CatalogStorage {
     ) -> Result<FastHashMap<TableID, TableRedoReplayFloor>> {
         let rows = self
             .load_rows_from_root(
-                self.tables[TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS.as_usize()].metadata(),
+                self.tables[must_catalog_table_slot(TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS)]
+                    .metadata(),
                 disk_pool_guard,
                 root,
             )
@@ -447,7 +444,7 @@ impl CatalogStorage {
 
         let disk_pool_guard = self.disk_pool.pool_guard();
         for (idx, table_root) in root.table_roots.iter().enumerate() {
-            if table_root.table_id.as_usize() != idx {
+            if catalog_table_slot(table_root.table_id) != Some(idx) {
                 return Err(invalid_catalog_root_invariant(
                     root.root_ts,
                     format!(
@@ -826,6 +823,26 @@ pub(crate) struct PreparedCatalogPublish {
     checkpointed_silent_watermarks: Arc<FastHashMap<TableID, TableRedoReplayFloor>>,
 }
 
+#[inline]
+fn must_catalog_table_slot(table_id: TableID) -> usize {
+    catalog_table_slot(table_id).expect("built-in catalog table id must be in catalog range")
+}
+
+#[inline]
+fn catalog_table_slot_checked(table_id: TableID, catalog_table_count: usize) -> Result<usize> {
+    let Some(slot) = catalog_table_slot(table_id) else {
+        return Err(invalid_catalog_payload(format!(
+            "catalog checkpoint redo table id is not in catalog range: table_id={table_id}"
+        )));
+    };
+    if slot >= catalog_table_count {
+        return Err(invalid_catalog_payload(format!(
+            "catalog checkpoint redo table id out of range: table_id={table_id}, slot={slot}, catalog_table_count={catalog_table_count}"
+        )));
+    }
+    Ok(slot)
+}
+
 fn build_lwc_blocks_from_row_records(
     metadata: &TableMetadata,
     rows: &[RowRecord],
@@ -1011,7 +1028,7 @@ pub(crate) mod tests {
     mod checkpoint_tests {
         use super::super::*;
         use crate::buffer::{PoolGuards, PoolRole};
-        use crate::catalog::USER_OBJ_ID_START;
+        use crate::catalog::USER_TABLE_ID_START;
         use crate::catalog::tests::{open_catalog_test_engine, table1, table2};
         use crate::catalog::{CatalogCheckpointBatch, CatalogCheckpointScanStopReason};
         use crate::error::DataIntegrityError;
@@ -1106,7 +1123,7 @@ pub(crate) mod tests {
             let mut name = vec![b'x'; name_len];
             name[0] = b'a' + (column_no % 26) as u8;
             CatalogRedoEntry {
-                table_id: TableID::new(1),
+                table_id: TABLE_ID_COLUMNS,
                 kind: RowRedoKind::Insert(vec![
                     Val::from(table_id),
                     Val::from(column_no),
@@ -1144,7 +1161,8 @@ pub(crate) mod tests {
         }
 
         async fn catalog_root_rows(storage: &CatalogStorage, table_id: TableID) -> Vec<RowRecord> {
-            let root = storage.checkpoint_snapshot().unwrap().meta.table_roots[table_id.as_usize()];
+            let root = storage.checkpoint_snapshot().unwrap().meta.table_roots
+                [must_catalog_table_slot(table_id)];
             let table = storage.get_catalog_table(table_id).unwrap();
             let disk_pool_guard = storage.disk_pool.pool_guard();
             storage
@@ -1157,7 +1175,8 @@ pub(crate) mod tests {
             storage: &CatalogStorage,
             table_id: TableID,
         ) -> Vec<RowRecord> {
-            let root = storage.checkpoint_snapshot().unwrap().meta.table_roots[table_id.as_usize()];
+            let root = storage.checkpoint_snapshot().unwrap().meta.table_roots
+                [must_catalog_table_slot(table_id)];
             let rows = catalog_root_rows(storage, table_id).await;
             for (idx, row) in rows.iter().enumerate() {
                 assert_eq!(row.row_id, RowID::new(idx as u64));
@@ -1272,7 +1291,7 @@ pub(crate) mod tests {
                 first_retained_file_seq: 0,
                 sealed_redo_segments: Vec::new(),
                 catalog_ops: vec![CatalogRedoEntry {
-                    table_id: TableID::new(0),
+                    table_id: TABLE_ID_TABLES,
                     kind: RowRedoKind::DeleteByPrimaryKey(key),
                 }],
                 catalog_ddl_txn_count: 0,
@@ -1310,7 +1329,7 @@ pub(crate) mod tests {
                 let root = &mut snapshot.meta.table_roots[0];
                 assert_eq!(root.root_block_id, None);
                 assert_eq!(root.pivot_row_id, RowID::new(0));
-                root.table_id = TableID::new(1);
+                root.table_id = TABLE_ID_COLUMNS;
 
                 let guards = PoolGuards::builder()
                     .push(PoolRole::Meta, storage.meta_pool.pool_guard())
@@ -1330,7 +1349,10 @@ pub(crate) mod tests {
                     report.contains("catalog root table id mismatch"),
                     "{report}"
                 );
-                assert!(report.contains("root_table_id=1"), "{report}");
+                assert!(
+                    report.contains(&format!("root_table_id={TABLE_ID_COLUMNS}")),
+                    "{report}"
+                );
                 assert!(report.contains("slot_idx=0"), "{report}");
             });
         }
@@ -1348,13 +1370,14 @@ pub(crate) mod tests {
                     .checkpoint_snapshot()
                     .unwrap()
                     .catalog_replay_start_ts;
+                let invalid_table_id = catalog_table_id_from_slot(CATALOG_TABLE_ROOT_DESC_COUNT);
                 let batch = CatalogCheckpointBatch {
                     replay_start_ts,
                     safe_cts: replay_start_ts,
                     first_retained_file_seq: 0,
                     sealed_redo_segments: Vec::new(),
                     catalog_ops: vec![CatalogRedoEntry {
-                        table_id: TableID::new(CATALOG_TABLE_ROOT_DESC_COUNT as u64),
+                        table_id: invalid_table_id,
                         kind: RowRedoKind::Insert(Vec::new()),
                     }],
                     catalog_ddl_txn_count: 0,
@@ -1376,7 +1399,11 @@ pub(crate) mod tests {
                     "{report}"
                 );
                 assert!(
-                    report.contains(&format!("table_id={}", CATALOG_TABLE_ROOT_DESC_COUNT)),
+                    report.contains(&format!("table_id={invalid_table_id}")),
+                    "{report}"
+                );
+                assert!(
+                    report.contains(&format!("slot={}", CATALOG_TABLE_ROOT_DESC_COUNT)),
                     "{report}"
                 );
                 assert!(
@@ -1399,7 +1426,7 @@ pub(crate) mod tests {
             smol::block_on(async {
                 assert_checkpoint_rejects_delete_key(
                     "catalog-delete-key-non-primary",
-                    SelectKey::new(1, vec![Val::from(USER_OBJ_ID_START)]),
+                    SelectKey::new(1, vec![Val::from(USER_TABLE_ID_START)]),
                     "catalog checkpoint delete key is not primary key",
                 )
                 .await;
@@ -1413,7 +1440,7 @@ pub(crate) mod tests {
                     "catalog-delete-key-value-count",
                     SelectKey::new(
                         0,
-                        vec![Val::from(USER_OBJ_ID_START), Val::from(0u16)],
+                        vec![Val::from(USER_TABLE_ID_START), Val::from(0u16)],
                     ),
                     "catalog checkpoint delete key value count 2 does not match primary key column count 1",
                 )
@@ -1430,9 +1457,9 @@ pub(crate) mod tests {
                     open_catalog_test_engine(main_dir, Some("catalog-lwc-direct-build")).await;
 
                 let storage = &engine.catalog().storage;
-                let catalog_table = storage.get_catalog_table(TableID::new(1)).unwrap();
+                let catalog_table = storage.get_catalog_table(TABLE_ID_COLUMNS).unwrap();
                 let metadata = catalog_table.metadata();
-                let table_id = USER_OBJ_ID_START + 101;
+                let table_id = USER_TABLE_ID_START + 101;
 
                 let allocated_before = storage.meta_pool.allocated();
                 let rows = vec![
@@ -1472,15 +1499,15 @@ pub(crate) mod tests {
                     open_catalog_test_engine(main_dir, Some("catalog-root-delete-deltas")).await;
 
                 let storage = &engine.catalog().storage;
-                let table = storage.get_catalog_table(TableID::new(0)).unwrap();
-                let table_id = USER_OBJ_ID_START + 111;
+                let table = storage.get_catalog_table(TABLE_ID_TABLES).unwrap();
+                let table_id = USER_TABLE_ID_START + 111;
                 let rows = vec![RowRecord {
                     row_id: RowID::new(0),
                     vals: catalog_table_vals(table_id, 0),
                 }];
                 let root = build_unpublished_catalog_root(
                     storage,
-                    TableID::new(0),
+                    TABLE_ID_TABLES,
                     table.metadata(),
                     &rows,
                     Some(&[0]),
@@ -1504,8 +1531,8 @@ pub(crate) mod tests {
                     open_catalog_test_engine(main_dir, Some("catalog-root-duplicate-pk")).await;
 
                 let storage = &engine.catalog().storage;
-                let table = storage.get_catalog_table(TableID::new(0)).unwrap();
-                let table_id = USER_OBJ_ID_START + 112;
+                let table = storage.get_catalog_table(TABLE_ID_TABLES).unwrap();
+                let table_id = USER_TABLE_ID_START + 112;
                 let rows = vec![
                     RowRecord {
                         row_id: RowID::new(0),
@@ -1518,7 +1545,7 @@ pub(crate) mod tests {
                 ];
                 let root = build_unpublished_catalog_root(
                     storage,
-                    TableID::new(0),
+                    TABLE_ID_TABLES,
                     table.metadata(),
                     &rows,
                     None,
@@ -1581,7 +1608,7 @@ pub(crate) mod tests {
                 let engine = open_catalog_test_engine(main_dir, Some("catalog-meta-reclaim")).await;
                 let snap = engine.catalog().storage.checkpoint_snapshot().unwrap();
                 assert_eq!(snap.catalog_replay_start_ts, expected_replay_start_ts);
-                assert_eq!(snap.meta.next_table_id, USER_OBJ_ID_START);
+                assert_eq!(snap.meta.next_table_id, USER_TABLE_ID_START);
             });
         }
 
@@ -1694,7 +1721,7 @@ pub(crate) mod tests {
                     .checkpoint_snapshot()
                     .unwrap()
                     .catalog_replay_start_ts;
-                let table_id = USER_OBJ_ID_START + 4242;
+                let table_id = USER_TABLE_ID_START + 4242;
                 let batch = CatalogCheckpointBatch {
                     replay_start_ts,
                     safe_cts: replay_start_ts,
@@ -1702,11 +1729,11 @@ pub(crate) mod tests {
                     sealed_redo_segments: Vec::new(),
                     catalog_ops: vec![
                         CatalogRedoEntry {
-                            table_id: TableID::new(0),
+                            table_id: TABLE_ID_TABLES,
                             kind: RowRedoKind::Insert(vec![Val::from(table_id), Val::from(0u16)]),
                         },
                         CatalogRedoEntry {
-                            table_id: TableID::new(0),
+                            table_id: TABLE_ID_TABLES,
                             kind: RowRedoKind::DeleteByPrimaryKey(SelectKey::new(
                                 0,
                                 vec![Val::from(table_id)],
@@ -1747,16 +1774,16 @@ pub(crate) mod tests {
                 .await;
 
                 let storage = &engine.catalog().storage;
-                let table_id = USER_OBJ_ID_START + 5252;
+                let table_id = USER_TABLE_ID_START + 5252;
                 let batch = checkpoint_batch_with_ops(
                     storage,
                     vec![
                         CatalogRedoEntry {
-                            table_id: TableID::new(0),
+                            table_id: TABLE_ID_TABLES,
                             kind: RowRedoKind::Insert(vec![Val::from(table_id), Val::from(0u16)]),
                         },
                         CatalogRedoEntry {
-                            table_id: TableID::new(0),
+                            table_id: TABLE_ID_TABLES,
                             kind: RowRedoKind::UpdateByPrimaryKey(
                                 SelectKey::new(0, vec![Val::from(table_id)]),
                                 vec![UpdateCol {
@@ -1773,14 +1800,14 @@ pub(crate) mod tests {
                     .await
                     .unwrap();
 
-                let rows = catalog_root_rows(storage, TableID::new(0)).await;
+                let rows = catalog_root_rows(storage, TABLE_ID_TABLES).await;
                 let matching_rows = rows
                     .iter()
                     .filter(|row| row.vals[0] == Val::from(table_id))
                     .collect::<Vec<_>>();
                 assert_eq!(matching_rows.len(), 1);
                 assert_eq!(matching_rows[0].vals[1], Val::from(7u16));
-                assert_compact_catalog_root(storage, TableID::new(0)).await;
+                assert_compact_catalog_root(storage, TABLE_ID_TABLES).await;
             });
         }
 
@@ -1793,16 +1820,16 @@ pub(crate) mod tests {
                     open_catalog_test_engine(main_dir, Some("catalog-update-pk-column")).await;
 
                 let storage = &engine.catalog().storage;
-                let table_id = USER_OBJ_ID_START + 6262;
+                let table_id = USER_TABLE_ID_START + 6262;
                 let batch = checkpoint_batch_with_ops(
                     storage,
                     vec![
                         CatalogRedoEntry {
-                            table_id: TableID::new(0),
+                            table_id: TABLE_ID_TABLES,
                             kind: RowRedoKind::Insert(vec![Val::from(table_id), Val::from(0u16)]),
                         },
                         CatalogRedoEntry {
-                            table_id: TableID::new(0),
+                            table_id: TABLE_ID_TABLES,
                             kind: RowRedoKind::UpdateByPrimaryKey(
                                 SelectKey::new(0, vec![Val::from(table_id)]),
                                 vec![UpdateCol {
@@ -1851,7 +1878,7 @@ pub(crate) mod tests {
                 let batch = checkpoint_batch_with_ops(
                     storage,
                     vec![CatalogRedoEntry {
-                        table_id: TableID::new(0),
+                        table_id: TABLE_ID_TABLES,
                         kind: RowRedoKind::UpdateByPrimaryKey(
                             SelectKey::new(0, vec![Val::from(table_id)]),
                             vec![UpdateCol {
@@ -1867,14 +1894,14 @@ pub(crate) mod tests {
                     .await
                     .unwrap();
 
-                let rows = catalog_root_rows(storage, TableID::new(0)).await;
+                let rows = catalog_root_rows(storage, TABLE_ID_TABLES).await;
                 let matching_rows = rows
                     .iter()
                     .filter(|row| row.vals[0] == Val::from(table_id))
                     .collect::<Vec<_>>();
                 assert_eq!(matching_rows.len(), 1);
                 assert_eq!(matching_rows[0].vals[1], Val::from(9u16));
-                assert_compact_catalog_root(storage, TableID::new(0)).await;
+                assert_compact_catalog_root(storage, TABLE_ID_TABLES).await;
             });
         }
 
@@ -1936,13 +1963,13 @@ pub(crate) mod tests {
                 .await;
 
                 let storage = &engine.catalog().storage;
-                let table = storage.get_catalog_table(TableID::new(0)).unwrap();
+                let table = storage.get_catalog_table(TABLE_ID_TABLES).unwrap();
                 let root = CatalogTableRootDesc {
-                    table_id: TableID::new(0),
+                    table_id: TABLE_ID_TABLES,
                     root_block_id: None,
                     pivot_row_id: RowID::new(0),
                 };
-                let table_id = USER_OBJ_ID_START + 42;
+                let table_id = USER_TABLE_ID_START + 42;
                 let table_ops = vec![
                     RowRedoKind::Insert(vec![Val::from(table_id), Val::from(0u16)]),
                     RowRedoKind::DeleteByPrimaryKey(SelectKey::new(0, vec![Val::from(table_id)])),
@@ -1953,7 +1980,7 @@ pub(crate) mod tests {
                 let (next_root, blocks_changed) = storage
                     .apply_table_ops(
                         &mut mutable,
-                        TableID::new(0),
+                        TABLE_ID_TABLES,
                         table.metadata(),
                         root,
                         &table_ops,
@@ -1987,11 +2014,11 @@ pub(crate) mod tests {
                     .unwrap();
 
                 let storage = &engine.catalog().storage;
-                let table = storage.get_catalog_table(TableID::new(0)).unwrap();
+                let table = storage.get_catalog_table(TABLE_ID_TABLES).unwrap();
                 let root = storage.checkpoint_snapshot().unwrap().meta.table_roots[0];
                 assert!(root.root_block_id.is_some());
 
-                let table_id = USER_OBJ_ID_START + 4242;
+                let table_id = USER_TABLE_ID_START + 4242;
                 let table_ops = vec![
                     RowRedoKind::Insert(vec![Val::from(table_id), Val::from(0u16)]),
                     RowRedoKind::DeleteByPrimaryKey(SelectKey::new(0, vec![Val::from(table_id)])),
@@ -2002,7 +2029,7 @@ pub(crate) mod tests {
                 let (next_root, blocks_changed) = storage
                     .apply_table_ops(
                         &mut mutable,
-                        TableID::new(0),
+                        TABLE_ID_TABLES,
                         table.metadata(),
                         root,
                         &table_ops,
@@ -2091,7 +2118,7 @@ pub(crate) mod tests {
                 let snap1 = engine.catalog().storage.checkpoint_snapshot().unwrap();
                 let tables_root1 = snap1.meta.table_roots[0];
                 assert!(tables_root1.root_block_id.is_some());
-                assert_compact_catalog_root(&engine.catalog().storage, TableID::new(0)).await;
+                assert_compact_catalog_root(&engine.catalog().storage, TABLE_ID_TABLES).await;
 
                 let table2_id = table2(&engine).await;
                 engine
@@ -2103,7 +2130,7 @@ pub(crate) mod tests {
                 let snap2 = engine.catalog().storage.checkpoint_snapshot().unwrap();
                 let tables_root2 = snap2.meta.table_roots[0];
                 let rows =
-                    assert_compact_catalog_root(&engine.catalog().storage, TableID::new(0)).await;
+                    assert_compact_catalog_root(&engine.catalog().storage, TABLE_ID_TABLES).await;
 
                 assert!(tables_root2.root_block_id != tables_root1.root_block_id);
                 assert_eq!(tables_root2.pivot_row_id, RowID::new(rows.len() as u64));
@@ -2131,7 +2158,7 @@ pub(crate) mod tests {
                 expected_table_ids.sort();
                 assert_eq!(recovered_table_ids, expected_table_ids);
                 assert_eq!(
-                    assert_compact_catalog_root(&recovered.catalog().storage, TableID::new(0))
+                    assert_compact_catalog_root(&recovered.catalog().storage, TABLE_ID_TABLES)
                         .await
                         .len(),
                     rows.len()
@@ -2148,7 +2175,7 @@ pub(crate) mod tests {
                     open_catalog_test_engine(main_dir, Some("catalog-compact-large-append")).await;
 
                 let storage = &engine.catalog().storage;
-                let table_id = USER_OBJ_ID_START + 9000;
+                let table_id = USER_TABLE_ID_START + 9000;
                 storage
                     .apply_checkpoint_batch(
                         checkpoint_batch_with_ops(
@@ -2186,7 +2213,7 @@ pub(crate) mod tests {
 
                 let snap2 = storage.checkpoint_snapshot().unwrap();
                 let columns_root2 = snap2.meta.table_roots[1];
-                let rows = assert_compact_catalog_root(storage, TableID::new(1)).await;
+                let rows = assert_compact_catalog_root(storage, TABLE_ID_COLUMNS).await;
                 assert_eq!(rows.len(), 5);
                 assert_eq!(columns_root2.pivot_row_id, RowID::new(5));
                 let entries2 = storage

--- a/doradb-storage/src/catalog/storage/table_replay_silent_watermarks.rs
+++ b/doradb-storage/src/catalog/storage/table_replay_silent_watermarks.rs
@@ -3,7 +3,9 @@ use crate::catalog::CatalogTable;
 use crate::catalog::storage::CatalogDefinition;
 use crate::catalog::storage::object::SilentWatermarkObject;
 use crate::catalog::table::{TableColumnLayout, TableMetadata};
-use crate::catalog::{ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec};
+use crate::catalog::{
+    ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, catalog_table_id_from_slot,
+};
 use crate::error::{DataIntegrityError, Error, Result};
 use crate::id::{TableID, TrxID};
 use crate::row::ops::DeleteMvcc;
@@ -16,7 +18,7 @@ use semistr::SemiStr;
 use std::sync::OnceLock;
 
 /// Catalog table id for `catalog.table_replay_silent_watermarks`.
-pub(crate) const TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS: TableID = TableID::new(4);
+pub(crate) const TABLE_ID_TABLE_REPLAY_SILENT_WATERMARKS: TableID = catalog_table_id_from_slot(4);
 const COL_NO_TABLE_REPLAY_SILENT_WATERMARKS_TABLE_ID: usize = 0;
 const COL_NAME_TABLE_REPLAY_SILENT_WATERMARKS_TABLE_ID: &str = "table_id";
 const COL_NO_TABLE_REPLAY_SILENT_WATERMARKS_HEAP_REDO_START_TS: usize = 1;

--- a/doradb-storage/src/catalog/storage/tables.rs
+++ b/doradb-storage/src/catalog/storage/tables.rs
@@ -3,7 +3,9 @@ use crate::catalog::CatalogTable;
 use crate::catalog::storage::CatalogDefinition;
 use crate::catalog::storage::object::TableObject;
 use crate::catalog::table::{TableColumnLayout, TableMetadata};
-use crate::catalog::{ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec};
+use crate::catalog::{
+    ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, catalog_table_id_from_slot,
+};
 use crate::error::Result;
 use crate::id::TableID;
 use crate::row::ops::DeleteMvcc;
@@ -15,7 +17,7 @@ use semistr::SemiStr;
 use std::sync::OnceLock;
 
 /// Catalog table id for `catalog.tables`.
-pub(crate) const TABLE_ID_TABLES: TableID = TableID::new(0);
+pub(crate) const TABLE_ID_TABLES: TableID = catalog_table_id_from_slot(0);
 const COL_NO_TABLES_TABLE_ID: usize = 0;
 const COL_NAME_TABLES_TABLE_ID: &str = "table_id";
 const COL_NO_TABLES_NEXT_INDEX_NO: usize = 1;

--- a/doradb-storage/src/catalog/table.rs
+++ b/doradb-storage/src/catalog/table.rs
@@ -1681,6 +1681,7 @@ fn validate_primary_key_contract(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::catalog::storage::tables::TABLE_ID_TABLES;
     use crate::catalog::{
         CatalogCheckpointScanStopReason, ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey,
         IndexSpec, TableSpec,
@@ -1689,7 +1690,7 @@ mod tests {
         CompletionErrorKind, ConfigError, Error, ErrorKind, FatalError, InternalError,
         OperationError,
     };
-    use crate::id::{SessionID, TableID, TrxID};
+    use crate::id::{SessionID, TrxID};
     use crate::io::install_storage_backend_test_hook;
     use crate::lock::tests::{LockDebugEntryState, try_acquire};
     use crate::lock::{LockMode, LockOwner, LockOwnerGroup, LockResource};
@@ -3124,7 +3125,7 @@ mod tests {
             let table_id = create_table2_for_test(&engine).await;
             let mut session = engine.new_session().unwrap();
 
-            let err = session.drop_table(TableID::new(0)).await.unwrap_err();
+            let err = session.drop_table(TABLE_ID_TABLES).await.unwrap_err();
             assert_eq!(err.operation_error(), Some(OperationError::TableNotFound));
 
             let missing_user_table_id = table_id + 1000;

--- a/doradb-storage/src/file/fs.rs
+++ b/doradb-storage/src/file/fs.rs
@@ -4,7 +4,7 @@ use crate::buffer::{
     EvictReadSubmission, EvictSubmission, EvictableBufferPool, EvictablePoolStateMachine,
     PoolRequest, PoolRole, ReadSubmission, ReadonlyBufferPool,
 };
-use crate::catalog::USER_OBJ_ID_START;
+use crate::catalog::is_user_table;
 use crate::catalog::table::TableMetadata;
 use crate::component::{Component, ComponentRegistry, ShelfScope, Supplier};
 use crate::conf::FileSystemConfig;
@@ -1924,7 +1924,7 @@ impl FileSystem {
     /// Delete one deterministic user-table file.
     #[inline]
     pub(crate) fn delete_user_table_file(&self, table_id: TableID) -> Result<()> {
-        debug_assert!(table_id >= USER_OBJ_ID_START);
+        debug_assert!(is_user_table(table_id));
         match fs::remove_file(self.data_dir.join(user_table_file_name(table_id))) {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == IoErrorKind::NotFound => Ok(()),
@@ -1983,7 +1983,7 @@ impl FileSystem {
             let Some(table_id) = parse_user_table_file_name(&entry.file_name()) else {
                 continue;
             };
-            if table_id < USER_OBJ_ID_START {
+            if !is_user_table(table_id) {
                 continue;
             }
             if recovered_user_table_ids.contains(&table_id)
@@ -2126,7 +2126,7 @@ fn path_to_string(path: &Path, field: &str) -> String {
 
 #[inline]
 fn user_table_file_name(table_id: TableID) -> String {
-    debug_assert!(table_id >= USER_OBJ_ID_START);
+    debug_assert!(is_user_table(table_id));
     format!("{table_id:016x}.tbl")
 }
 
@@ -2138,7 +2138,7 @@ fn parse_user_table_file_name(file_name: &OsStr) -> Option<TableID> {
         return None;
     }
     let table_id = TableID::from_str_radix(table_id_hex, 16).ok()?;
-    (table_id >= USER_OBJ_ID_START).then_some(table_id)
+    is_user_table(table_id).then_some(table_id)
 }
 
 #[cfg(test)]
@@ -2152,7 +2152,7 @@ pub(crate) mod tests {
         test_persist_and_evict_page,
     };
     use crate::catalog::{
-        ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, USER_OBJ_ID_START,
+        ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, USER_TABLE_ID_START,
     };
     use crate::component::{DiskPoolConfig, IndexPoolConfig, MetaPoolConfig, RegistryBuilder};
     use crate::conf::{EngineConfig, EvictableBufferPoolConfig, TrxSysConfig};
@@ -2999,7 +2999,7 @@ pub(crate) mod tests {
                 .unwrap();
             let snapshot = mtb.load_snapshot().unwrap();
             assert_eq!(snapshot.catalog_replay_start_ts, MIN_SNAPSHOT_TS);
-            assert_eq!(snapshot.meta.next_table_id, USER_OBJ_ID_START);
+            assert_eq!(snapshot.meta.next_table_id, USER_TABLE_ID_START);
             assert!(mtb.active_root_unchecked().meta_block_id > BlockID::new(0));
         });
     }
@@ -3008,7 +3008,7 @@ pub(crate) mod tests {
     fn test_user_table_commit_submits_backend_fsync_after_root_writes() {
         smol::block_on(async {
             let (_temp_dir, fs) = build_test_fs();
-            let table_id = USER_OBJ_ID_START + 201;
+            let table_id = USER_TABLE_ID_START + 201;
             let mutable = fs
                 .create_table_file(table_id, make_metadata(), false)
                 .unwrap();
@@ -3036,7 +3036,7 @@ pub(crate) mod tests {
     fn test_user_table_commit_fsync_failure_keeps_active_root() {
         smol::block_on(async {
             let (_temp_dir, fs) = build_test_fs();
-            let table_id = USER_OBJ_ID_START + 202;
+            let table_id = USER_TABLE_ID_START + 202;
             let mutable = fs
                 .create_table_file(table_id, make_metadata(), false)
                 .unwrap();
@@ -3115,7 +3115,7 @@ pub(crate) mod tests {
             )
             .unwrap();
 
-            let table_id = USER_OBJ_ID_START + 130;
+            let table_id = USER_TABLE_ID_START + 130;
             let table_file = fs
                 .create_table_file(table_id, make_metadata(), false)
                 .unwrap();
@@ -3276,14 +3276,14 @@ pub(crate) mod tests {
                 .expect("valid table metadata"),
             );
             let mutable = fs
-                .create_table_file(USER_OBJ_ID_START, Arc::clone(&metadata), false)
+                .create_table_file(USER_TABLE_ID_START, Arc::clone(&metadata), false)
                 .unwrap();
             let (table_file, old_root) = mutable.commit(TrxID::new(1), false).await.unwrap();
             drop(old_root);
 
-            let path = fs.user_table_file_path(USER_OBJ_ID_START);
+            let path = fs.user_table_file_path(USER_TABLE_ID_START);
             assert!(
-                path.ends_with("0001000000000000.tbl"),
+                path.ends_with("0000000000000000.tbl"),
                 "unexpected user table file path: {path}"
             );
             assert!(Path::new(&path).exists());
@@ -3297,7 +3297,7 @@ pub(crate) mod tests {
     fn test_delete_user_table_file_is_idempotent() {
         smol::block_on(async {
             let (_temp_dir, fs) = build_test_fs();
-            let table_id = USER_OBJ_ID_START + 9;
+            let table_id = USER_TABLE_ID_START + 9;
             let metadata = Arc::new(
                 TableMetadata::try_new(
                     vec![ColumnSpec::new(
@@ -3327,10 +3327,10 @@ pub(crate) mod tests {
     #[test]
     fn test_cleanup_checkpoint_absent_user_table_files_filters_catalog_and_future_ids() {
         let (_temp_dir, fs) = build_test_fs();
-        let present_id = USER_OBJ_ID_START + 1;
-        let absent_id = USER_OBJ_ID_START + 2;
-        let future_id = USER_OBJ_ID_START + 5;
-        let catalog_path = fs.data_dir.join("1.tbl");
+        let present_id = USER_TABLE_ID_START + 1;
+        let absent_id = USER_TABLE_ID_START + 2;
+        let future_id = USER_TABLE_ID_START + 5;
+        let catalog_path = fs.data_dir.join("8000000000000000.tbl");
         let present_path = fs.data_dir.join(user_table_file_name(present_id));
         let absent_path = fs.data_dir.join(user_table_file_name(absent_id));
         let future_path = fs.data_dir.join(user_table_file_name(future_id));
@@ -3340,8 +3340,11 @@ pub(crate) mod tests {
         write(&future_path, b"future").unwrap();
 
         let checkpointed_tables = [present_id].into_iter().collect::<FastHashSet<_>>();
-        fs.cleanup_checkpoint_absent_user_table_files(USER_OBJ_ID_START + 4, &checkpointed_tables)
-            .unwrap();
+        fs.cleanup_checkpoint_absent_user_table_files(
+            USER_TABLE_ID_START + 4,
+            &checkpointed_tables,
+        )
+        .unwrap();
 
         assert!(catalog_path.exists());
         assert!(present_path.exists());
@@ -3352,15 +3355,15 @@ pub(crate) mod tests {
     #[test]
     fn test_cleanup_checkpoint_absent_user_table_files_skips_non_files() {
         let (_temp_dir, fs) = build_test_fs();
-        let dir_id = USER_OBJ_ID_START + 1;
-        let absent_id = USER_OBJ_ID_START + 2;
+        let dir_id = USER_TABLE_ID_START + 1;
+        let absent_id = USER_TABLE_ID_START + 2;
         let dir_path = fs.data_dir.join(user_table_file_name(dir_id));
         let absent_path = fs.data_dir.join(user_table_file_name(absent_id));
         create_dir(&dir_path).unwrap();
         write(&absent_path, b"absent").unwrap();
 
         fs.cleanup_checkpoint_absent_user_table_files(
-            USER_OBJ_ID_START + 4,
+            USER_TABLE_ID_START + 4,
             &FastHashSet::default(),
         )
         .unwrap();
@@ -3372,10 +3375,10 @@ pub(crate) mod tests {
     #[test]
     fn test_cleanup_recovery_absent_user_table_files_keeps_recovered_and_deferred_drop_files() {
         let (_temp_dir, fs) = build_test_fs();
-        let recovered_id = USER_OBJ_ID_START + 1;
-        let deferred_drop_id = USER_OBJ_ID_START + 2;
-        let orphan_id = USER_OBJ_ID_START + 7;
-        let catalog_path = fs.data_dir.join("2.tbl");
+        let recovered_id = USER_TABLE_ID_START + 1;
+        let deferred_drop_id = USER_TABLE_ID_START + 2;
+        let orphan_id = USER_TABLE_ID_START + 7;
+        let catalog_path = fs.data_dir.join("8000000000000000.tbl");
         let recovered_path = fs.data_dir.join(user_table_file_name(recovered_id));
         let deferred_drop_path = fs.data_dir.join(user_table_file_name(deferred_drop_id));
         let orphan_path = fs.data_dir.join(user_table_file_name(orphan_id));

--- a/doradb-storage/src/file/meta_block.rs
+++ b/doradb-storage/src/file/meta_block.rs
@@ -200,7 +200,7 @@ impl Deser for MultiTableMetaBlockData {
         let (idx, next_table_id) = TableID::deser(input, start_idx)?;
         if next_table_id > USER_TABLE_ID_LIMIT {
             return Err(invalid_payload(format!(
-                "next_table_id {next_table_id} exceeds user table id limit {USER_TABLE_ID_LIMIT}"
+                "next_table_id {next_table_id} is out of user table id range (limit: {USER_TABLE_ID_LIMIT})"
             )));
         }
         let (idx, table_count) = input.deser_u32(idx)?;

--- a/doradb-storage/src/file/meta_block.rs
+++ b/doradb-storage/src/file/meta_block.rs
@@ -1,5 +1,5 @@
 use crate::bitmap::AllocMap;
-use crate::catalog::USER_OBJ_ID_START;
+use crate::catalog::USER_TABLE_ID_LIMIT;
 use crate::catalog::table::{TableBriefMetadata, TableBriefMetadataSerView, TableMetadata};
 use crate::error::{DataIntegrityError, Error, Result};
 use crate::file::cow_file::SUPER_BLOCK_ID;
@@ -198,9 +198,9 @@ impl Deser for MultiTableMetaBlockData {
     #[inline]
     fn deser<S: Serde + ?Sized>(input: &S, start_idx: usize) -> Result<(usize, Self)> {
         let (idx, next_table_id) = TableID::deser(input, start_idx)?;
-        if next_table_id < USER_OBJ_ID_START {
+        if next_table_id > USER_TABLE_ID_LIMIT {
             return Err(invalid_payload(format!(
-                "next_table_id {next_table_id} is below user table id start {USER_OBJ_ID_START}"
+                "next_table_id {next_table_id} exceeds user table id limit {USER_TABLE_ID_LIMIT}"
             )));
         }
         let (idx, table_count) = input.deser_u32(idx)?;
@@ -362,6 +362,7 @@ mod tests {
     use super::*;
     use crate::catalog::{
         ActiveIndexSpec, ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec,
+        USER_TABLE_ID_START, catalog_table_id_from_slot,
     };
     use crate::file::multi_table_file::CATALOG_TABLE_ROOT_DESC_COUNT;
     use crate::file::table_file::ActiveRoot;
@@ -644,7 +645,7 @@ mod tests {
 
     #[test]
     fn test_multi_table_meta_block_serde_none_root_block_id() {
-        let mut meta = MultiTableMetaBlock::new(USER_OBJ_ID_START + 9);
+        let mut meta = MultiTableMetaBlock::new(USER_TABLE_ID_START + 9);
         meta.first_redo_log_seq = 7;
         meta.table_roots[0].root_block_id = None;
         meta.table_roots[0].pivot_row_id = RowID::new(0);
@@ -662,9 +663,16 @@ mod tests {
         let (_, decoded) = MultiTableMetaBlockData::deser(&data[..], 0).unwrap();
         assert_eq!(decoded.next_table_id, meta.next_table_id);
         assert_eq!(decoded.first_redo_log_seq, 7);
-        assert_eq!(decoded.table_roots[0].table_id, TableID::new(0));
+        assert_eq!(
+            decoded.table_roots[0].table_id,
+            catalog_table_id_from_slot(0)
+        );
         assert_eq!(decoded.table_roots[0].root_block_id, None);
         assert_eq!(decoded.table_roots[0].pivot_row_id, RowID::new(0));
+        assert_eq!(
+            decoded.table_roots[1].table_id,
+            catalog_table_id_from_slot(1)
+        );
         assert_eq!(decoded.table_roots[1].root_block_id, NonZeroU64::new(42));
         assert_eq!(decoded.table_roots[1].pivot_row_id, RowID::new(128));
         assert_eq!(decoded.table_roots.len(), CATALOG_TABLE_ROOT_DESC_COUNT);

--- a/doradb-storage/src/file/mod.rs
+++ b/doradb-storage/src/file/mod.rs
@@ -14,7 +14,6 @@ pub(crate) use self::tests::{test_block_id, test_file_id};
 use crate::id::{BlockID, FileID};
 
 use crate::buffer::{ReadSubmission, ReadonlyWriteLease};
-use crate::catalog::USER_OBJ_ID_START;
 use crate::error::{
     CompletionErrorKind, ConfigError, Error, IoError, ResourceError, Result, StorageOp,
 };
@@ -42,13 +41,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 pub(crate) const UNTRACKED_FILE_ID: FileID = FileID::MAX;
 
 /// Reserved persisted-file identity of the shared index-pool swap file.
-pub(crate) const INDEX_POOL_SWAP_FILE_ID: FileID = FileID::new(USER_OBJ_ID_START.as_u64() - 3);
+pub(crate) const INDEX_POOL_SWAP_FILE_ID: FileID = FileID::new(u64::MAX - 3);
 
 /// Reserved persisted-file identity of the shared mem-pool swap file.
-pub(crate) const MEM_POOL_SWAP_FILE_ID: FileID = FileID::new(USER_OBJ_ID_START.as_u64() - 2);
+pub(crate) const MEM_POOL_SWAP_FILE_ID: FileID = FileID::new(u64::MAX - 2);
 
 /// Reserved persisted-file identity of `catalog.mtb`.
-pub(crate) const CATALOG_MTB_FILE_ID: FileID = FileID::new(USER_OBJ_ID_START.as_u64() - 1);
+pub(crate) const CATALOG_MTB_FILE_ID: FileID = FileID::new(u64::MAX - 1);
 
 /// Physical persisted-block identity for cache lookup and shared-storage IO.
 ///
@@ -826,7 +825,7 @@ mod tests {
     use super::*;
     use crate::catalog::table::TableMetadata;
     use crate::catalog::{
-        ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, USER_OBJ_ID_START,
+        ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, USER_TABLE_ID_START,
     };
     use crate::compression::BitPackable;
     use crate::file::fs::tests::{TestFileSystem, build_test_fs};
@@ -870,7 +869,7 @@ mod tests {
     async fn committed_test_table_file() -> (TempDir, TestFileSystem, Arc<TableFile>) {
         let (temp_dir, fs) = build_test_fs();
         let mutable = fs
-            .create_table_file(USER_OBJ_ID_START + 801, build_test_metadata(), false)
+            .create_table_file(USER_TABLE_ID_START + 801, build_test_metadata(), false)
             .unwrap();
         let (table_file, old_root) = mutable.commit(TrxID::new(1), false).await.unwrap();
         drop(old_root);

--- a/doradb-storage/src/file/multi_table_file.rs
+++ b/doradb-storage/src/file/multi_table_file.rs
@@ -1,6 +1,6 @@
 use crate::bitmap::AllocMap;
 use crate::buffer::ReadonlyBufferPool;
-use crate::catalog::USER_OBJ_ID_START;
+use crate::catalog::{USER_TABLE_ID_LIMIT, USER_TABLE_ID_START, catalog_table_id_from_slot};
 use crate::error::{
     DataIntegrityError, Error, FileKind, InternalError, IoError, ResourceError, Result,
 };
@@ -40,7 +40,7 @@ pub(crate) use crate::file::CATALOG_MTB_FILE_ID;
 pub(crate) use tests::publish_first_redo_log_seq_for_test;
 
 /// On-disk format version of `catalog.mtb`.
-pub(crate) const CATALOG_MTB_VERSION: u64 = 4;
+pub(crate) const CATALOG_MTB_VERSION: u64 = 5;
 /// Reserved number of catalog logical-table root descriptors.
 pub(crate) const CATALOG_TABLE_ROOT_DESC_COUNT: usize = 5;
 /// Initial sparse-file size for `catalog.mtb`.
@@ -94,10 +94,10 @@ impl MultiTableMetaBlock {
     pub(crate) fn new(next_table_id: TableID) -> Self {
         let mut table_roots = [CatalogTableRootDesc::default(); CATALOG_TABLE_ROOT_DESC_COUNT];
         for (idx, root) in table_roots.iter_mut().enumerate() {
-            root.table_id = TableID::from(idx);
+            root.table_id = catalog_table_id_from_slot(idx);
         }
         MultiTableMetaBlock {
-            next_table_id: next_table_id.max(USER_OBJ_ID_START),
+            next_table_id,
             first_redo_log_seq: 0,
             table_roots,
         }
@@ -121,7 +121,7 @@ impl MultiTableActiveRoot {
             MIN_SNAPSHOT_TS,
             SUPER_BLOCK_ID,
             alloc_map,
-            MultiTableMetaBlock::new(USER_OBJ_ID_START),
+            MultiTableMetaBlock::new(USER_TABLE_ID_START),
         )
     }
 
@@ -334,9 +334,9 @@ impl MutableMultiTableFile {
                 root.root_ts
             )));
         }
-        if next_table_id < USER_OBJ_ID_START {
+        if next_table_id > USER_TABLE_ID_LIMIT {
             return Err(catalog_root_descriptor_invariant(format!(
-                "next_table_id={next_table_id}, minimum={USER_OBJ_ID_START}"
+                "next_table_id={next_table_id}, user_table_id_limit={USER_TABLE_ID_LIMIT}"
             )));
         }
         for root in &table_roots {
@@ -709,14 +709,14 @@ mod tests {
                 .unwrap();
             let s0 = mtb.load_snapshot().unwrap();
             assert_eq!(s0.catalog_replay_start_ts, MIN_SNAPSHOT_TS);
-            assert_eq!(s0.meta.next_table_id, USER_OBJ_ID_START);
+            assert_eq!(s0.meta.next_table_id, USER_TABLE_ID_START);
             assert_eq!(s0.meta.first_redo_log_seq, 0);
             let meta_block_id_0 = mtb.active_root_unchecked().meta_block_id;
             assert!(meta_block_id_0 > test_block_id(0));
 
             let mut roots = [CatalogTableRootDesc::default(); CATALOG_TABLE_ROOT_DESC_COUNT];
             for (idx, root) in roots.iter_mut().enumerate() {
-                root.table_id = TableID::new(idx as u64);
+                root.table_id = catalog_table_id_from_slot(idx);
                 root.root_block_id = NonZeroU64::new((idx + 10) as u64);
                 root.pivot_row_id = RowID::new((idx * 100) as u64);
             }
@@ -724,7 +724,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(7),
-                USER_OBJ_ID_START + 16,
+                USER_TABLE_ID_START + 16,
                 roots,
             )
             .await;
@@ -738,7 +738,7 @@ mod tests {
                 .unwrap();
             let s1 = mtb2.load_snapshot().unwrap();
             assert_eq!(s1.catalog_replay_start_ts, TrxID::new(7));
-            assert_eq!(s1.meta.next_table_id, USER_OBJ_ID_START + 16);
+            assert_eq!(s1.meta.next_table_id, USER_TABLE_ID_START + 16);
             assert_eq!(s1.meta.first_redo_log_seq, 0);
             assert_eq!(s1.meta.table_roots, roots);
 
@@ -767,13 +767,13 @@ mod tests {
 
             let mut roots = [CatalogTableRootDesc::default(); CATALOG_TABLE_ROOT_DESC_COUNT];
             for (idx, root) in roots.iter_mut().enumerate() {
-                root.table_id = TableID::new(idx as u64);
+                root.table_id = catalog_table_id_from_slot(idx);
             }
             publish_checkpoint_for_test(
                 &mtb,
                 background_writes,
                 TrxID::new(8),
-                USER_OBJ_ID_START + 5,
+                USER_TABLE_ID_START + 5,
                 roots,
             )
             .await;
@@ -807,7 +807,7 @@ mod tests {
 
             let mut roots = [CatalogTableRootDesc::default(); CATALOG_TABLE_ROOT_DESC_COUNT];
             for (idx, root) in roots.iter_mut().enumerate() {
-                root.table_id = TableID::new(idx as u64);
+                root.table_id = catalog_table_id_from_slot(idx);
             }
 
             let meta_block_id_0 = mtb.active_root_unchecked().meta_block_id;
@@ -815,7 +815,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(3),
-                USER_OBJ_ID_START + 1,
+                USER_TABLE_ID_START + 1,
                 roots,
             )
             .await;
@@ -824,7 +824,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(4),
-                USER_OBJ_ID_START + 2,
+                USER_TABLE_ID_START + 2,
                 roots,
             )
             .await;
@@ -957,7 +957,7 @@ mod tests {
 
             let mut roots_v1 = [CatalogTableRootDesc::default(); CATALOG_TABLE_ROOT_DESC_COUNT];
             for (idx, root) in roots_v1.iter_mut().enumerate() {
-                root.table_id = TableID::new(idx as u64);
+                root.table_id = catalog_table_id_from_slot(idx);
                 root.root_block_id = NonZeroU64::new((idx + 10) as u64);
                 root.pivot_row_id = RowID::new((idx as u64) + 1);
             }
@@ -965,7 +965,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(3),
-                USER_OBJ_ID_START + 1,
+                USER_TABLE_ID_START + 1,
                 roots_v1,
             )
             .await;
@@ -978,7 +978,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(4),
-                USER_OBJ_ID_START + 2,
+                USER_TABLE_ID_START + 2,
                 roots_v2,
             )
             .await;
@@ -1018,7 +1018,7 @@ mod tests {
 
             let mut roots_v1 = [CatalogTableRootDesc::default(); CATALOG_TABLE_ROOT_DESC_COUNT];
             for (idx, root) in roots_v1.iter_mut().enumerate() {
-                root.table_id = TableID::new(idx as u64);
+                root.table_id = catalog_table_id_from_slot(idx);
                 root.root_block_id = NonZeroU64::new((idx + 20) as u64);
                 root.pivot_row_id = RowID::new((idx as u64) + 10);
             }
@@ -1026,7 +1026,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(5),
-                USER_OBJ_ID_START + 10,
+                USER_TABLE_ID_START + 10,
                 roots_v1,
             )
             .await;
@@ -1038,7 +1038,7 @@ mod tests {
                 &mtb,
                 background_writes,
                 TrxID::new(6),
-                USER_OBJ_ID_START + 11,
+                USER_TABLE_ID_START + 11,
                 roots_v2,
             )
             .await;

--- a/doradb-storage/src/recovery/mod.rs
+++ b/doradb-storage/src/recovery/mod.rs
@@ -1219,7 +1219,7 @@ mod tests {
     use crate::catalog::{
         ActiveIndexSpec, ColumnAttributes, ColumnSpec, IndexAttributes, IndexColumnObject,
         IndexKey, IndexObject, IndexOrder, IndexSpec, TableMetadata, TableObject, TableSpec,
-        USER_OBJ_ID_START,
+        USER_TABLE_ID_START,
     };
     use crate::conf::{EngineConfig, EvictableBufferPoolConfig, FileSystemConfig, TrxSysConfig};
     use crate::engine::Engine;
@@ -1966,7 +1966,7 @@ mod tests {
             deletion_cutoff_ts: TrxID::new(9),
         };
         validate_create_table_reloaded_root_ts(
-            USER_OBJ_ID_START,
+            USER_TABLE_ID_START,
             TrxID::new(10),
             root_before_create,
             false,
@@ -1979,7 +1979,7 @@ mod tests {
             deletion_cutoff_ts: TrxID::new(10),
         };
         let err = validate_create_table_reloaded_root_ts(
-            USER_OBJ_ID_START,
+            USER_TABLE_ID_START,
             TrxID::new(10),
             pending_without_later_root,
             true,
@@ -1999,7 +1999,7 @@ mod tests {
             deletion_cutoff_ts: TrxID::new(10),
         };
         validate_create_table_reloaded_root_ts(
-            USER_OBJ_ID_START,
+            USER_TABLE_ID_START,
             TrxID::new(10),
             pending_with_later_root,
             true,
@@ -2018,7 +2018,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-            let unknown_table_id = USER_OBJ_ID_START + 142;
+            let unknown_table_id = USER_TABLE_ID_START + 142;
             let mut recovery = log_recovery_for_engine(&engine, TrxID::new(10));
 
             recovery
@@ -2058,7 +2058,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-            let unknown_table_id = USER_OBJ_ID_START + 143;
+            let unknown_table_id = USER_TABLE_ID_START + 143;
 
             let mut dml_recovery = log_recovery_for_engine(&engine, TrxID::new(10));
             let err = dml_recovery

--- a/doradb-storage/src/table/mod.rs
+++ b/doradb-storage/src/table/mod.rs
@@ -1487,7 +1487,7 @@ pub(crate) mod tests {
     use crate::catalog::tests::table2;
     use crate::catalog::{
         ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec, TableSpec,
-        USER_OBJ_ID_START,
+        USER_TABLE_ID_START,
     };
     use crate::conf::{EngineConfig, EvictableBufferPoolConfig, FileSystemConfig, TrxSysConfig};
     use crate::engine::Engine;
@@ -1549,7 +1549,7 @@ pub(crate) mod tests {
 
     #[inline]
     pub(crate) fn test_user_table_id(offset: u64) -> TableID {
-        USER_OBJ_ID_START
+        USER_TABLE_ID_START
             .checked_add(offset)
             .expect("test user table id offset overflow")
     }

--- a/doradb-storage/src/table/recover.rs
+++ b/doradb-storage/src/table/recover.rs
@@ -183,7 +183,7 @@ mod tests {
     use super::ensure_recovery_index_insert;
     use crate::buffer::guard::PageGuard;
     use crate::buffer::page::PAGE_SIZE;
-    use crate::catalog::{TableMetadata, USER_OBJ_ID_START};
+    use crate::catalog::{TableMetadata, USER_TABLE_ID_START};
     use crate::error::{DataIntegrityError, Error, RecoveryDuplicateKey};
     use crate::id::RowID;
     use crate::id::{PageID, TrxID};
@@ -494,7 +494,7 @@ mod tests {
                 .build()
                 .await
                 .unwrap();
-            let table_id = USER_OBJ_ID_START + 99;
+            let table_id = USER_TABLE_ID_START + 99;
             let table_file_path = engine.inner().table_fs.user_table_file_path(table_id);
             let (table_spec, index_specs) = drop_table_test_spec();
             let metadata =

--- a/doradb-storage/src/trx/mod.rs
+++ b/doradb-storage/src/trx/mod.rs
@@ -2518,7 +2518,7 @@ pub(crate) mod tests {
     /// Add one redo log entry for tests that need a non-readonly transaction.
     #[inline]
     pub(crate) fn add_pseudo_redo_log_entry(trx: &mut Transaction) {
-        use crate::catalog::USER_OBJ_ID_START;
+        use crate::catalog::USER_TABLE_ID_START;
 
         static PSEUDO_SYSBENCH_VAR1: [u8; 60] = [3; 60];
         static PSEUDO_SYSBENCH_VAR2: [u8; 120] = [4; 120];
@@ -2527,7 +2527,7 @@ pub(crate) mod tests {
             // Simulate one sysbench record:
             // uint64 + int32 + int32 + char(60) + char(120)
             inner.redo_mut().insert_dml(
-                USER_OBJ_ID_START,
+                USER_TABLE_ID_START,
                 RowRedo {
                     page_id: PageID::new(0),
                     row_id: RowID::new(0),

--- a/doradb-storage/src/trx/stmt.rs
+++ b/doradb-storage/src/trx/stmt.rs
@@ -703,6 +703,7 @@ impl Drop for Statement<'_> {
 pub(crate) mod tests {
     use super::*;
     use crate::buffer::PoolRole;
+    use crate::catalog::storage::tables::TABLE_ID_TABLES;
     use crate::conf::{EngineConfig, EvictableBufferPoolConfig, TrxSysConfig};
     use crate::engine::Engine;
     use crate::error::{FatalError, InternalError, OperationError};
@@ -890,7 +891,7 @@ pub(crate) mod tests {
             let catalog_table = engine
                 .catalog()
                 .storage
-                .get_catalog_table(TableID::new(0))
+                .get_catalog_table(TABLE_ID_TABLES)
                 .unwrap();
             let mut session = engine.new_session().unwrap();
             let mut trx = session.begin_trx().unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved separation between catalog data and user table data, reducing the chance of ID overlap during normal operation, recovery, and restart.
  * Fixed user-table file naming and cleanup so only valid user tables are matched and removed.
  * Strengthened validation for saved metadata and checkpoint loading to reject out-of-range table IDs earlier.
  * Updated built-in catalog table handling to use consistent slot-based identifiers, improving reliability when opening or reloading system tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->