### PR TITLE
chore: remove global namespace lock

### DIFF
--- a/docs/backlogs/closed/000153-remove-obsolete-global-catalog-namespace-lock.md
+++ b/docs/backlogs/closed/000153-remove-obsolete-global-catalog-namespace-lock.md
@@ -43,3 +43,11 @@ When a backlog item is moved to `docs/backlogs/closed/`, append:
 - Reference: <task/issue/pr reference>
 - Closed At: <YYYY-MM-DD>
 ```
+
+## Close Reason
+
+- Type: implemented
+- Detail: Removed the obsolete catalog-wide logical lock; CREATE now uses atomic per-ID publication, DROP uses table-local locking with post-lock revalidation, and distinct-table DDL concurrency regressions cover checkpoint-drain isolation.
+- Closed By: backlog close
+- Reference: Direct implementation requested by user
+- Closed At: 2026-07-11

--- a/docs/transaction-system.md
+++ b/docs/transaction-system.md
@@ -230,12 +230,18 @@ deletes acquire transaction-lifetime `TableMetadata(S)` followed by
 secondary-index write undo. Repeated writes to the same table reuse the
 transaction lock cache rather than re-entering the lock manager.
 
-`CREATE TABLE` acquires a session-owned `CatalogNamespace(X)` before allocating
-the user table id and holds it through catalog-row writes, provisional
-table-file publication, runtime table construction, catalog DDL commit, and
-catalog runtime publication. The initial table-file root uses the create
-transaction STS as `root_ts`; catalog commit is held until file/runtime staging
-succeeds, and the runtime is inserted only after the durable catalog commit.
+`CREATE TABLE` does not acquire a logical lock. The atomic table-id allocator
+assigns a distinct id before the operation creates its deterministic table
+file, stages catalog rows, or builds the per-id runtime. The initial table-file
+root uses the create transaction STS as `root_ts`; catalog commit is held until
+file/runtime staging succeeds, and the runtime is inserted into the concurrent
+per-id catalog map only after the durable catalog commit.
+
+`DROP TABLE` prechecks the id-only runtime and catalog row, acquires
+`TableMetadata(X)` followed by `TableData(X)`, and then revalidates the target
+under those table-local locks before crossing the terminal lifecycle gate. A
+drop that waits for an already-admitted checkpoint publisher therefore does
+not delay CREATE or DROP for unrelated table ids.
 Recovery, checkpoint, purge, and no-transaction catalog replay
 remain outside logical lock acquisition because they run at internal lifecycle
 boundaries rather than through foreground sessions and waiters.

--- a/doradb-storage/src/catalog/table.rs
+++ b/doradb-storage/src/catalog/table.rs
@@ -1092,10 +1092,6 @@ pub(crate) async fn create_table_for_session(
     let engine = ctx.engine.clone();
     let guards = ctx.pool_guards.clone();
     reject_user_table_primary_key_indexes(&index_specs, "create table")?;
-    let _namespace_lock = engine
-        .lock_manager()
-        .acquire_catalog_namespace_lock(ctx.owner, ctx.owner_group)
-        .await?;
 
     let table_id = engine.catalog().next_table_id();
     let metadata = Arc::new(TableMetadata::try_new(
@@ -1228,17 +1224,12 @@ pub(crate) async fn drop_table_for_session(session: SessionPin, table_id: TableI
     let ctx = SessionDdlContext::new(&session)?;
     let engine = ctx.engine.clone();
     let lock_manager = engine.lock_manager();
-    // Keep this guard alive until the catalog entry is transitioned to dropped
-    // state so table identity changes remain namespace-serialized.
-    let _namespace_lock = lock_manager
-        .acquire_catalog_namespace_lock(ctx.owner, ctx.owner_group)
-        .await?;
-
-    let table = validated_drop_table_target(&ctx.pool_guards, &engine, table_id).await?;
+    validated_drop_table_target(&ctx.pool_guards, &engine, table_id).await?;
     lock_manager.reject_table_ddl_explicit_session_lock(table_id, ctx.owner, "drop table")?;
     let mut table_locks = lock_manager
         .acquire_table_ddl_locks(table_id, ctx.owner, ctx.owner_group)
         .await?;
+    let table = validated_drop_table_target(&ctx.pool_guards, &engine, table_id).await?;
     engine.trx_sys.ensure_runtime_healthy()?;
 
     let mut trx = session.begin_trx("begin transaction")?;
@@ -2378,55 +2369,74 @@ mod tests {
     }
 
     #[test]
-    fn test_create_table_waits_on_catalog_namespace_lock() {
+    fn test_concurrent_create_table_publishes_distinct_tables() {
         smol::block_on(async {
             let temp_dir = TempDir::new().unwrap();
             let engine =
                 evictable_test_engine(&temp_dir, 64u64 * 1024 * 1024, "redo_testsys").await;
-            let _ = create_table2_for_test(&engine).await;
-            let blocker = LockOwner::Session(SessionID::new(91_400));
-            assert!(
-                try_acquire(
-                    engine.lock_manager(),
-                    LockResource::CatalogNamespace,
-                    LockMode::Exclusive,
-                    blocker,
-                )
-                .unwrap()
-            );
-
-            let mut session = engine.new_session().unwrap();
-            let waiting_owner = LockOwner::Session(session.id());
-            let create_task = smol::spawn(async move {
-                session
-                    .create_table(
-                        TableSpec::new(vec![ColumnSpec::new(
-                            "id",
-                            crate::value::ValKind::I32,
-                            ColumnAttributes::empty(),
-                        )]),
-                        vec![IndexSpec::new(vec![IndexKey::new(0)], IndexAttributes::UK)],
-                    )
-                    .await
+            let mut session1 = engine.new_session().unwrap();
+            let mut session2 = engine.new_session().unwrap();
+            let (table_spec, index_specs) = drop_table_test_spec();
+            let create1 = smol::spawn({
+                let table_spec = table_spec.clone();
+                let index_specs = index_specs.clone();
+                async move { session1.create_table(table_spec, index_specs).await }
             });
+            let create2 =
+                smol::spawn(async move { session2.create_table(table_spec, index_specs).await });
 
-            wait_for_lock_entry(
-                &engine,
-                waiting_owner,
-                LockResource::CatalogNamespace,
-                LockMode::Exclusive,
-                LockDebugEntryState::Waiting,
-            )
-            .await;
+            let table_id1 = create1.await.unwrap();
+            let table_id2 = create2.await.unwrap();
+            assert_ne!(table_id1, table_id2);
 
-            assert_eq!(engine.lock_manager().release_owner(blocker), 1);
-            let table_id = create_task.await.unwrap();
-            assert!(engine.catalog().get_table(table_id).await.is_some());
-            assert!(!has_lock_resource(
-                &engine,
-                waiting_owner,
-                LockResource::CatalogNamespace,
-            ));
+            let verify_session = engine.new_session().unwrap();
+            let guards = verify_session.pool_guards();
+            for table_id in [table_id1, table_id2] {
+                assert!(engine.catalog().get_table(table_id).await.is_some());
+                assert!(
+                    engine
+                        .catalog()
+                        .storage
+                        .tables()
+                        .find_uncommitted_by_id(&guards, table_id)
+                        .await
+                        .unwrap()
+                        .is_some()
+                );
+                assert!(
+                    !engine
+                        .catalog()
+                        .storage
+                        .columns()
+                        .list_uncommitted_by_table_id(&guards, table_id)
+                        .await
+                        .unwrap()
+                        .is_empty()
+                );
+                assert!(
+                    !engine
+                        .catalog()
+                        .storage
+                        .indexes()
+                        .list_uncommitted_by_table_id(&guards, table_id)
+                        .await
+                        .unwrap()
+                        .is_empty()
+                );
+                assert!(
+                    !engine
+                        .catalog()
+                        .storage
+                        .index_columns()
+                        .list_uncommitted_by_table_id(&guards, table_id)
+                        .await
+                        .unwrap()
+                        .is_empty()
+                );
+                assert!(
+                    Path::new(&engine.inner().table_fs.user_table_file_path(table_id)).exists()
+                );
+            }
         });
     }
 
@@ -3242,11 +3252,6 @@ mod tests {
                     TableTerminal::Live
                 );
                 assert!(engine.catalog().get_table(table_id).await.is_some());
-                assert!(!has_lock_resource(
-                    &engine,
-                    owner,
-                    LockResource::CatalogNamespace,
-                ));
                 assert!(has_lock_entry(
                     &engine,
                     owner,
@@ -3275,6 +3280,77 @@ mod tests {
                 ));
                 session.drop_table(table_id).await.unwrap();
             }
+        });
+    }
+
+    #[test]
+    fn test_drop_waiting_on_checkpoint_does_not_block_other_table_drop() {
+        smol::block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let engine = lightweight_test_engine(&temp_dir, "redo_testsys_lightweight").await;
+            let table_id = create_table2_for_test(&engine).await;
+            let other_table_id = create_table2_for_test(&engine).await;
+            let table = table_for_internal_assertion(&engine, table_id);
+            let (root_lease, publish_lease) = begin_checkpoint_publish_for_test(&table);
+
+            let mut waiting_session = engine.new_session().unwrap();
+            let mut waiting_drop = Box::pin(waiting_session.drop_table(table_id));
+            assert!(matches!(
+                futures::poll!(waiting_drop.as_mut()),
+                std::task::Poll::Pending
+            ));
+            assert_eq!(table.lifecycle.inspect_terminal(), TableTerminal::Dropping);
+
+            let mut other_session = engine.new_session().unwrap();
+            other_session.drop_table(other_table_id).await.unwrap();
+            assert!(engine.catalog().get_table(other_table_id).await.is_none());
+            assert_eq!(table.lifecycle.inspect_terminal(), TableTerminal::Dropping);
+
+            drop(publish_lease);
+            waiting_drop.await.unwrap();
+            drop(root_lease);
+        });
+    }
+
+    #[test]
+    fn test_drop_waiting_on_checkpoint_does_not_block_create_table() {
+        smol::block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let engine = lightweight_test_engine(&temp_dir, "redo_testsys_lightweight").await;
+            let table_id = create_table2_for_test(&engine).await;
+            let table = table_for_internal_assertion(&engine, table_id);
+            let (root_lease, publish_lease) = begin_checkpoint_publish_for_test(&table);
+
+            let mut waiting_session = engine.new_session().unwrap();
+            let mut waiting_drop = Box::pin(waiting_session.drop_table(table_id));
+            assert!(matches!(
+                futures::poll!(waiting_drop.as_mut()),
+                std::task::Poll::Pending
+            ));
+            assert_eq!(table.lifecycle.inspect_terminal(), TableTerminal::Dropping);
+
+            let mut create_session = engine.new_session().unwrap();
+            let (table_spec, index_specs) = drop_table_test_spec();
+            let created_table_id = create_session
+                .create_table(table_spec, index_specs)
+                .await
+                .unwrap();
+            assert_ne!(created_table_id, table_id);
+            assert!(engine.catalog().get_table(created_table_id).await.is_some());
+            assert!(
+                Path::new(
+                    &engine
+                        .inner()
+                        .table_fs
+                        .user_table_file_path(created_table_id)
+                )
+                .exists()
+            );
+            assert_eq!(table.lifecycle.inspect_terminal(), TableTerminal::Dropping);
+
+            drop(publish_lease);
+            waiting_drop.await.unwrap();
+            drop(root_lease);
         });
     }
 
@@ -3494,11 +3570,6 @@ mod tests {
             assert!(Path::new(&table_file_path).exists());
             session.drop_table(table_id).await.unwrap();
 
-            assert!(!has_lock_resource(
-                &engine,
-                owner,
-                LockResource::CatalogNamespace,
-            ));
             assert!(!has_lock_resource(
                 &engine,
                 owner,

--- a/doradb-storage/src/engine.rs
+++ b/doradb-storage/src/engine.rs
@@ -951,7 +951,7 @@ mod tests {
             let root = TempDir::new().unwrap();
             let engine = test_engine_config_for(root.path()).build().await.unwrap();
             let engine_ref = engine.new_ref().unwrap();
-            let resource = LockResource::CatalogNamespace;
+            let resource = LockResource::TableMetadata(TableID::new(10));
             let owner = LockOwner::Session(SessionID::new(10));
 
             assert!(

--- a/doradb-storage/src/lock/mod.rs
+++ b/doradb-storage/src/lock/mod.rs
@@ -1,7 +1,7 @@
 //! Logical metadata and table-data lock manager primitives.
 //!
 //! This module is the standalone core for RFC-0016 logical locks. It tracks
-//! catalog, table metadata, and table data resources independently from the
+//! table metadata and table data resources independently from the
 //! engine/session/transaction lifecycle wiring that later phases will add.
 
 mod state;
@@ -29,8 +29,7 @@ pub(crate) type StmtNo = u64;
 /// multi-resource operations:
 ///
 /// ```text
-/// CatalogNamespace
-///   -> TableMetadata(table_id ascending)
+/// TableMetadata(table_id ascending)
 ///   -> TableData(table_id ascending)
 ///   -> row undo/CDB ownership
 /// ```
@@ -40,8 +39,6 @@ pub(crate) type StmtNo = u64;
 /// acquired only after the relevant `TableData` lock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum LockResource {
-    /// Catalog-wide table identity or namespace invariants.
-    CatalogNamespace,
     /// Table definition and metadata for one table.
     TableMetadata(TableID),
     /// Multi-granularity table-data root above row ownership.
@@ -167,23 +164,6 @@ impl Drop for FreshLockGuard<'_> {
     }
 }
 
-/// Scoped catalog namespace lock guard.
-pub(crate) struct ScopedCatalogNamespaceLock<'a> {
-    lock_manager: &'a LockManager,
-    resource: LockResource,
-    owner: LockOwner,
-    fresh: bool,
-}
-
-impl Drop for ScopedCatalogNamespaceLock<'_> {
-    #[inline]
-    fn drop(&mut self) {
-        if self.fresh {
-            self.lock_manager.release(self.resource, self.owner);
-        }
-    }
-}
-
 /// Scoped table DDL lock guard for metadata and data resources.
 pub(crate) struct ScopedTableDdlLocks<'a> {
     lock_manager: &'a LockManager,
@@ -293,25 +273,6 @@ impl LockManager {
     ) -> Result<LockGrant> {
         self.acquire_with_group(resource, mode, owner, Some(owner_group))
             .await
-    }
-
-    /// Acquires the catalog namespace lock for grouped catalog DDL.
-    #[inline]
-    pub(crate) async fn acquire_catalog_namespace_lock<'a>(
-        &'a self,
-        owner: LockOwner,
-        owner_group: LockOwnerGroup,
-    ) -> Result<ScopedCatalogNamespaceLock<'a>> {
-        let resource = LockResource::CatalogNamespace;
-        let grant = self
-            .acquire_grouped_with_grant(resource, LockMode::Exclusive, owner, owner_group)
-            .await?;
-        Ok(ScopedCatalogNamespaceLock {
-            lock_manager: self,
-            resource,
-            owner,
-            fresh: grant == LockGrant::Fresh,
-        })
     }
 
     /// Acquires the ordered metadata/data locks for a grouped table operation.
@@ -1077,7 +1038,7 @@ fn validate_mode(resource: LockResource, mode: LockMode) -> Result<()> {
 #[inline]
 fn mode_is_valid(resource: LockResource, mode: LockMode) -> bool {
     match resource {
-        LockResource::CatalogNamespace | LockResource::TableMetadata(_) => {
+        LockResource::TableMetadata(_) => {
             matches!(mode, LockMode::Shared | LockMode::Exclusive)
         }
         LockResource::TableData(_) => true,
@@ -1087,11 +1048,11 @@ fn mode_is_valid(resource: LockResource, mode: LockMode) -> bool {
 /// Returns whether two modes can be granted together on the same resource.
 ///
 /// Compatibility is symmetric and is checked only after both modes have been
-/// validated for the resource. Catalog and table-metadata resources use the
-/// ordinary shared/exclusive matrix:
+/// validated for the resource. Table-metadata resources use the ordinary
+/// shared/exclusive matrix:
 ///
 /// ```text
-/// CatalogNamespace and TableMetadata
+/// TableMetadata
 ///
 ///       | S | X
 /// ------+---+---
@@ -1114,7 +1075,7 @@ fn mode_is_valid(resource: LockResource, mode: LockMode) -> bool {
 #[inline]
 fn modes_are_compatible(resource: LockResource, left: LockMode, right: LockMode) -> bool {
     match resource {
-        LockResource::CatalogNamespace | LockResource::TableMetadata(_) => {
+        LockResource::TableMetadata(_) => {
             matches!((left, right), (LockMode::Shared, LockMode::Shared))
         }
         LockResource::TableData(_) => matches!(
@@ -1134,12 +1095,11 @@ fn modes_are_compatible(resource: LockResource, left: LockMode, right: LockMode)
 ///
 /// Coverage is directional: a mode can cover another mode even when the reverse
 /// is not true. The lock manager uses this for reentrant acquisitions and
-/// immediate same-owner conversions. Catalog and table-metadata resources use
-/// the ordinary hierarchy where `X` covers every valid request and `S` covers
-/// only `S`.
+/// immediate same-owner conversions. Table-metadata resources use the ordinary
+/// hierarchy where `X` covers every valid request and `S` covers only `S`.
 ///
 /// ```text
-/// CatalogNamespace and TableMetadata
+/// TableMetadata
 ///
 /// held \ requested | S | X
 /// -----------------+---+---
@@ -1164,9 +1124,7 @@ fn modes_are_compatible(resource: LockResource, left: LockMode, right: LockMode)
 #[inline]
 fn mode_covers(resource: LockResource, held: LockMode, requested: LockMode) -> bool {
     match resource {
-        LockResource::CatalogNamespace | LockResource::TableMetadata(_) => {
-            held == LockMode::Exclusive || held == requested
-        }
+        LockResource::TableMetadata(_) => held == LockMode::Exclusive || held == requested,
         LockResource::TableData(_) => match held {
             LockMode::IntentShared => requested == LockMode::IntentShared,
             LockMode::IntentExclusive => {
@@ -1477,37 +1435,33 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn metadata_and_catalog_only_accept_shared_and_exclusive() {
-        for resource in [
-            LockResource::CatalogNamespace,
-            table_metadata(TableID::new(1)),
-        ] {
-            assert!(LockMode::Shared.validate_for(resource).is_ok());
-            assert!(LockMode::Exclusive.validate_for(resource).is_ok());
-            assert_operation_err(
-                LockMode::IntentShared.validate_for(resource),
-                OperationError::InvalidLockMode,
-            );
-            assert_operation_err(
-                LockMode::IntentExclusive.validate_for(resource),
-                OperationError::InvalidLockMode,
-            );
-            assert!(modes_are_compatible(
-                resource,
-                LockMode::Shared,
-                LockMode::Shared
-            ));
-            assert!(!modes_are_compatible(
-                resource,
-                LockMode::Shared,
-                LockMode::Exclusive
-            ));
-            assert!(!modes_are_compatible(
-                resource,
-                LockMode::Exclusive,
-                LockMode::Shared
-            ));
-        }
+    fn metadata_only_accepts_shared_and_exclusive() {
+        let resource = table_metadata(TableID::new(1));
+        assert!(LockMode::Shared.validate_for(resource).is_ok());
+        assert!(LockMode::Exclusive.validate_for(resource).is_ok());
+        assert_operation_err(
+            LockMode::IntentShared.validate_for(resource),
+            OperationError::InvalidLockMode,
+        );
+        assert_operation_err(
+            LockMode::IntentExclusive.validate_for(resource),
+            OperationError::InvalidLockMode,
+        );
+        assert!(modes_are_compatible(
+            resource,
+            LockMode::Shared,
+            LockMode::Shared
+        ));
+        assert!(!modes_are_compatible(
+            resource,
+            LockMode::Shared,
+            LockMode::Exclusive
+        ));
+        assert!(!modes_are_compatible(
+            resource,
+            LockMode::Exclusive,
+            LockMode::Shared
+        ));
     }
 
     #[test]
@@ -1860,48 +1814,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn nested_catalog_namespace_scope_does_not_release_outer_grant() {
-        smol::block_on(async {
-            let manager = LockManager::new();
-            let resource = LockResource::CatalogNamespace;
-            let owner = session(SessionID::new(7));
-            let owner_group = group(SessionID::new(7));
-
-            let outer = manager
-                .acquire_catalog_namespace_lock(owner, owner_group)
-                .await
-                .unwrap();
-            assert!(manager.owner_holds(resource, owner, LockMode::Exclusive));
-            {
-                let inner = manager
-                    .acquire_catalog_namespace_lock(owner, owner_group)
-                    .await
-                    .unwrap();
-                let snapshot = debug_snapshot(&manager);
-                assert_eq!(
-                    count_entries(&snapshot, resource, LockDebugEntryState::Granted),
-                    1
-                );
-                drop(inner);
-            }
-
-            assert!(manager.owner_holds(resource, owner, LockMode::Exclusive));
-            let snapshot = debug_snapshot(&manager);
-            assert_eq!(
-                count_entries(&snapshot, resource, LockDebugEntryState::Granted),
-                1
-            );
-            drop(outer);
-            assert!(!manager.owner_holds(resource, owner, LockMode::Exclusive));
-            let snapshot = debug_snapshot(&manager);
-            assert_eq!(
-                count_entries(&snapshot, resource, LockDebugEntryState::Granted),
-                0
-            );
-        });
-    }
-
-    #[test]
     fn same_group_covered_request_grants_without_waiting() {
         smol::block_on(async {
             let manager = Arc::new(LockManager::new());
@@ -2108,7 +2020,7 @@ pub(crate) mod tests {
     fn async_acquire_waits_behind_conflict_and_completes_after_release() {
         smol::block_on(async {
             let manager = Arc::new(LockManager::new());
-            let resource = LockResource::CatalogNamespace;
+            let resource = table_metadata(TableID::new(70));
             assert!(
                 try_acquire(&manager, resource, LockMode::Exclusive, trx(TrxID::new(1))).unwrap()
             );
@@ -2142,7 +2054,7 @@ pub(crate) mod tests {
     fn duplicate_async_acquire_reuses_existing_waiter() {
         smol::block_on(async {
             let manager = Arc::new(LockManager::new());
-            let resource = LockResource::CatalogNamespace;
+            let resource = table_metadata(TableID::new(71));
             let owner = trx(TrxID::new(2));
             assert!(
                 try_acquire(&manager, resource, LockMode::Exclusive, trx(TrxID::new(1))).unwrap()
@@ -2214,7 +2126,7 @@ pub(crate) mod tests {
     fn cancelled_acquire_removes_queued_waiter() {
         smol::block_on(async {
             let manager = Arc::new(LockManager::new());
-            let resource = LockResource::CatalogNamespace;
+            let resource = table_metadata(TableID::new(72));
             assert!(
                 try_acquire(&manager, resource, LockMode::Exclusive, trx(TrxID::new(1))).unwrap()
             );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Concurrent table creation is now supported more effectively, allowing simultaneous operations to publish distinct tables.

- **Bug Fixes**
  - Improved concurrency for `DROP TABLE` and `CREATE TABLE` operations while checkpoints are publishing.
  - Added validation safeguards to prevent conflicting table operations and maintain catalog consistency.
  - Updated locking behavior to reduce unnecessary operation blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->