### PR TITLE
chore: refactor internal API of vmap, rmap and row read/write access

### DIFF
--- a/docs/unsafe-usage-baseline.md
+++ b/docs/unsafe-usage-baseline.md
@@ -8,7 +8,7 @@
 
 | module | files | unsafe | transmute | new_unchecked | assume_init | // SAFETY: |
 |---|---:|---:|---:|---:|---:|---:|
-| buffer | 13 | 52 | 0 | 0 | 0 | 46 |
+| buffer | 13 | 51 | 0 | 0 | 0 | 45 |
 | latch | 4 | 40 | 0 | 0 | 0 | 36 |
 | row | 3 | 6 | 0 | 0 | 0 | 6 |
 | index | 21 | 13 | 0 | 0 | 3 | 7 |
@@ -18,14 +18,14 @@
 | file | 8 | 12 | 0 | 0 | 2 | 12 |
 | log | 6 | 0 | 0 | 0 | 0 | 0 |
 | recovery | 5 | 0 | 0 | 0 | 0 | 0 |
-| **total** | **82** | **153** | **0** | **0** | **6** | **132** |
+| **total** | **82** | **152** | **0** | **0** | **6** | **131** |
 
 ## File Hotspots (top 40)
 
 | file | module | unsafe | // SAFETY: |
 |---|---|---:|---:|
 | `doradb-storage/src/latch/rwlock.rs` | latch | 20 | 17 |
-| `doradb-storage/src/buffer/guard.rs` | buffer | 15 | 15 |
+| `doradb-storage/src/buffer/guard.rs` | buffer | 14 | 14 |
 | `doradb-storage/src/latch/mutex.rs` | latch | 14 | 13 |
 | `doradb-storage/src/buffer/util.rs` | buffer | 10 | 5 |
 | `doradb-storage/src/buffer/evict.rs` | buffer | 9 | 9 |

--- a/doradb-storage/src/buffer/frame.rs
+++ b/doradb-storage/src/buffer/frame.rs
@@ -44,7 +44,7 @@ pub(crate) struct BufferFrame {
     persisted_block_id: AtomicU64,
     /// Context of this buffer frame. It can store additinal contextual information
     /// about the page, e.g. undo map of row page.
-    pub(crate) ctx: Option<Box<FrameContext>>,
+    pub(super) ctx: Option<Box<FrameContext>>,
     pub(super) page: *mut Page,
 }
 
@@ -169,6 +169,36 @@ impl BufferFrame {
             create_cts,
         ))));
     }
+
+    /// Returns the runtime row-version map or panics on an invalid page state.
+    #[inline]
+    pub(super) fn unwrap_vmap(&self) -> &RowVersionMap {
+        match self.ctx.as_deref() {
+            Some(FrameContext::RowVerMap(ver)) => ver,
+            Some(FrameContext::RowRecoveryMap(_)) => {
+                panic!("row-version map required after recovery")
+            }
+            None => panic!("row page requires frame context"),
+        }
+    }
+
+    /// Returns the recovery map when this frame is still being recovered.
+    #[inline]
+    pub(super) fn try_rmap(&self) -> Option<&RowRecoveryMap> {
+        match self.ctx.as_deref() {
+            Some(FrameContext::RowRecoveryMap(rec)) => Some(rec),
+            Some(FrameContext::RowVerMap(_)) | None => None,
+        }
+    }
+
+    /// Returns mutable recovery state while the frame is exclusively latched.
+    #[inline]
+    pub(super) fn try_rmap_mut(&mut self) -> Option<&mut RowRecoveryMap> {
+        match self.ctx.as_deref_mut() {
+            Some(FrameContext::RowRecoveryMap(rec)) => Some(rec),
+            Some(FrameContext::RowVerMap(_)) | None => None,
+        }
+    }
 }
 
 impl Default for BufferFrame {
@@ -233,58 +263,21 @@ impl From<u8> for FrameKind {
 }
 
 /// Optional page-specific context stored beside a frame header.
-pub(crate) enum FrameContext {
+pub(super) enum FrameContext {
     RowVerMap(RowVersionMap),
     RowRecoveryMap(RowRecoveryMap),
 }
 
-impl FrameContext {
-    /// Returns the row-version map required by normal runtime operations.
-    ///
-    /// Recovery-time callers must use [`FrameContext::recover`] or match the
-    /// context variant directly until the page is refreshed after redo replay.
-    #[inline]
-    pub(crate) fn expect_vmap(&self) -> &RowVersionMap {
-        match self {
-            FrameContext::RowVerMap(ver) => ver,
-            FrameContext::RowRecoveryMap(_) => {
-                panic!("row-version map required after recovery")
-            }
-        }
-    }
-
-    /// Returns the recovery map when this context stores one.
-    #[inline]
-    pub(crate) fn recover(&self) -> Option<&RowRecoveryMap> {
-        match self {
-            FrameContext::RowRecoveryMap(rec) => Some(rec),
-            FrameContext::RowVerMap(_) => None,
-        }
-    }
-
-    /// Returns the mutable recovery map when this context stores one.
-    #[inline]
-    pub(crate) fn recover_mut(&mut self) -> Option<&mut RowRecoveryMap> {
-        match self {
-            FrameContext::RowRecoveryMap(rec) => Some(rec),
-            FrameContext::RowVerMap(_) => None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::FrameContext;
+    use super::BufferFrame;
     use crate::catalog::{ColumnAttributes, ColumnSpec, TableMetadata};
     use crate::id::TrxID;
-    use crate::recovery::RowRecoveryMap;
-    use crate::trx::ver_map::RowVersionMap;
     use crate::value::ValKind;
     use std::sync::Arc;
 
-    #[test]
-    fn test_expect_vmap_returns_version_map() {
-        let metadata = TableMetadata::try_new(
+    fn metadata() -> TableMetadata {
+        TableMetadata::try_new(
             vec![ColumnSpec::new(
                 "id",
                 ValKind::I64,
@@ -292,16 +285,34 @@ mod tests {
             )],
             Vec::new(),
         )
-        .expect("valid table metadata");
-        let ctx = FrameContext::RowVerMap(RowVersionMap::new(Arc::clone(&metadata.col), 1));
+        .expect("valid table metadata")
+    }
 
-        assert!(Arc::ptr_eq(&ctx.expect_vmap().column_layout, &metadata.col));
+    #[test]
+    fn test_row_context_accessors_distinguish_runtime_and_recovery_maps() {
+        let metadata = metadata();
+        let mut frame = BufferFrame::default();
+        frame.init_undo_map(Arc::clone(&metadata.col), 1);
+
+        assert!(Arc::ptr_eq(
+            &frame.unwrap_vmap().column_layout,
+            &metadata.col
+        ));
+        assert!(frame.try_rmap().is_none());
+
+        frame.init_recover_map(TrxID::new(7));
+        assert_eq!(
+            frame.try_rmap().map(|map| map.create_cts()),
+            Some(TrxID::new(7))
+        );
+        assert!(frame.try_rmap_mut().is_some());
     }
 
     #[test]
     #[should_panic(expected = "row-version map required after recovery")]
-    fn test_expect_vmap_rejects_recovery_map() {
-        let ctx = FrameContext::RowRecoveryMap(RowRecoveryMap::new(TrxID::new(1)));
-        let _ = ctx.expect_vmap();
+    fn test_runtime_map_accessor_rejects_recovery_map() {
+        let mut frame = BufferFrame::default();
+        frame.init_recover_map(TrxID::new(1));
+        let _ = frame.unwrap_vmap();
     }
 }

--- a/doradb-storage/src/buffer/guard.rs
+++ b/doradb-storage/src/buffer/guard.rs
@@ -1,5 +1,5 @@
 use crate::buffer::PoolGuard;
-use crate::buffer::frame::{BufferFrame, FrameContext};
+use crate::buffer::frame::BufferFrame;
 use crate::buffer::page::{PAGE_SIZE, VersionedPageID};
 use crate::error::{
     Validation,
@@ -8,11 +8,13 @@ use crate::error::{
 use crate::id::PageID;
 use crate::latch::{GuardState, LatchFallbackMode, RawHybridGuard};
 use crate::ptr::UnsafePtr;
+use crate::recovery::RowRecoveryMap;
+use crate::row::RowPage;
+use crate::trx::ver_map::RowVersionMap;
 use either::Either;
 use std::future::{Future, ready};
 use std::marker::PhantomData;
 use std::mem;
-use std::sync::atomic::AtomicBool;
 
 /// Typed access interface shared by page latch guards.
 pub(crate) trait PageGuard<T: 'static> {
@@ -692,21 +694,6 @@ impl<T: 'static> PageSharedGuard<T> {
         }
     }
 
-    /// Returns the frame context and typed page reference.
-    #[inline]
-    pub(crate) fn ctx_and_page(&self) -> (&FrameContext, &T) {
-        let bf = self.bf();
-        let undo_map = bf.ctx.as_ref().unwrap();
-        let page = page_ref(bf);
-        (undo_map, page)
-    }
-
-    /// Returns the frame dirty flag associated with this shared page guard.
-    #[inline]
-    pub(crate) fn dirty_flag(&self) -> &AtomicBool {
-        self.bf().dirty_flag()
-    }
-
     /// Converts this shared guard back into a facade and optionally marks dirty.
     #[inline]
     pub(crate) fn facade(self, dirty: bool) -> FacadePageGuard<T> {
@@ -720,6 +707,20 @@ impl<T: 'static> PageSharedGuard<T> {
             captured_generation: self.captured_generation,
             _marker: PhantomData,
         }
+    }
+}
+
+impl PageSharedGuard<RowPage> {
+    /// Returns the row-version map required by normal runtime operations.
+    #[inline]
+    pub(crate) fn unwrap_vmap(&self) -> &RowVersionMap {
+        self.bf().unwrap_vmap()
+    }
+
+    /// Returns the recovery map when this guard protects a recovering row page.
+    #[inline]
+    pub(crate) fn try_rmap(&self) -> Option<&RowRecoveryMap> {
+        self.bf().try_rmap()
     }
 }
 
@@ -810,19 +811,6 @@ impl<T: 'static> PageExclusiveGuard<T> {
         self.frame_mut()
     }
 
-    /// Returns mutable access to both the frame context and typed page image.
-    #[inline]
-    pub(crate) fn ctx_and_page_mut(&mut self) -> (&mut FrameContext, &mut T) {
-        let bf = self.frame_mut();
-        debug_assert_page_cast::<T>(bf);
-        let ctx = bf.ctx.as_mut().unwrap().as_mut();
-        // SAFETY: the exclusive page guard owns the latch exclusively, the
-        // retained pool guard keeps the page allocation alive, and callers only
-        // construct typed guards after validating the frame's logical page kind.
-        let page = unsafe { &mut *(bf.page.cast::<T>()) };
-        (ctx, page)
-    }
-
     /// Converts this exclusive guard back into a facade and optionally marks dirty.
     #[inline]
     #[cfg_attr(not(test), expect(dead_code, reason = "pending dead-code audit"))]
@@ -852,6 +840,26 @@ impl<T: 'static> PageExclusiveGuard<T> {
     #[inline]
     pub(crate) fn is_dirty(&self) -> bool {
         self.bf().is_dirty()
+    }
+}
+
+impl PageExclusiveGuard<RowPage> {
+    /// Returns the row-version map required by normal runtime operations.
+    #[inline]
+    pub(crate) fn unwrap_vmap(&self) -> &RowVersionMap {
+        self.bf().unwrap_vmap()
+    }
+
+    /// Returns the recovery map when this guard protects a recovering row page.
+    #[inline]
+    pub(crate) fn try_rmap(&self) -> Option<&RowRecoveryMap> {
+        self.bf().try_rmap()
+    }
+
+    /// Returns the mutable recovery map for a recovering row page.
+    #[inline]
+    pub(crate) fn try_rmap_mut(&mut self) -> Option<&mut RowRecoveryMap> {
+        self.frame_mut().try_rmap_mut()
     }
 }
 

--- a/doradb-storage/src/index/row_page_index.rs
+++ b/doradb-storage/src/index/row_page_index.rs
@@ -964,8 +964,7 @@ impl<P: BufferPool> RowPageIndex<P> {
 
                     match inserted.create_redo {
                         Ok(Some(create_cts)) => {
-                            let (ctx, _) = new_page.ctx_and_page_mut();
-                            ctx.expect_vmap().set_create_cts(create_cts);
+                            new_page.unwrap_vmap().set_create_cts(create_cts);
                         }
                         Ok(None) => (),
                         Err(err) => {
@@ -2857,8 +2856,7 @@ mod tests {
                     )
                     .await
                     .expect("test insert-page allocation should succeed");
-                let (ctx, _) = page_guard.ctx_and_page();
-                let create_cts = ctx.expect_vmap().create_cts();
+                let create_cts = page_guard.unwrap_vmap().create_cts();
                 assert!(create_cts > TrxID::new(0));
 
                 let page_id = page_guard.page_id();

--- a/doradb-storage/src/recovery/mod.rs
+++ b/doradb-storage/src/recovery/mod.rs
@@ -626,16 +626,12 @@ impl<'a> RecoveryCoordinator<'a> {
             .unwrap();
 
         let create_cts = page_guard
-            .bf()
-            .ctx
-            .as_ref()
-            .and_then(|ctx| ctx.recover())
+            .try_rmap()
             .map(|rec| rec.create_cts())
             .unwrap_or(TrxID::new(0));
         let max_row_count = page_guard.page().header.max_row_count as usize;
         page_guard.bf_mut().init_undo_map(col_layout, max_row_count);
-        let (ctx, _) = page_guard.ctx_and_page_mut();
-        ctx.expect_vmap().set_create_cts(create_cts);
+        page_guard.unwrap_vmap().set_create_cts(create_cts);
         Ok(())
     }
 

--- a/doradb-storage/src/table/access.rs
+++ b/doradb-storage/src/table/access.rs
@@ -34,10 +34,7 @@ use crate::table::{
     index_key_is_changed, index_key_replace, read_latest_index_key, row_len,
     unique_key_from_full_row,
 };
-use crate::trx::row::{
-    FindOldVersion, IndexCandidateRecheck, ReadAllRows, ReadLatestRow, RowReadAccess,
-    RowWriteAccess,
-};
+use crate::trx::row::{FindOldVersion, IndexCandidateRecheck, ReadLatestRow, RowReadAccess};
 use crate::trx::stmt::StmtEffects;
 use crate::trx::undo::{IndexBranch, OwnedRowUndo, RowUndoKind};
 use crate::trx::{MIN_SNAPSHOT_TS, SharedTrxStatus, TrxContext, TrxRuntime, trx_is_committed};
@@ -738,8 +735,7 @@ impl<'a> UserTableAccessor<'a> {
                     else {
                         continue;
                     };
-                    let (page_ctx, page) = page_guard.ctx_and_page();
-                    let access = RowReadAccess::new(page, page_ctx, page.row_idx(candidate.row_id));
+                    let access = page_guard.read_row_by_id(candidate.row_id);
                     let recheck = IndexCandidateRecheck {
                         index_no,
                         unique,
@@ -1427,8 +1423,7 @@ impl<'a> UserTableAccessor<'a> {
                 }
             }
         };
-        let (ctx, page) = page_guard.ctx_and_page();
-        let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
+        let access = page_guard.read_row_by_id(row_id);
         // To safely delete an index entry, we need to make sure
         // no version with matched keys can be found in either page
         // data or version chain. Hot row pages still have undo chains, unlike
@@ -1491,8 +1486,7 @@ impl<'a> UserTableAccessor<'a> {
                 }
             }
         };
-        let (ctx, page) = page_guard.ctx_and_page();
-        let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
+        let access = page_guard.read_row_by_id(row_id);
         // To safely delete an index entry, we need to make sure
         // no version with matched keys can be found in either page
         // data or version chain. Hot row pages still have undo chains, unlike
@@ -1603,9 +1597,7 @@ impl<'a> UserTableAccessor<'a> {
             return Ok(LinkForUniqueIndex::DuplicateKey);
         };
         let metadata = self.metadata();
-        let (page_ctx, page) = new_guard.ctx_and_page();
-        let mut new_access =
-            RowWriteAccess::new(page, page_ctx, new_guard.dirty_flag(), page.row_idx(new_id));
+        let mut new_access = new_guard.write_row_by_id(new_id);
         let undo_vals = new_access.row().calc_delta(metadata.col.as_ref(), &old_row);
         // The new hot row owns the key now. The terminal branch preserves the
         // old cold image for snapshots that still need to see it. The branch is
@@ -1686,21 +1678,14 @@ impl<'a> UserTableAccessor<'a> {
         // snapshots. If this transaction can see it, the new claim is a real
         // duplicate.
         let metadata = self.metadata();
-        let (page_ctx, page) = old_guard.ctx_and_page();
-        let old_access = RowReadAccess::new(page, page_ctx, page.row_idx(old_id));
+        let old_access = old_guard.read_row_by_id(old_id);
         match old_access.find_old_version_for_unique_key(metadata, index_no, key_vals, rt.ctx()) {
             FindOldVersion::None => Ok(LinkForUniqueIndex::NotNeeded),
             FindOldVersion::DuplicateKey => Ok(LinkForUniqueIndex::DuplicateKey),
             FindOldVersion::WriteConflict => Ok(LinkForUniqueIndex::WriteConflict),
             FindOldVersion::Ok(old_row, cts, old_entry) => {
                 // row latch is enough, because row lock is already acquired.
-                let (page_ctx, page) = new_guard.ctx_and_page();
-                let mut new_access = RowWriteAccess::new(
-                    page,
-                    page_ctx,
-                    new_guard.dirty_flag(),
-                    page.row_idx(new_id),
-                );
+                let mut new_access = new_guard.write_row_by_id(new_id);
                 let undo_vals = new_access.row().calc_delta(metadata.col.as_ref(), &old_row);
                 new_access.link_for_unique_index(
                     SelectKey::new(index_no, key_vals.to_vec()),
@@ -2402,9 +2387,8 @@ impl<'a> UserTableAccessor<'a> {
         F: for<'m, 'p> FnMut(&'m TableColumnLayout, Row<'p>) -> bool,
     {
         self.mem_scan(guards, |page_guard| {
-            let (ctx, page) = page_guard.ctx_and_page();
-            let col_layout = ctx.expect_vmap().column_layout.as_ref();
-            for row_access in ReadAllRows::new(page, ctx) {
+            let col_layout = page_guard.unwrap_vmap().column_layout.as_ref();
+            for row_access in page_guard.read_all_rows() {
                 if !row_action(col_layout, row_access.row()) {
                     return false;
                 }
@@ -2434,8 +2418,7 @@ impl<'a> UserTableAccessor<'a> {
         }
         let metadata = self.metadata();
         self.mem_scan_from(guards, root_snapshot.pivot_row_id(), |page_guard| {
-            let (page_ctx, page) = page_guard.ctx_and_page();
-            for row_access in ReadAllRows::new(page, page_ctx) {
+            for row_access in page_guard.read_all_rows() {
                 match row_access.read_row_mvcc(rt.ctx(), metadata, read_set, None) {
                     ReadRow::InvalidIndex => unreachable!(),
                     ReadRow::NotFound => (),
@@ -2610,10 +2593,7 @@ impl<'a> UserTableAccessor<'a> {
                     .mem()
                     .must_get_row_page_shared(rt.pool_guards(), descriptor.page_id)
                     .await?;
-                let access = {
-                    let (page_ctx, page) = page_guard.ctx_and_page();
-                    RowReadAccess::new(page, page_ctx, page.row_idx(row_id))
-                };
+                let access = page_guard.read_row_by_id(row_id);
                 match access.read_latest(rt.ctx()) {
                     ReadLatestRow::Readable => (),
                     ReadLatestRow::NotFound => continue,
@@ -5310,8 +5290,7 @@ mod tests {
                 .lock_shared_async()
                 .await
                 .unwrap();
-            let (ctx, _) = page_guard.ctx_and_page();
-            let row_ver = ctx.expect_vmap();
+            let row_ver = page_guard.unwrap_vmap();
             *row_ver.write_state() = RowPageState::Transition;
 
             let insert_page_guard = engine

--- a/doradb-storage/src/table/hot.rs
+++ b/doradb-storage/src/table/hot.rs
@@ -1,4 +1,4 @@
-use crate::buffer::guard::PageSharedGuard;
+use crate::buffer::guard::{PageGuard, PageSharedGuard};
 use crate::catalog::TableMetadata;
 use crate::id::{RowID, TableID};
 use crate::log::redo::{RowRedo, RowRedoKind};
@@ -9,7 +9,7 @@ use crate::row::ops::{
 use crate::row::{RowPage, RowRead, var_len_for_insert};
 use crate::table::{DeleteInternal, InsertRowIntoPage, UpdateRowInplace};
 use crate::trx::TrxRuntime;
-use crate::trx::row::{LockRowForWrite, LockUndo, RowReadAccess, RowWriteAccess};
+use crate::trx::row::{LockRowForWrite, LockUndo};
 use crate::trx::stmt::StmtEffects;
 use crate::trx::undo::{IndexBranch, IndexBranchTarget, RowUndoKind};
 use crate::trx::ver_map::RowPageState;
@@ -47,8 +47,8 @@ impl<'m, 'r> RowInserter<'m, 'r> {
         debug_assert!(matches!(undo_kind, RowUndoKind::Insert));
         let page_id = page_guard.page_id();
         let versioned_page_id = page_guard.versioned_page_id();
-        let (page_ctx, page) = page_guard.ctx_and_page();
-        let ver_map = page_ctx.expect_vmap();
+        let page = page_guard.page();
+        let ver_map = page_guard.unwrap_vmap();
         let state_guard = ver_map.read_state();
         if *state_guard != RowPageState::Active {
             return InsertRowIntoPage::NoSpaceOrFrozen(cols, undo_kind, index_branches);
@@ -65,13 +65,7 @@ impl<'m, 'r> RowInserter<'m, 'r> {
             };
         // Before real insert, we need to lock the row.
         let row_id = page.header.start_row_id + row_idx as u64;
-        let mut access = RowWriteAccess::new_with_state_guard(
-            page,
-            page_ctx,
-            page_guard.dirty_flag(),
-            row_idx,
-            state_guard,
-        );
+        let mut access = page_guard.write_row_with_state_guard(row_idx, state_guard);
         // Row slot reservation above has already modified the page.
         access.mark_dirty();
         let res = access.lock_undo(
@@ -157,7 +151,7 @@ impl<'m, 'r> HotRowDeleter<'m, 'r> {
         log_by_key: bool,
     ) -> DeleteInternal {
         let page_id = page_guard.page_id();
-        let (_, page) = page_guard.ctx_and_page();
+        let page = page_guard.page();
         if !page.row_id_in_valid_range(row_id) {
             return DeleteInternal::NotFound;
         }
@@ -239,8 +233,8 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
         row_id: RowID,
         key: Option<(usize, &[Val])>,
     ) -> LockRowForWrite<'b> {
-        let (page_ctx, page) = page_guard.ctx_and_page();
-        let ver_map = page_ctx.expect_vmap();
+        let page = page_guard.page();
+        let ver_map = page_guard.unwrap_vmap();
         loop {
             #[cfg(test)]
             {
@@ -251,13 +245,8 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
             if *state_guard == RowPageState::Transition {
                 return LockRowForWrite::RetryInTransition;
             }
-            let mut access = RowWriteAccess::new_with_state_guard(
-                page,
-                page_ctx,
-                page_guard.dirty_flag(),
-                page.row_idx(row_id),
-                state_guard,
-            );
+            let mut access =
+                page_guard.write_row_with_state_guard(page.row_idx(row_id), state_guard);
             let lock_undo = access.lock_undo(
                 self.rt,
                 effects,
@@ -344,7 +333,7 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
         redo_key: Option<SelectKey>,
     ) -> UpdateRowInplace {
         let page_id = page_guard.page_id();
-        let (_, page) = page_guard.ctx_and_page();
+        let page = page_guard.page();
         debug_assert!(
             update.as_view().is_valid_for(self.metadata.col.as_ref()),
             "row update values must be ordered, in range, and type-compatible"
@@ -508,8 +497,7 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
             // move update changes RowID, the new hot row's insert undo carries
             // runtime branches back to the deleted old hot row so older
             // snapshots can still resolve the previous unique-key owner.
-            let (page_ctx, page) = old_guard.ctx_and_page();
-            let old_access = RowReadAccess::new(page, page_ctx, page.row_idx(old_id));
+            let old_access = old_guard.read_row_by_id(old_id);
             let undo_head = old_access.undo_head().expect("undo head");
             debug_assert!(self.rt.is_same_trx(undo_head));
             let old_entry = old_access.first_undo_entry().expect("old undo entry");
@@ -557,8 +545,7 @@ pub(super) fn read_hot_row_mvcc(
     key: Option<(usize, &[Val])>,
     read_set: &[usize],
 ) -> SelectMvcc {
-    let (page_ctx, page) = page_guard.ctx_and_page();
-    let access = RowReadAccess::new(page, page_ctx, page.row_idx(row_id));
+    let access = page_guard.read_row_by_id(row_id);
     match access.read_row_mvcc(rt.ctx(), metadata, read_set, key) {
         ReadRow::Ok(vals) => SelectMvcc::Found(vals),
         ReadRow::InvalidIndex | ReadRow::NotFound => SelectMvcc::NotFound,

--- a/doradb-storage/src/table/mem_table.rs
+++ b/doradb-storage/src/table/mem_table.rs
@@ -29,7 +29,7 @@ use crate::row::ops::{
     UpdateMvcc, UpsertMvcc,
 };
 use crate::row::{Row, RowPage, RowRead, estimate_max_row_count, var_len_for_insert};
-use crate::trx::row::{FindOldVersion, ReadAllRows, RowReadAccess, RowWriteAccess};
+use crate::trx::row::FindOldVersion;
 use crate::trx::stmt::StmtEffects;
 use crate::trx::undo::{IndexBranch, OwnedRowUndo, RowUndoKind};
 use crate::trx::{MIN_SNAPSHOT_TS, RetiredRowPageBatch, TrxRuntime};
@@ -412,12 +412,10 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
         let Some(page_guard) = page_guard else {
             return Ok(());
         };
-        let (ctx, page) = page_guard.ctx_and_page();
         let metadata = self.metadata();
         // TODO: we should retry or wait for notification if rollback happens on a page
         // in transition state. This will be handled in a future task.
-        let row_idx = page.row_idx(entry.row_id);
-        let mut access = RowWriteAccess::new(page, ctx, page_guard.dirty_flag(), row_idx);
+        let mut access = page_guard.write_row_by_id(entry.row_id);
         access.rollback_first_undo(metadata, entry);
         Ok(())
     }
@@ -981,20 +979,13 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
             }
         };
         let metadata = self.metadata();
-        let (page_ctx, page) = old_guard.ctx_and_page();
-        let old_access = RowReadAccess::new(page, page_ctx, page.row_idx(old_id));
+        let old_access = old_guard.read_row_by_id(old_id);
         match old_access.find_old_version_for_unique_key(metadata, index_no, key_vals, rt.ctx()) {
             FindOldVersion::None => Ok(LinkForUniqueIndex::NotNeeded),
             FindOldVersion::DuplicateKey => Ok(LinkForUniqueIndex::DuplicateKey),
             FindOldVersion::WriteConflict => Ok(LinkForUniqueIndex::WriteConflict),
             FindOldVersion::Ok(old_row, cts, old_entry) => {
-                let (page_ctx, page) = new_guard.ctx_and_page();
-                let mut new_access = RowWriteAccess::new(
-                    page,
-                    page_ctx,
-                    new_guard.dirty_flag(),
-                    page.row_idx(new_id),
-                );
+                let mut new_access = new_guard.write_row_by_id(new_id);
                 let undo_vals = new_access.row().calc_delta(metadata.col.as_ref(), &old_row);
                 new_access.link_for_unique_index(
                     SelectKey::new(index_no, key_vals.to_vec()),
@@ -1249,8 +1240,7 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                 }
             }
         };
-        let (ctx, page) = page_guard.ctx_and_page();
-        let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
+        let access = page_guard.read_row_by_id(row_id);
         if !access.any_version_matches_key(self.metadata(), index_no, key_vals) {
             return index
                 .compare_delete(key_vals, row_id, false, MIN_SNAPSHOT_TS)
@@ -1292,8 +1282,7 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                 }
             }
         };
-        let (ctx, page) = page_guard.ctx_and_page();
-        let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
+        let access = page_guard.read_row_by_id(row_id);
         if !access.any_version_matches_key(self.metadata(), index_no, key_vals) {
             return index
                 .compare_delete(key_vals, row_id, false, MIN_SNAPSHOT_TS)
@@ -1700,9 +1689,8 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
         F: for<'m, 'p> FnMut(&'m TableColumnLayout, Row<'p>) -> bool,
     {
         self.scan(guards, |page_guard| {
-            let (ctx, page) = page_guard.ctx_and_page();
-            let col_layout = ctx.expect_vmap().column_layout.as_ref();
-            for row_access in ReadAllRows::new(page, ctx) {
+            let col_layout = page_guard.unwrap_vmap().column_layout.as_ref();
+            for row_access in page_guard.read_all_rows() {
                 if !row_action(col_layout, row_access.row()) {
                     return false;
                 }
@@ -1752,12 +1740,12 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                 }
             },
         };
-        let (ctx, page) = page_guard.ctx_and_page();
+        let page = page_guard.page();
         if !page.row_id_in_valid_range(row_id) {
             return Ok(None);
         }
-        let row_layout = ctx.expect_vmap().column_layout.as_ref();
-        let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
+        let row_layout = page_guard.unwrap_vmap().column_layout.as_ref();
+        let access = page_guard.read_row_by_id(row_id);
         let row = access.row();
         if row.is_deleted() {
             return Ok(None);
@@ -4155,8 +4143,7 @@ mod tests {
                 .await
                 .unwrap()
                 .expect("inserted row page should validate");
-            let (ctx, _) = page_guard.ctx_and_page();
-            let row_ver = ctx.expect_vmap();
+            let row_ver = page_guard.unwrap_vmap();
             *row_ver.write_state() = RowPageState::Transition;
             drop(page_guard);
 

--- a/doradb-storage/src/table/mod.rs
+++ b/doradb-storage/src/table/mod.rs
@@ -49,7 +49,6 @@ use crate::map::FastHashMap;
 use crate::quiescent::QuiescentGuard;
 use crate::row::ops::{RowUpdateInput, RowUpdateView, SelectKey, UpdateCol};
 use crate::row::{RowPage, RowRead, var_len_for_insert};
-use crate::trx::row::RowReadAccess;
 use crate::trx::undo::{IndexBranch, RowUndoKind};
 use crate::trx::{TrxContext, TrxReadProof};
 use crate::value::{PAGE_VAR_LEN_INLINE, Val};
@@ -583,7 +582,7 @@ impl Table {
         cts: TrxID,
     ) -> Result<()> {
         let page_id = page_guard.page_id();
-        let (ctx, page) = page_guard.ctx_and_page_mut();
+        let page = page_guard.page();
         debug_assert!(metadata.col.col_count() == page.header.col_count as usize);
         debug_assert!(cols.len() == page.header.col_count as usize);
         if !page.row_id_in_valid_range(row_id) {
@@ -596,8 +595,8 @@ impl Table {
             ));
         }
         let row_idx = page.row_idx(row_id);
-        if !ctx
-            .recover()
+        if !page_guard
+            .try_rmap()
             .ok_or_else(|| {
                 recovery_page_invariant_error("insert", page_id, row_id, cts, "missing recover map")
             })?
@@ -624,13 +623,15 @@ impl Table {
             ));
         };
         // update count field to include current row id.
-        page.update_count_to_include_row_id(row_id);
+        page_guard.page_mut().update_count_to_include_row_id(row_id);
         // insert CTS.
-        ctx.recover_mut()
+        page_guard
+            .try_rmap_mut()
             .ok_or_else(|| {
                 recovery_page_invariant_error("insert", page_id, row_id, cts, "missing recover map")
             })?
             .insert_at(row_idx, cts);
+        let page = page_guard.page_mut();
         let row_idx = page.row_idx(row_id);
         let mut row = page.row_mut_exclusive(row_idx, var_offset, var_end);
         if !row.is_deleted() {
@@ -659,7 +660,7 @@ impl Table {
         cts: TrxID,
     ) -> Result<()> {
         let page_id = page_guard.page_id();
-        let (ctx, page) = page_guard.ctx_and_page_mut();
+        let page = page_guard.page();
         // column indexes must be in range
         debug_assert!(
             {
@@ -710,8 +711,8 @@ impl Table {
                 "insufficient row page space",
             ));
         };
-        if ctx
-            .recover()
+        if page_guard
+            .try_rmap()
             .ok_or_else(|| {
                 recovery_page_invariant_error("update", page_id, row_id, cts, "missing recover map")
             })?
@@ -727,11 +728,13 @@ impl Table {
             ));
         }
         // update CTS.
-        ctx.recover_mut()
+        page_guard
+            .try_rmap_mut()
             .ok_or_else(|| {
                 recovery_page_invariant_error("update", page_id, row_id, cts, "missing recover map")
             })?
             .update_at(row_idx, cts);
+        let page = page_guard.page_mut();
         let mut row = page.row_mut_exclusive(row_idx, var_offset, var_end);
         debug_assert_eq!(row_id, row.row_id());
 
@@ -750,7 +753,7 @@ impl Table {
         cts: TrxID,
     ) -> Result<()> {
         let page_id = page_guard.page_id();
-        let (ctx, page) = page_guard.ctx_and_page_mut();
+        let page = page_guard.page();
         if !page.row_id_in_valid_range(row_id) {
             return Err(recovery_page_invariant_error(
                 "delete",
@@ -771,8 +774,8 @@ impl Table {
                 "row is already deleted",
             ));
         }
-        if ctx
-            .recover()
+        if page_guard
+            .try_rmap()
             .ok_or_else(|| {
                 recovery_page_invariant_error("delete", page_id, row_id, cts, "missing recover map")
             })?
@@ -787,11 +790,13 @@ impl Table {
                 "missing recover CTS",
             ));
         }
-        ctx.recover_mut()
+        page_guard
+            .try_rmap_mut()
             .ok_or_else(|| {
                 recovery_page_invariant_error("delete", page_id, row_id, cts, "missing recover map")
             })?
             .update_at(row_idx, cts);
+        let page = page_guard.page_mut();
         page.set_deleted_exclusive(row_idx, true);
         if !was_deleted {
             page.inc_approx_deleted();
@@ -1108,8 +1113,7 @@ fn read_latest_index_key(
         .expect("active index spec must exist for latest key read");
     let mut new_key = SelectKey::null(index_no, index_spec.cols.len());
     for (pos, key) in index_spec.cols.iter().enumerate() {
-        let (ctx, page) = page_guard.ctx_and_page();
-        let access = RowReadAccess::new(page, ctx, page.row_idx(row_id));
+        let access = page_guard.read_row_by_id(row_id);
         let val = access.row().val(metadata.col.as_ref(), key.col_no as usize);
         new_key.vals[pos] = val;
     }

--- a/doradb-storage/src/table/page_transition.rs
+++ b/doradb-storage/src/table/page_transition.rs
@@ -4,13 +4,12 @@ use super::checkpoint_workflow::{
 use super::{DeleteMarker, Table};
 use crate::bitmap::Bitmap;
 use crate::buffer::PoolGuards;
-use crate::buffer::frame::FrameContext;
 use crate::buffer::guard::{PageGuard, PageSharedGuard};
 use crate::error::{InternalError, Result};
 use crate::id::{PageID, RowID, TableID, TrxID};
 use crate::row::RowPage;
 use crate::trx::undo::{RowUndoKind, UndoStatus};
-use crate::trx::ver_map::RowPageState;
+use crate::trx::ver_map::{RowPageState, RowVersionMap};
 use crate::trx::{MAX_SNAPSHOT_TS, SharedTrxStatus, trx_is_committed};
 use error_stack::Report;
 use std::mem::take;
@@ -144,7 +143,7 @@ impl Table {
         // maintenance state transition, while foreground writers do not change
         // page state or row-page identity.
         for (page_guard, page_info) in page_guards.iter().zip(pages) {
-            let (ctx, page) = page_guard.ctx_and_page();
+            let page = page_guard.page();
             assert_eq!(
                 page_guard.page_id(),
                 page_info.page_id,
@@ -158,7 +157,7 @@ impl Table {
                 self.table_id(),
                 page_info.page_id
             );
-            let state = ctx.expect_vmap().inspect_state();
+            let state = page_guard.unwrap_vmap().inspect_state();
             assert_eq!(
                 state,
                 RowPageState::Active,
@@ -175,8 +174,7 @@ impl Table {
             return false;
         }
         for (page_guard, page_info) in page_guards.iter().zip(pages) {
-            let (ctx, _) = page_guard.ctx_and_page();
-            let mut state = ctx.expect_vmap().write_state();
+            let mut state = page_guard.unwrap_vmap().write_state();
             assert_eq!(
                 *state,
                 RowPageState::Active,
@@ -234,8 +232,11 @@ impl Table {
         let page_info = batch.pages[page_idx];
         match batch.validation[page_idx] {
             state @ FrozenPageValidationState::Stable { .. } => {
-                let (ctx, _) = page_guard.ctx_and_page();
-                assert_frozen_page_state(ctx, batch.table_id, page_info.page_id);
+                assert_frozen_page_state(
+                    page_guard.unwrap_vmap(),
+                    batch.table_id,
+                    page_info.page_id,
+                );
                 debug_assert!(batch.blockers_for(page_info.page_id).is_none());
                 state
             }
@@ -265,8 +266,8 @@ impl Table {
         // page-local revalidation and fail-closed Transition publication.
         for (page_idx, page_guard) in page_guards.iter().enumerate() {
             let page_info = batch.pages[page_idx];
-            let (ctx, page) = page_guard.ctx_and_page();
-            let map = ctx.expect_vmap();
+            let page = page_guard.page();
+            let map = page_guard.unwrap_vmap();
             assert!(
                 matches!(
                     batch.validation[page_idx],
@@ -299,7 +300,7 @@ impl Table {
                 .or_else(|| {
                     scan_frozen_page(
                         page,
-                        ctx,
+                        map,
                         page_info,
                         FrozenPageScanMode::RefreshStablePlan,
                         cutoff_ts,
@@ -375,8 +376,11 @@ fn validate_frozen_pages_incrementally(
                 // Stable caches only the image-readiness proof and required
                 // cutoff. Plan freshness and current overlays are deliberately
                 // deferred to the full optimistic refresh below.
-                let (ctx, _) = page_guard.ctx_and_page();
-                assert_frozen_page_state(ctx, batch.table_id, page_info.page_id);
+                assert_frozen_page_state(
+                    page_guard.unwrap_vmap(),
+                    batch.table_id,
+                    page_info.page_id,
+                );
                 batch.validation[page_idx]
             }
             FrozenPageValidationState::Unchecked | FrozenPageValidationState::Blocked { .. } => {
@@ -423,15 +427,15 @@ fn analyze_frozen_page_readiness(
     cutoff_ts: TrxID,
 ) -> FrozenPageValidationState {
     let page_info = batch.pages[page_idx];
-    let (ctx, page) = page_guard.ctx_and_page();
-    let map = ctx.expect_vmap();
-    assert_frozen_page_state(ctx, batch.table_id, page_info.page_id);
+    let page = page_guard.page();
+    let map = page_guard.unwrap_vmap();
+    assert_frozen_page_state(map, batch.table_id, page_info.page_id);
     // This version is an equality token, not a seqlock parity value. Any
     // mutation between the samples invalidates the optimistic plan.
     let version_before = map.frozen_mutation_version();
     let analysis = scan_frozen_page(
         page,
-        ctx,
+        map,
         page_info,
         FrozenPageScanMode::EstablishReadiness {
             frozen_ts: batch.frozen_ts,
@@ -478,9 +482,9 @@ fn refresh_stable_page_plan(
     cutoff_ts: TrxID,
 ) {
     let page_info = batch.pages[page_idx];
-    let (ctx, page) = page_guard.ctx_and_page();
-    let map = ctx.expect_vmap();
-    assert_frozen_page_state(ctx, batch.table_id, page_info.page_id);
+    let page = page_guard.page();
+    let map = page_guard.unwrap_vmap();
+    assert_frozen_page_state(map, batch.table_id, page_info.page_id);
     assert!(
         matches!(
             batch.validation[page_idx],
@@ -500,7 +504,7 @@ fn refresh_stable_page_plan(
         .or_else(|| {
             scan_frozen_page(
                 page,
-                ctx,
+                map,
                 page_info,
                 FrozenPageScanMode::RefreshStablePlan,
                 cutoff_ts,
@@ -533,9 +537,9 @@ fn retain_optimistic_page_plan(
 }
 
 #[inline]
-fn assert_frozen_page_state(ctx: &FrameContext, table_id: TableID, page_id: PageID) {
+fn assert_frozen_page_state(map: &RowVersionMap, table_id: TableID, page_id: PageID) {
     assert_eq!(
-        ctx.expect_vmap().inspect_state(),
+        map.inspect_state(),
         RowPageState::Frozen,
         "optimistic preparation requires frozen page: table_id={table_id}, page_id={page_id}"
     );
@@ -571,7 +575,7 @@ fn record_frozen_page_readiness(
 
 fn scan_frozen_page(
     page: &RowPage,
-    ctx: &FrameContext,
+    map: &RowVersionMap,
     page_info: FrozenPage,
     mode: FrozenPageScanMode,
     cutoff_ts: TrxID,
@@ -585,7 +589,6 @@ fn scan_frozen_page(
     // Start from the current physical image. Undo inspection below only
     // adjusts rows whose cutoff visibility differs from that latest image.
     let mut del_bitmap = page.del_bitmap(row_count);
-    let map = ctx.expect_vmap();
     let mut required_cutoff_ts = None;
     let mut blocked = false;
     let mut blockers = Vec::new();
@@ -753,7 +756,7 @@ mod tests {
     use crate::catalog::{ColumnAttributes, ColumnSpec, TableMetadata};
     use crate::id::RowID;
     use crate::table::test_hooks;
-    use crate::trx::row::RowWriteAccess;
+    use crate::trx::row::tests::test_row_write_access;
     use crate::trx::undo::{
         MainBranch, NextRowUndo, OwnedRowUndo, RowUndoHead, RowUndoKind, UndoStatus,
     };
@@ -766,7 +769,7 @@ mod tests {
 
     struct FrozenAnalyzerFixture {
         page: RowPage,
-        ctx: FrameContext,
+        map: RowVersionMap,
         page_info: FrozenPage,
         _undo_owners: Vec<OwnedRowUndo>,
     }
@@ -830,7 +833,7 @@ mod tests {
         };
         FrozenAnalyzerFixture {
             page,
-            ctx: FrameContext::RowVerMap(row_ver),
+            map: row_ver,
             page_info,
             _undo_owners: nodes.into_iter().map(|(undo, _)| undo).collect(),
         }
@@ -841,10 +844,10 @@ mod tests {
         frozen_ts: TrxID,
         cutoff_ts: TrxID,
     ) -> FrozenPageReadinessAnalysis {
-        let observed_version = fixture.ctx.expect_vmap().frozen_mutation_version();
+        let observed_version = fixture.map.frozen_mutation_version();
         scan_frozen_page(
             &fixture.page,
-            &fixture.ctx,
+            &fixture.map,
             fixture.page_info,
             FrozenPageScanMode::EstablishReadiness { frozen_ts },
             cutoff_ts,
@@ -856,10 +859,10 @@ mod tests {
         fixture: &FrozenAnalyzerFixture,
         cutoff_ts: TrxID,
     ) -> Option<PreparedTransitionPage> {
-        let observed_version = fixture.ctx.expect_vmap().frozen_mutation_version();
+        let observed_version = fixture.map.frozen_mutation_version();
         scan_frozen_page(
             &fixture.page,
-            &fixture.ctx,
+            &fixture.map,
             fixture.page_info,
             FrozenPageScanMode::RefreshStablePlan,
             cutoff_ts,
@@ -890,7 +893,6 @@ mod tests {
         );
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         *row_ver.write_state() = RowPageState::Frozen;
-        let ctx = FrameContext::RowVerMap(row_ver);
         let page_info = FrozenPage {
             page_id: PageID::new(8),
             start_row_id: RowID::new(100),
@@ -902,20 +904,20 @@ mod tests {
         thread::scope(|scope| {
             let writer = scope.spawn(|| {
                 let dirty = AtomicBool::new(false);
-                let mut access = RowWriteAccess::new(&page, &ctx, &dirty, 1);
+                let mut access = test_row_write_access(&page, &row_ver, &dirty, 1);
                 entered_tx.send(()).unwrap();
                 release_rx.recv().unwrap();
                 access.delete_row();
             });
             entered_rx.recv().unwrap();
-            let version_before = ctx.expect_vmap().frozen_mutation_version();
+            let version_before = row_ver.frozen_mutation_version();
             assert_eq!(version_before, 1);
             test_hooks::set_test_frozen_page_scan_hook(move |_| {
                 release_tx.send(()).unwrap();
             });
             let analysis = scan_frozen_page(
                 &page,
-                &ctx,
+                &row_ver,
                 page_info,
                 FrozenPageScanMode::EstablishReadiness {
                     frozen_ts: TrxID::new(20),
@@ -924,7 +926,7 @@ mod tests {
             )
             .into_readiness_analysis(TrxID::new(20), version_before);
             writer.join().unwrap();
-            let version_after = ctx.expect_vmap().frozen_mutation_version();
+            let version_after = row_ver.frozen_mutation_version();
             assert_eq!(version_after, 2);
             assert!(analysis.plan.is_some());
             let retained_plan = (version_before == version_after).then_some(analysis.plan);

--- a/doradb-storage/src/table/persistence.rs
+++ b/doradb-storage/src/table/persistence.rs
@@ -1096,8 +1096,7 @@ impl Table {
         let mut heap_redo_start_ts = None;
         self.mem_scan(&guards, |page_guard| {
             if reached_row_budget {
-                let (ctx, _) = page_guard.ctx_and_page();
-                heap_redo_start_ts = Some(ctx.expect_vmap().create_cts());
+                heap_redo_start_ts = Some(page_guard.unwrap_vmap().create_cts());
                 return false;
             }
             let page = page_guard.page();
@@ -1137,8 +1136,7 @@ impl Table {
         let mut heap_redo_start_ts = None;
         self.mem
             .scan_from(guards, start_row_id, |page_guard| {
-                let (ctx, _) = page_guard.ctx_and_page();
-                heap_redo_start_ts = Some(ctx.expect_vmap().create_cts());
+                heap_redo_start_ts = Some(page_guard.unwrap_vmap().create_cts());
                 false
             })
             .await?;
@@ -1818,7 +1816,6 @@ mod tests {
     use crate::table::tests::*;
     use crate::table::{DeleteMarker, TableLifecycle, TableTerminal};
     use crate::trx::Transaction;
-    use crate::trx::row::RowWriteAccess;
     use crate::trx::stmt::tests as stmt_tests;
     use crate::trx::tests::discard_transaction_after_fatal_rollback;
     use crate::trx::undo::{OwnedRowUndo, RowUndoHead, RowUndoKind};
@@ -1831,7 +1828,6 @@ mod tests {
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::rc::Rc;
     use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
     use std::task::Poll;
     use std::thread;
     use tempfile::TempDir;
@@ -1840,8 +1836,7 @@ mod tests {
         let mut states = Vec::new();
         table
             .mem_scan(guards, |page_guard| {
-                let (ctx, _) = page_guard.ctx_and_page();
-                states.push(ctx.expect_vmap().inspect_state());
+                states.push(page_guard.unwrap_vmap().inspect_state());
                 true
             })
             .await
@@ -1853,8 +1848,7 @@ mod tests {
         let mut timestamps = Vec::new();
         table
             .mem_scan(guards, |page_guard| {
-                let (ctx, _) = page_guard.ctx_and_page();
-                timestamps.push(ctx.expect_vmap().create_cts());
+                timestamps.push(page_guard.unwrap_vmap().create_cts());
                 true
             })
             .await
@@ -1895,21 +1889,19 @@ mod tests {
             .must_get_row_page_shared(guards, page_id)
             .await
             .unwrap();
-        let (ctx, _) = page_guard.ctx_and_page();
-        ctx.expect_vmap().inspect_state()
+        page_guard.unwrap_vmap().inspect_state()
     }
 
     fn delete_last_frozen_row_image(page_guard: PageSharedGuard<RowPage>) {
-        let (ctx, page) = page_guard.ctx_and_page();
-        let map = ctx.expect_vmap();
+        let page = page_guard.page();
+        let map = page_guard.unwrap_vmap();
         assert_eq!(map.inspect_state(), RowPageState::Frozen);
         let row_idx = page.header.row_count() - 1;
         assert!(
             map.read_latch(row_idx).is_none(),
             "raw frozen-page image delete requires purged row undo"
         );
-        let dirty = AtomicBool::new(false);
-        let mut access = RowWriteAccess::new(page, ctx, &dirty, row_idx);
+        let mut access = page_guard.write_row(row_idx);
         access.delete_row();
     }
 
@@ -3363,8 +3355,7 @@ mod tests {
                         .must_get_row_page_shared(&session.pool_guards(), page_id)
                         .await
                         .unwrap();
-                    let (ctx, _) = page_guard.ctx_and_page();
-                    *ctx.expect_vmap().write_state() = unexpected;
+                    *page_guard.unwrap_vmap().write_state() = unexpected;
                     drop(page_guard);
 
                     // The selected-page invariant must panic before an outcome is returned.
@@ -3906,8 +3897,10 @@ mod tests {
                 .must_get_row_page_shared(&session.pool_guards(), first_frozen_page)
                 .await
                 .unwrap();
-            let (ctx, _) = page_guard.ctx_and_page();
-            assert_eq!(ctx.expect_vmap().inspect_state(), RowPageState::Frozen);
+            assert_eq!(
+                page_guard.unwrap_vmap().inspect_state(),
+                RowPageState::Frozen
+            );
             drop(page_guard);
             assert_eq!(
                 table.checkpoint_workflow.frozen_page_ids().unwrap(),
@@ -4195,8 +4188,7 @@ mod tests {
             let result = publication_guard.begin_transition();
             assert!(matches!(result, Err(CheckpointCancelReason::TableDropping)));
             assert!(transition_pages.iter().all(|page_guard| {
-                let (ctx, _) = page_guard.ctx_and_page();
-                ctx.expect_vmap().inspect_state() == RowPageState::Frozen
+                page_guard.unwrap_vmap().inspect_state() == RowPageState::Frozen
             }));
             drop(transition_pages);
             drop(attempt);
@@ -4565,8 +4557,11 @@ mod tests {
                     && !row_hook_mutation_started.replace(true)
                 {
                     let page_guard = row_hook_page.borrow();
-                    let (ctx, _) = page_guard.as_ref().unwrap().ctx_and_page();
-                    ctx.expect_vmap().begin_frozen_mutation();
+                    page_guard
+                        .as_ref()
+                        .unwrap()
+                        .unwrap_vmap()
+                        .begin_frozen_mutation();
                 }
             });
             let comparison_hook_page = Rc::clone(&first_frozen_page);
@@ -4578,11 +4573,12 @@ mod tests {
                     assert_eq!(version_after, version_before + 1);
                     assert!(!retained);
                     let page_guard = comparison_hook_page.borrow();
-                    let (ctx, page) = page_guard.as_ref().unwrap().ctx_and_page();
+                    let guard_ref = page_guard.as_ref().unwrap();
+                    let page = guard_ref.page();
                     let row_idx = page.header.row_count() - 1;
                     assert!(page.set_deleted(row_idx, true));
                     page.inc_approx_deleted();
-                    ctx.expect_vmap().finish_frozen_mutation();
+                    guard_ref.unwrap_vmap().finish_frozen_mutation();
                     drop(page_guard);
                     comparison_hook_page.borrow_mut().take();
                 },
@@ -4667,8 +4663,10 @@ mod tests {
             let hook_prefix_delete_done_rx = prefix_delete_done_rx.clone();
             set_test_transition_page_published_hook(move |page_id| {
                 assert_eq!(page_id, first_frozen_page_id);
-                let (ctx, _) = second_frozen_page.ctx_and_page();
-                assert_eq!(ctx.expect_vmap().inspect_state(), RowPageState::Frozen);
+                assert_eq!(
+                    second_frozen_page.unwrap_vmap().inspect_state(),
+                    RowPageState::Frozen
+                );
                 prefix_update_start_tx.send(()).unwrap();
                 prefix_delete_start_tx.send(()).unwrap();
                 suffix_delete_start_tx.send(()).unwrap();
@@ -4811,8 +4809,10 @@ mod tests {
                     hook_first_analysis_count.set(count);
                     if count == 2 {
                         let page_guard = hook_second_page.borrow_mut().take().unwrap();
-                        let (ctx, _) = page_guard.ctx_and_page();
-                        assert_eq!(ctx.expect_vmap().inspect_state(), RowPageState::Frozen);
+                        assert_eq!(
+                            page_guard.unwrap_vmap().inspect_state(),
+                            RowPageState::Frozen
+                        );
                         delete_last_frozen_row_image(page_guard);
                         hook_cross_page_delete_completed.set(true);
                     }
@@ -4918,8 +4918,8 @@ mod tests {
             let hook_ownership_status = Arc::clone(&ownership_status);
             set_test_frozen_pages_ready_hook(move || {
                 let page_guard = hook_first_page.borrow_mut().take().unwrap();
-                let (ctx, page) = page_guard.ctx_and_page();
-                let map = ctx.expect_vmap();
+                let page = page_guard.page();
+                let map = page_guard.unwrap_vmap();
                 let undo = OwnedRowUndo::new(table_id, None, page.row_id(0), RowUndoKind::Lock);
                 map.begin_frozen_mutation();
                 *map.write_latch(0) = Some(Box::new(RowUndoHead::new(
@@ -4984,8 +4984,8 @@ mod tests {
             let hook_ownership_status = Arc::clone(&ownership_status);
             set_test_stable_page_plans_refreshed_hook(move || {
                 let page_guard = hook_first_page.borrow_mut().take().unwrap();
-                let (ctx, page) = page_guard.ctx_and_page();
-                let map = ctx.expect_vmap();
+                let page = page_guard.page();
+                let map = page_guard.unwrap_vmap();
                 let undo = OwnedRowUndo::new(table_id, None, page.row_id(0), RowUndoKind::Lock);
                 map.begin_frozen_mutation();
                 *map.write_latch(0) = Some(Box::new(RowUndoHead::new(
@@ -5774,8 +5774,10 @@ mod tests {
                 .must_get_row_page_shared(&checkpoint_session.pool_guards(), frozen_page_id)
                 .await
                 .unwrap();
-            let (ctx, _) = page_guard.ctx_and_page();
-            assert_eq!(ctx.expect_vmap().inspect_state(), RowPageState::Frozen);
+            assert_eq!(
+                page_guard.unwrap_vmap().inspect_state(),
+                RowPageState::Frozen
+            );
             drop(page_guard);
             let (wait_result, rollback_result) = futures::join!(
                 checkpoint_session.wait_for_checkpoint_retry(reason),

--- a/doradb-storage/src/table/recover.rs
+++ b/doradb-storage/src/table/recover.rs
@@ -7,7 +7,6 @@ use crate::row::RowRead;
 use crate::row::ops::{ReadRow, UpdateCol};
 use crate::table::{DeletionError, DmlValidationDomain, DmlValidator, Table};
 use crate::trx::MIN_SNAPSHOT_TS;
-use crate::trx::row::ReadAllRows;
 use crate::value::Val;
 use error_stack::Report;
 
@@ -128,11 +127,10 @@ impl Table {
         let layout = self.layout_snapshot();
         let metadata = layout.metadata();
         let index_pool_guard = self.mem.index_pool_guard(guards)?;
-        let (ctx, page) = page_guard.ctx_and_page();
         for (index_no, index_spec) in metadata.idx.active_indexes() {
             let sec_idx = layout.secondary_index(index_no)?;
             let read_set: Vec<_> = index_spec.cols.iter().map(|c| c.col_no as usize).collect();
-            for row_access in ReadAllRows::new(page, ctx) {
+            for row_access in page_guard.read_all_rows() {
                 let row_id = row_access.row().row_id();
                 match row_access.read_row_latest(metadata, &read_set, None) {
                     ReadRow::Ok(vals) => {

--- a/doradb-storage/src/trx/purge.rs
+++ b/doradb-storage/src/trx/purge.rs
@@ -1,5 +1,5 @@
 use crate::buffer::PoolGuards;
-use crate::buffer::guard::PageSharedGuard;
+use crate::buffer::guard::{PageGuard, PageSharedGuard};
 use crate::catalog::{
     Catalog, DroppedTableFileCleanup, DroppedTableRuntime, TableCache, is_catalog_table,
 };
@@ -12,7 +12,6 @@ use crate::row::RowPage;
 use crate::runtime;
 use crate::table::Table;
 use crate::thread;
-use crate::trx::row::RowWriteAccess;
 use crate::trx::sys::TransactionSystem;
 use crate::trx::undo::{OwnedRowUndo, RowUndoKind};
 use crate::trx::{CommittedTrx, MAX_SNAPSHOT_TS, RetiredRowPageBatch};
@@ -1346,12 +1345,11 @@ fn purge_undo_chain_from_page(
     undo: &OwnedRowUndo,
     min_active_sts: TrxID,
 ) {
-    let (ctx, page) = page_guard.ctx_and_page();
+    let page = page_guard.page();
     if !page.row_id_in_valid_range(undo.row_id) {
         return;
     }
-    let row_idx = page.row_idx(undo.row_id);
-    let mut access = RowWriteAccess::new(page, ctx, page_guard.dirty_flag(), row_idx);
+    let mut access = page_guard.write_row_by_id(undo.row_id);
     access.purge_undo_chain(min_active_sts);
 }
 

--- a/doradb-storage/src/trx/row.rs
+++ b/doradb-storage/src/trx/row.rs
@@ -1,4 +1,4 @@
-use crate::buffer::frame::FrameContext;
+use crate::buffer::guard::{PageGuard, PageSharedGuard};
 use crate::buffer::page::VersionedPageID;
 use crate::catalog::{TableColumnLayout, TableMetadata};
 use crate::id::{RowID, TableID, TrxID};
@@ -43,8 +43,13 @@ pub(crate) struct RowReadAccess<'a> {
 impl<'a> RowReadAccess<'a> {
     /// Acquire read latch for single row with offset.
     #[inline]
-    pub(crate) fn new(page: &'a RowPage, ctx: &'a FrameContext, row_idx: usize) -> Self {
-        let state = RowReadState::from_ctx(ctx, row_idx);
+    fn new(page_guard: &'a PageSharedGuard<RowPage>, row_idx: usize) -> Self {
+        let state = RowReadState::from_guard(page_guard, row_idx);
+        Self::from_state(page_guard.page(), row_idx, state)
+    }
+
+    #[inline]
+    fn from_state(page: &'a RowPage, row_idx: usize, state: RowReadState<'a>) -> Self {
         RowReadAccess {
             page,
             row_idx,
@@ -717,10 +722,11 @@ pub(crate) enum RowReadState<'a> {
 
 impl<'a> RowReadState<'a> {
     #[inline]
-    fn from_ctx(ctx: &'a FrameContext, row_idx: usize) -> Self {
-        match ctx {
-            FrameContext::RowVerMap(ver) => RowReadState::RowVer(ver.read_latch(row_idx)),
-            FrameContext::RowRecoveryMap(rec) => RowReadState::Recover(rec),
+    fn from_guard(page_guard: &'a PageSharedGuard<RowPage>, row_idx: usize) -> Self {
+        if let Some(rec) = page_guard.try_rmap() {
+            RowReadState::Recover(rec)
+        } else {
+            RowReadState::RowVer(page_guard.unwrap_vmap().read_latch(row_idx))
         }
     }
 }
@@ -755,10 +761,9 @@ impl IndexCandidateRecheck<'_> {
     }
 }
 
-/// Iterator over all rows in a row page using one frame context.
+/// Iterator over all rows protected by one shared row-page guard.
 pub(crate) struct ReadAllRows<'a> {
-    ctx: &'a FrameContext,
-    page: &'a RowPage,
+    page_guard: &'a PageSharedGuard<RowPage>,
     start_idx: usize,
     end_idx: usize,
 }
@@ -766,11 +771,10 @@ pub(crate) struct ReadAllRows<'a> {
 impl<'a> ReadAllRows<'a> {
     /// Create an iterator over all row indexes in the page.
     #[inline]
-    pub(crate) fn new(page: &'a RowPage, ctx: &'a FrameContext) -> Self {
-        let end_idx = page.header.row_count();
+    fn new(page_guard: &'a PageSharedGuard<RowPage>) -> Self {
+        let end_idx = page_guard.page().header.row_count();
         ReadAllRows {
-            ctx,
-            page,
+            page_guard,
             start_idx: 0,
             end_idx,
         }
@@ -786,7 +790,49 @@ impl<'a> Iterator for ReadAllRows<'a> {
             return None;
         }
         self.start_idx += 1;
-        Some(RowReadAccess::new(self.page, self.ctx, row_idx))
+        Some(self.page_guard.read_row(row_idx))
+    }
+}
+
+impl PageSharedGuard<RowPage> {
+    /// Acquires read access to one row slot.
+    #[inline]
+    pub(crate) fn read_row(&self, row_idx: usize) -> RowReadAccess<'_> {
+        RowReadAccess::new(self, row_idx)
+    }
+
+    /// Acquires read access to one row identified by its row ID.
+    #[inline]
+    pub(crate) fn read_row_by_id(&self, row_id: RowID) -> RowReadAccess<'_> {
+        self.read_row(self.page().row_idx(row_id))
+    }
+
+    /// Iterates over all populated row slots with row-aware read access.
+    #[inline]
+    pub(crate) fn read_all_rows(&self) -> ReadAllRows<'_> {
+        ReadAllRows::new(self)
+    }
+
+    /// Acquires write access to one row slot and read-locks page state.
+    #[inline]
+    pub(crate) fn write_row(&self, row_idx: usize) -> RowWriteAccess<'_> {
+        RowWriteAccess::new(self, row_idx)
+    }
+
+    /// Acquires write access to one row identified by its row ID.
+    #[inline]
+    pub(crate) fn write_row_by_id(&self, row_id: RowID) -> RowWriteAccess<'_> {
+        self.write_row(self.page().row_idx(row_id))
+    }
+
+    /// Acquires write access while retaining an existing page-state guard.
+    #[inline]
+    pub(crate) fn write_row_with_state_guard<'a>(
+        &'a self,
+        row_idx: usize,
+        state_guard: RwLockReadGuard<'a, RowPageState>,
+    ) -> RowWriteAccess<'a> {
+        RowWriteAccess::new_with_state_guard(self, row_idx, state_guard)
     }
 }
 
@@ -945,27 +991,37 @@ pub(crate) struct RowWriteAccess<'a> {
 impl<'a> RowWriteAccess<'a> {
     /// Acquire write access to one row and read-lock the page state.
     #[inline]
-    pub(crate) fn new(
-        page: &'a RowPage,
-        ctx: &'a FrameContext,
-        dirty: &'a AtomicBool,
-        row_idx: usize,
-    ) -> Self {
-        let ver_map = ctx.expect_vmap();
+    fn new(page_guard: &'a PageSharedGuard<RowPage>, row_idx: usize) -> Self {
+        let ver_map = page_guard.unwrap_vmap();
         let state_guard = ver_map.read_state();
-        Self::new_with_state_guard(page, ctx, dirty, row_idx, state_guard)
+        Self::new_with_state_guard(page_guard, row_idx, state_guard)
     }
 
     /// Acquire write access using an existing page-state guard.
     #[inline]
-    pub(crate) fn new_with_state_guard(
+    fn new_with_state_guard(
+        page_guard: &'a PageSharedGuard<RowPage>,
+        row_idx: usize,
+        state_guard: RwLockReadGuard<'a, RowPageState>,
+    ) -> Self {
+        let ver_map = page_guard.unwrap_vmap();
+        Self::from_parts(
+            page_guard.page(),
+            ver_map,
+            page_guard.bf().dirty_flag(),
+            row_idx,
+            state_guard,
+        )
+    }
+
+    #[inline]
+    fn from_parts(
         page: &'a RowPage,
-        ctx: &'a FrameContext,
+        ver_map: &'a RowVersionMap,
         dirty: &'a AtomicBool,
         row_idx: usize,
         state_guard: RwLockReadGuard<'a, RowPageState>,
     ) -> Self {
-        let ver_map = ctx.expect_vmap();
         let guard = ver_map.write_latch(row_idx);
         let frozen_version_map = if *state_guard == RowPageState::Frozen {
             // The row latch and page-state guard are already held, so a final
@@ -1413,7 +1469,7 @@ pub(crate) enum FindOldVersion {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::catalog::{
         ActiveIndexSpec, ColumnAttributes, ColumnSpec, IndexAttributes, IndexKey, IndexSpec,
@@ -1472,13 +1528,34 @@ mod tests {
         *row_ver.write_latch(0) = Some(Box::new(RowUndoHead::new(status, undo.leak())));
     }
 
-    fn test_row_write_access<'a>(
+    fn test_row_read_access<'a>(
         page: &'a RowPage,
-        ctx: &'a FrameContext,
+        row_ver: &'a RowVersionMap,
+        row_idx: usize,
+    ) -> RowReadAccess<'a> {
+        RowReadAccess::from_state(
+            page,
+            row_idx,
+            RowReadState::RowVer(row_ver.read_latch(row_idx)),
+        )
+    }
+
+    fn test_recovery_row_read_access<'a>(
+        page: &'a RowPage,
+        rec_map: &'a RowRecoveryMap,
+        row_idx: usize,
+    ) -> RowReadAccess<'a> {
+        RowReadAccess::from_state(page, row_idx, RowReadState::Recover(rec_map))
+    }
+
+    pub(crate) fn test_row_write_access<'a>(
+        page: &'a RowPage,
+        row_ver: &'a RowVersionMap,
         dirty: &'a AtomicBool,
         row_idx: usize,
     ) -> RowWriteAccess<'a> {
-        RowWriteAccess::new(page, ctx, dirty, row_idx)
+        let state_guard = row_ver.read_state();
+        RowWriteAccess::from_parts(page, row_ver, dirty, row_idx, state_guard)
     }
 
     #[test]
@@ -1489,8 +1566,7 @@ mod tests {
         let status = Arc::new(SharedTrxStatus::new(MIN_ACTIVE_TRX_ID + 99));
         status.commit_for_test(TrxID::new(10));
         install_test_undo_head(&row_ver, status);
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let access = test_row_read_access(&page, &row_ver, 0);
         let trx_ctx = test_trx_context(TrxID::new(1));
 
         assert_eq!(access.read_latest(&trx_ctx), ReadLatestRow::Readable);
@@ -1507,18 +1583,16 @@ mod tests {
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         let trx_ctx = test_trx_context(TrxID::new(1));
         install_test_undo_head(&row_ver, trx_ctx.status());
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-
         {
-            let access = RowReadAccess::new(&page, &frame_ctx, 0);
+            let access = test_row_read_access(&page, &row_ver, 0);
             assert_eq!(access.read_latest(&trx_ctx), ReadLatestRow::Readable);
         }
 
         install_test_undo_head(
-            frame_ctx.expect_vmap(),
+            &row_ver,
             Arc::new(SharedTrxStatus::new(MIN_ACTIVE_TRX_ID + 100)),
         );
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let access = test_row_read_access(&page, &row_ver, 0);
         assert_eq!(access.read_latest(&trx_ctx), ReadLatestRow::WriteConflict);
     }
 
@@ -1530,8 +1604,7 @@ mod tests {
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         let status = Arc::new(SharedTrxStatus::new(MIN_ACTIVE_TRX_ID + 99));
         install_test_undo_head(&row_ver, Arc::clone(&status));
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let access = test_row_read_access(&page, &row_ver, 0);
         let trx_ctx = test_trx_context(TrxID::new(1));
 
         assert_eq!(access.read_latest(&trx_ctx), ReadLatestRow::WriteConflict);
@@ -1545,19 +1618,17 @@ mod tests {
         let page = row_page(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         *row_ver.write_state() = RowPageState::Frozen;
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let row_ver = frame_ctx.expect_vmap();
         let dirty = AtomicBool::new(false);
 
         assert_eq!(row_ver.frozen_mutation_version(), 0);
         {
-            let _access = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+            let _access = test_row_write_access(&page, &row_ver, &dirty, 0);
             assert_eq!(row_ver.frozen_mutation_version(), 1);
         }
         assert_eq!(row_ver.frozen_mutation_version(), 2);
 
         *row_ver.write_state() = RowPageState::Active;
-        drop(test_row_write_access(&page, &frame_ctx, &dirty, 0));
+        drop(test_row_write_access(&page, &row_ver, &dirty, 0));
         assert_eq!(row_ver.frozen_mutation_version(), 2);
     }
 
@@ -1566,22 +1637,20 @@ mod tests {
         let metadata = sparse_metadata();
         let page = row_page_with_two_rows(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
         let dirty = AtomicBool::new(false);
 
-        drop(test_row_write_access(&page, &frame_ctx, &dirty, 0));
+        drop(test_row_write_access(&page, &row_ver, &dirty, 0));
         assert!(!dirty.load(Ordering::Acquire));
 
-        let state_guard = frame_ctx.expect_vmap().read_state();
-        let access =
-            RowWriteAccess::new_with_state_guard(&page, &frame_ctx, &dirty, 0, state_guard);
+        let state_guard = row_ver.read_state();
+        let access = RowWriteAccess::from_parts(&page, &row_ver, &dirty, 0, state_guard);
         access.mark_dirty();
         drop(access);
         assert!(dirty.load(Ordering::Acquire));
 
         dirty.store(false, Ordering::Release);
         {
-            let access = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+            let access = test_row_write_access(&page, &row_ver, &dirty, 0);
             let offset = page.header.var_field_offset();
             let _row = access.row_mut(offset, offset);
         }
@@ -1589,7 +1658,7 @@ mod tests {
 
         dirty.store(false, Ordering::Release);
         {
-            let mut access = test_row_write_access(&page, &frame_ctx, &dirty, 1);
+            let mut access = test_row_write_access(&page, &row_ver, &dirty, 1);
             access.delete_row();
         }
         assert!(dirty.load(Ordering::Acquire));
@@ -1601,16 +1670,15 @@ mod tests {
         let page = row_page(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         *row_ver.write_state() = RowPageState::Frozen;
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
         let dirty = AtomicBool::new(false);
 
         let result = catch_unwind(AssertUnwindSafe(|| {
-            let _access = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+            let _access = test_row_write_access(&page, &row_ver, &dirty, 0);
             panic!("exercise unwind cleanup");
         }));
 
         assert!(result.is_err());
-        assert_eq!(frame_ctx.expect_vmap().frozen_mutation_version(), 2);
+        assert_eq!(row_ver.frozen_mutation_version(), 2);
     }
 
     #[test]
@@ -1619,13 +1687,11 @@ mod tests {
         let page = row_page_with_two_rows(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         *row_ver.write_state() = RowPageState::Frozen;
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let row_ver = frame_ctx.expect_vmap();
         let dirty = AtomicBool::new(false);
 
-        let first = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+        let first = test_row_write_access(&page, &row_ver, &dirty, 0);
         assert_eq!(row_ver.frozen_mutation_version(), 1);
-        let second = test_row_write_access(&page, &frame_ctx, &dirty, 1);
+        let second = test_row_write_access(&page, &row_ver, &dirty, 1);
         assert_eq!(row_ver.frozen_mutation_version(), 2);
 
         drop(first);
@@ -1640,8 +1706,6 @@ mod tests {
         let metadata = sparse_metadata();
         let page = row_page_with_two_rows(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let row_ver = frame_ctx.expect_vmap();
         let dirty = AtomicBool::new(false);
         assert_eq!(row_ver.inspect_state(), RowPageState::Active);
 
@@ -1650,11 +1714,11 @@ mod tests {
                 .is_ok()
         );
         {
-            let _access = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+            let _access = test_row_write_access(&page, &row_ver, &dirty, 0);
             page.update_col(metadata.col.as_ref(), 0, 0, &Val::from(11i32), 0, true);
         }
         {
-            let mut access = test_row_write_access(&page, &frame_ctx, &dirty, 1);
+            let mut access = test_row_write_access(&page, &row_ver, &dirty, 1);
             access.delete_row();
         }
 
@@ -1667,7 +1731,7 @@ mod tests {
         )));
         // Statement rollback and full transaction rollback share this row
         // restoration boundary, so exercise two independent rollback passes.
-        test_row_write_access(&page, &frame_ctx, &dirty, 0)
+        test_row_write_access(&page, &row_ver, &dirty, 0)
             .rollback_first_undo(&metadata, rollback_undo);
         let trx_rollback_undo =
             OwnedRowUndo::new(TableID::new(1), None, RowID::new(100), RowUndoKind::Lock);
@@ -1675,7 +1739,7 @@ mod tests {
             Arc::new(SharedTrxStatus::new(MIN_ACTIVE_TRX_ID + 11)),
             trx_rollback_undo.leak(),
         )));
-        test_row_write_access(&page, &frame_ctx, &dirty, 0)
+        test_row_write_access(&page, &row_ver, &dirty, 0)
             .rollback_first_undo(&metadata, trx_rollback_undo);
 
         let purge_undo =
@@ -1684,7 +1748,7 @@ mod tests {
             Arc::new(SharedTrxStatus::new(TrxID::new(20))),
             purge_undo.leak(),
         )));
-        test_row_write_access(&page, &frame_ctx, &dirty, 1).purge_undo_chain(TrxID::new(21));
+        test_row_write_access(&page, &row_ver, &dirty, 1).purge_undo_chain(TrxID::new(21));
 
         assert_eq!(row_ver.frozen_mutation_version(), 0);
     }
@@ -1695,8 +1759,6 @@ mod tests {
         let page = row_page_with_two_rows(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
         *row_ver.write_state() = RowPageState::Frozen;
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let row_ver = frame_ctx.expect_vmap();
         let dirty = AtomicBool::new(false);
         let repeated_status = Arc::new(SharedTrxStatus::new(MIN_ACTIVE_TRX_ID + 9));
         let repeated_first_undo =
@@ -1713,13 +1775,13 @@ mod tests {
         )));
 
         {
-            let mut access = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+            let mut access = test_row_write_access(&page, &row_ver, &dirty, 0);
             assert_eq!(row_ver.frozen_mutation_version(), 1);
             access.delete_row();
         }
         assert_eq!(row_ver.frozen_mutation_version(), 2);
         {
-            let mut access = test_row_write_access(&page, &frame_ctx, &dirty, 1);
+            let mut access = test_row_write_access(&page, &row_ver, &dirty, 1);
             assert_eq!(row_ver.frozen_mutation_version(), 3);
             access.delete_row();
         }
@@ -1735,7 +1797,7 @@ mod tests {
         let prepared_version = row_ver.frozen_mutation_version();
         // First model statement rollback of the current undo entry.
         {
-            let mut access = test_row_write_access(&page, &frame_ctx, &dirty, 0);
+            let mut access = test_row_write_access(&page, &row_ver, &dirty, 0);
             assert_eq!(row_ver.frozen_mutation_version(), prepared_version + 1);
             access.rollback_first_undo(&metadata, rollback_undo);
         }
@@ -1749,7 +1811,7 @@ mod tests {
         )));
         let prepared_version = row_ver.frozen_mutation_version();
         // Then model the identical boundary reached by transaction rollback.
-        test_row_write_access(&page, &frame_ctx, &dirty, 0)
+        test_row_write_access(&page, &row_ver, &dirty, 0)
             .rollback_first_undo(&metadata, trx_rollback_undo);
         assert_eq!(row_ver.frozen_mutation_version(), prepared_version + 2);
 
@@ -1761,7 +1823,7 @@ mod tests {
         )));
         let prepared_version = row_ver.frozen_mutation_version();
         {
-            let mut access = test_row_write_access(&page, &frame_ctx, &dirty, 1);
+            let mut access = test_row_write_access(&page, &row_ver, &dirty, 1);
             assert_eq!(row_ver.frozen_mutation_version(), prepared_version + 1);
             access.purge_undo_chain(TrxID::new(21));
         }
@@ -1772,8 +1834,8 @@ mod tests {
     fn test_read_row_latest_inactive_index_returns_invalid_index() {
         let metadata = sparse_metadata();
         let page = row_page(&metadata);
-        let frame_ctx = FrameContext::RowRecoveryMap(RowRecoveryMap::new(TrxID::new(0)));
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let rec_map = RowRecoveryMap::new(TrxID::new(0));
+        let access = test_recovery_row_read_access(&page, &rec_map, 0);
         let key = SelectKey::new(1, vec![Val::from(10i32)]);
 
         let res = access.read_row_latest(&metadata, &[0], Some((key.index_no, &key.vals)));
@@ -1800,8 +1862,7 @@ mod tests {
             Arc::new(SharedTrxStatus::new(MIN_ACTIVE_TRX_ID + 99)),
             undo.leak(),
         )));
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let access = test_row_read_access(&page, &row_ver, 0);
         let trx_ctx = test_trx_context(TrxID::new(1));
         let key = SelectKey::new(1, vec![Val::from(10i32)]);
 
@@ -1814,8 +1875,8 @@ mod tests {
     fn test_any_version_matches_key_inactive_index_returns_false() {
         let metadata = sparse_metadata();
         let page = row_page(&metadata);
-        let frame_ctx = FrameContext::RowRecoveryMap(RowRecoveryMap::new(TrxID::new(0)));
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let rec_map = RowRecoveryMap::new(TrxID::new(0));
+        let access = test_recovery_row_read_access(&page, &rec_map, 0);
         let key = SelectKey::new(1, vec![Val::from(10i32)]);
 
         assert!(!access.any_version_matches_key(&metadata, key.index_no, &key.vals));
@@ -1825,8 +1886,8 @@ mod tests {
     fn test_any_version_matches_key_latest_page_row_returns_true() {
         let metadata = sparse_metadata();
         let page = row_page(&metadata);
-        let frame_ctx = FrameContext::RowRecoveryMap(RowRecoveryMap::new(TrxID::new(0)));
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let rec_map = RowRecoveryMap::new(TrxID::new(0));
+        let access = test_recovery_row_read_access(&page, &rec_map, 0);
         let key = SelectKey::new(0, vec![Val::from(10i32)]);
 
         assert!(access.any_version_matches_key(&metadata, key.index_no, &key.vals));
@@ -1854,8 +1915,7 @@ mod tests {
         let metadata = sparse_metadata();
         let page = row_page(&metadata);
         let row_ver = RowVersionMap::new(Arc::clone(&metadata.col), 4);
-        let frame_ctx = FrameContext::RowVerMap(row_ver);
-        let access = RowReadAccess::new(&page, &frame_ctx, 0);
+        let access = test_row_read_access(&page, &row_ver, 0);
         let key = SelectKey::new(1, vec![Val::from(10i32)]);
         let trx_ctx = test_trx_context(TrxID::new(1));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved handling of row-page version and recovery state during inserts, updates, deletes, scans, indexing, persistence, and transaction cleanup.
  * Strengthened page-freezing, checkpoint, recovery, and undo-chain workflows for more consistent data operations.

* **Maintenance**
  * Simplified internal row-access handling across storage and table operations without changing expected functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->