### PR TITLE
chore: internal refactor of hot row mutation

### DIFF
--- a/doradb-storage/src/row/ops.rs
+++ b/doradb-storage/src/row/ops.rs
@@ -459,7 +459,6 @@ pub(crate) enum Delete {
 pub enum DeleteMvcc {
     Deleted,
     NotFound,
-    WriteConflict,
 }
 
 impl DeleteMvcc {

--- a/doradb-storage/src/table/access.rs
+++ b/doradb-storage/src/table/access.rs
@@ -1,5 +1,8 @@
 use super::{
-    hot::{HotRowDeleter, HotRowUpdater, RowInserter, read_hot_row_mvcc},
+    hot::{
+        DeleteInternal, HotRowMutator, InsertRowIntoPage, RowInserter, UpdateRowInplace,
+        read_hot_row_mvcc,
+    },
     missing_secondary_index,
 };
 use crate::buffer::guard::{PageGuard, PageSharedGuard};
@@ -28,10 +31,9 @@ use crate::row::ops::{
 };
 use crate::row::{Row, RowPage, RowRead, estimate_max_row_count};
 use crate::table::{
-    ColumnDeletionBuffer, ColumnStorage, DeleteInternal, DeleteMarker, DeletionError,
-    DmlValidationDomain, DmlValidator, InsertRowIntoPage, MemTable, RowPageDescriptor, Table,
-    TableRootSnapshot, TableRuntimeLayout, UpdateRowInplace, UpdateUniqueMvcc,
-    index_key_is_changed, index_key_replace, read_latest_index_key, row_len,
+    ColumnDeletionBuffer, ColumnStorage, DeleteMarker, DeletionError, DmlValidationDomain,
+    DmlValidator, MemTable, RowPageDescriptor, Table, TableRootSnapshot, TableRuntimeLayout,
+    UpdateUniqueMvcc, index_key_is_changed, index_key_replace, read_latest_index_key, row_len,
     unique_key_from_full_row,
 };
 use crate::trx::row::{FindOldVersion, IndexCandidateRecheck, ReadLatestRow, RowReadAccess};
@@ -1147,8 +1149,10 @@ impl<'a> UserTableAccessor<'a> {
         old_id: RowID,
         old_guard: PageSharedGuard<RowPage>,
     ) -> Result<(RowID, FastHashMap<usize, Val>, PageSharedGuard<RowPage>)> {
-        let prepared = HotRowUpdater::new(self.table_id(), self.metadata(), rt)
-            .prepare_move_update(old_row, update, old_id, old_guard);
+        let prepared = HotRowMutator::new(self.table_id(), self.metadata(), rt, &old_guard, old_id)
+            .prepare_move_update(old_row, update);
+        // Release the old row page before awaiting replacement-row insertion.
+        drop(old_guard);
         let (new_row_id, new_guard) = self
             .insert_row_internal(
                 rt,
@@ -2708,16 +2712,11 @@ impl<'a> UserTableAccessor<'a> {
         update: Vec<UpdateCol>,
         root_snapshot: &TableRootSnapshot<'_>,
     ) -> Result<Option<InsertedRow>> {
-        match HotRowUpdater::new(self.table_id(), self.metadata(), rt)
-            .update_known_row(
-                effects,
-                page_guard,
-                row_id,
-                RowUpdateInput::Sparse(update),
-            )
-            .await
-        {
-            UpdateRowInplace::Ok(new_row_id, index_change_cols, page_guard) => {
+        let result = HotRowMutator::new(self.table_id(), self.metadata(), rt, &page_guard, row_id)
+            .update_known_row(effects, RowUpdateInput::Sparse(update))
+            .await?;
+        match result {
+            UpdateRowInplace::Ok(new_row_id, index_change_cols) => {
                 debug_assert_eq!(row_id, new_row_id);
                 if !index_change_cols.is_empty() {
                     self.update_indexes_only_key_change(
@@ -2738,9 +2737,6 @@ impl<'a> UserTableAccessor<'a> {
                     .attach("full-table update hot row changed after visibility")
                     .into())
             }
-            UpdateRowInplace::WriteConflict => Err(Report::new(OperationError::WriteConflict)
-                .attach("full-table update hot row write lock")
-                .into()),
             UpdateRowInplace::RetryInTransition(_) => {
                 Err(Report::new(InternalError::FullTableUpdateTransitionPage)
                     .attach(format!(
@@ -2748,7 +2744,7 @@ impl<'a> UserTableAccessor<'a> {
                     ))
                     .into())
             }
-            UpdateRowInplace::NoFreeSpace(old_row_id, old_row, update, old_guard) => {
+            UpdateRowInplace::NoFreeSpaceOrFrozen(old_row_id, old_row, update) => {
                 let (new_row_id, index_change_cols, new_guard) = self
                     .move_update_for_space(
                         rt,
@@ -2756,7 +2752,7 @@ impl<'a> UserTableAccessor<'a> {
                         old_row,
                         update,
                         old_row_id,
-                        old_guard,
+                        page_guard,
                     )
                     .await?;
                 let result = if index_change_cols.is_empty() {
@@ -3204,13 +3200,11 @@ impl<'a> UserTableAccessor<'a> {
                     }
                 }
             };
-            let res = HotRowUpdater::new(self.table_id(), self.metadata(), rt)
-                .update_inplace(
-                    effects, page_guard, index_no, key_vals, row_id, input, log_by_key,
-                )
-                .await;
+            let res = HotRowMutator::new(self.table_id(), self.metadata(), rt, &page_guard, row_id)
+                .update_inplace(effects, index_no, key_vals, input, log_by_key)
+                .await?;
             match res {
-                UpdateRowInplace::Ok(new_row_id, index_change_cols, page_guard) => {
+                UpdateRowInplace::Ok(new_row_id, index_change_cols) => {
                     debug_assert!(row_id == new_row_id);
                     if !index_change_cols.is_empty() {
                         // RowID is unchanged, but logical keys may have moved.
@@ -3234,16 +3228,13 @@ impl<'a> UserTableAccessor<'a> {
                 UpdateRowInplace::RowDeleted(input) | UpdateRowInplace::RowNotFound(input) => {
                     return Ok(UpdateUniqueMvcc::NotFound(input));
                 }
-                UpdateRowInplace::WriteConflict => {
-                    return Err(Report::new(OperationError::WriteConflict)
-                        .attach("update MVCC row-page write lock")
-                        .into());
-                }
                 UpdateRowInplace::RetryInTransition(returned_input) => {
                     input = returned_input;
+                    // Release the row page so the checkpoint transition can complete.
+                    drop(page_guard);
                     self.wait_transition_route_or_poison(rt, row_id).await?;
                 }
-                UpdateRowInplace::NoFreeSpace(old_row_id, old_row, returned_input, old_guard) => {
+                UpdateRowInplace::NoFreeSpaceOrFrozen(old_row_id, old_row, returned_input) => {
                     // In-place update failed after the old row was locked and
                     // marked deleted. Finish the move update by inserting the
                     // replacement row and then update indexes for any RowID or
@@ -3255,7 +3246,7 @@ impl<'a> UserTableAccessor<'a> {
                             old_row,
                             returned_input,
                             old_row_id,
-                            old_guard,
+                            page_guard,
                         )
                         .await?;
                     if !index_change_cols.is_empty() {
@@ -3385,7 +3376,9 @@ impl<'a> UserTableAccessor<'a> {
                                     return Ok(DeleteMvcc::Deleted);
                                 }
                                 Err(DeletionError::WriteConflict) => {
-                                    return Ok(DeleteMvcc::WriteConflict);
+                                    return Err(Report::new(OperationError::WriteConflict)
+                                        .attach("delete MVCC cold delete marker ownership")
+                                        .into());
                                 }
                                 Err(DeletionError::AlreadyDeleted) => {
                                     return Ok(DeleteMvcc::NotFound);
@@ -3413,16 +3406,17 @@ impl<'a> UserTableAccessor<'a> {
                     }
                 }
             };
-            match HotRowDeleter::new(self.table_id(), self.metadata(), rt)
-                .delete(effects, page_guard, row_id, index_no, key_vals, log_by_key)
-                .await
-            {
+            let res = HotRowMutator::new(self.table_id(), self.metadata(), rt, &page_guard, row_id)
+                .delete(effects, index_no, key_vals, log_by_key)
+                .await?;
+            match res {
                 DeleteInternal::NotFound => return Ok(DeleteMvcc::NotFound),
-                DeleteInternal::WriteConflict => return Ok(DeleteMvcc::WriteConflict),
                 DeleteInternal::RetryInTransition => {
+                    // Release the row page so the checkpoint transition can complete.
+                    drop(page_guard);
                     self.wait_transition_route_or_poison(rt, row_id).await?;
                 }
-                DeleteInternal::Ok(page_guard) => {
+                DeleteInternal::Ok => {
                     // Mask every secondary-index entry for this hot row. The
                     // physical index entry remains until rollback unmasks it
                     // or index GC removes it after it is no longer visible.
@@ -3658,11 +3652,11 @@ mod tests {
         SessionTestExt, assert_checkpoint_published, wait_for_checkpoint_purge,
     };
     use crate::table::checkpoint_workflow::CheckpointPublicationGuard;
-    use crate::table::hot::{HotRowDeleter, HotRowUpdater, RowInserter};
-    use crate::table::tests::*;
-    use crate::table::{
-        CheckpointOutcome, DeleteInternal, FreezeOutcome, InsertRowIntoPage, UpdateRowInplace,
+    use crate::table::hot::{
+        DeleteInternal, HotRowMutator, InsertRowIntoPage, RowInserter, UpdateRowInplace,
     };
+    use crate::table::tests::*;
+    use crate::table::{CheckpointOutcome, FreezeOutcome};
     use crate::table::{ColumnDeletionBuffer, DeleteMarker};
     use crate::trx::row::{LockRowForWrite, ReadLatestRow};
     use crate::trx::stmt::tests as stmt_tests;
@@ -4469,8 +4463,10 @@ mod tests {
 
             let mut session2 = engine.new_session().unwrap();
             let mut trx2 = session2.begin_trx().unwrap();
-            let res2 = trx_delete_row_by_id(&mut trx2, table_id, &key).await;
-            assert!(matches!(res2, Ok(DeleteMvcc::WriteConflict)));
+            let err = trx_delete_row_by_id(&mut trx2, table_id, &key)
+                .await
+                .unwrap_err();
+            assert_eq!(err.operation_error(), Some(OperationError::WriteConflict));
             trx2.rollback().await.unwrap();
             drop(session2);
 
@@ -4560,8 +4556,10 @@ mod tests {
             })
             .await;
 
-            let res = trx_delete_row_by_id(&mut writer, table_id, &key).await;
-            assert!(matches!(res, Ok(DeleteMvcc::WriteConflict)));
+            let err = trx_delete_row_by_id(&mut writer, table_id, &key)
+                .await
+                .unwrap_err();
+            assert_eq!(err.operation_error(), Some(OperationError::WriteConflict));
             writer.rollback().await.unwrap();
 
             expect_select_not_found_committed(table_id, &mut session, &key).await;
@@ -5335,17 +5333,21 @@ mod tests {
                     let table = table_for_internal_assertion(&engine, table_id);
                     let layout = table.layout_snapshot();
                     let accessor = table.accessor_with_layout(&layout);
-                    let res = HotRowUpdater::new(accessor.table_id(), accessor.metadata(), rt)
-                        .update_inplace(
-                            effects,
-                            page_guard,
-                            key.index_no,
-                            &key.vals,
-                            row_id,
-                            RowUpdateInput::Sparse(update),
-                            false,
-                        )
-                        .await;
+                    let res = HotRowMutator::new(
+                        accessor.table_id(),
+                        accessor.metadata(),
+                        rt,
+                        &page_guard,
+                        row_id,
+                    )
+                    .update_inplace(
+                        effects,
+                        key.index_no,
+                        &key.vals,
+                        RowUpdateInput::Sparse(update),
+                        false,
+                    )
+                    .await?;
                     assert!(matches!(res, UpdateRowInplace::RetryInTransition(_)));
                     Err(Report::new(OperationError::NotSupported).into())
                 })
@@ -5378,9 +5380,15 @@ mod tests {
                     let table = table_for_internal_assertion(&engine, table_id);
                     let layout = table.layout_snapshot();
                     let accessor = table.accessor_with_layout(&layout);
-                    let res = HotRowDeleter::new(accessor.table_id(), accessor.metadata(), rt)
-                        .delete(effects, page_guard, row_id, key.index_no, &key.vals, false)
-                        .await;
+                    let res = HotRowMutator::new(
+                        accessor.table_id(),
+                        accessor.metadata(),
+                        rt,
+                        &page_guard,
+                        row_id,
+                    )
+                    .delete(effects, key.index_no, &key.vals, false)
+                    .await?;
                     assert!(matches!(res, DeleteInternal::RetryInTransition));
                     Err(Report::new(OperationError::NotSupported).into())
                 })
@@ -6705,15 +6713,15 @@ mod tests {
                     // undo entry at the row's undo head. That entry is the
                     // row-level write lock and the rollback anchor that is
                     // later rewritten to Insert/Update/Delete.
-                    let mut lock_row =
-                        HotRowUpdater::new(accessor.table_id(), accessor.metadata(), rt)
-                            .lock_for_write(
-                                effects,
-                                &page_guard,
-                                row_id,
-                                Some((key.index_no, &key.vals)),
-                            )
-                            .await;
+                    let mut lock_row = HotRowMutator::new(
+                        accessor.table_id(),
+                        accessor.metadata(),
+                        rt,
+                        &page_guard,
+                        row_id,
+                    )
+                    .lock_for_write(effects, Some((key.index_no, &key.vals)))
+                    .await;
                     match &mut lock_row {
                         LockRowForWrite::Ok(access) => {
                             drop(access.take());

--- a/doradb-storage/src/table/hot.rs
+++ b/doradb-storage/src/table/hot.rs
@@ -1,5 +1,6 @@
 use crate::buffer::guard::{PageGuard, PageSharedGuard};
 use crate::catalog::TableMetadata;
+use crate::error::{OperationError, OperationResult};
 use crate::id::{RowID, TableID};
 use crate::log::redo::{RowRedo, RowRedoKind};
 use crate::map::FastHashMap;
@@ -7,14 +8,41 @@ use crate::row::ops::{
     ReadRow, RowUpdateInput, SelectKey, SelectMvcc, UndoCol, UpdateCol, UpdateRow,
 };
 use crate::row::{RowPage, RowRead, var_len_for_insert};
-use crate::table::{DeleteInternal, InsertRowIntoPage, UpdateRowInplace};
 use crate::trx::TrxRuntime;
 use crate::trx::row::{LockRowForWrite, LockUndo};
 use crate::trx::stmt::StmtEffects;
 use crate::trx::undo::{IndexBranch, IndexBranchTarget, RowUndoKind};
 use crate::trx::ver_map::RowPageState;
 use crate::value::Val;
+use error_stack::Report;
 use std::mem::replace;
+
+/// Result of inserting a row into one hot row page.
+pub(super) enum InsertRowIntoPage {
+    Ok(RowID, PageSharedGuard<RowPage>),
+    NoSpaceOrFrozen(Vec<Val>, RowUndoKind, Vec<IndexBranch>),
+}
+
+/// Result of updating one hot row in place.
+pub(super) enum UpdateRowInplace {
+    // The caller keeps the row page lock if there is any index change,
+    // so it can read latest values from page.
+    // The hash map stores the changed column number and its old value.
+    // for other columns in the changed index, we can read value(old and new are same)
+    // from current page.
+    Ok(RowID, FastHashMap<usize, Val>),
+    RowNotFound(RowUpdateInput),
+    RowDeleted(RowUpdateInput),
+    RetryInTransition(RowUpdateInput),
+    NoFreeSpaceOrFrozen(RowID, Vec<Val>, RowUpdateInput),
+}
+
+/// Result of deleting one hot row.
+pub(super) enum DeleteInternal {
+    Ok,
+    NotFound,
+    RetryInTransition,
+}
 
 /// Hot row-page insert context shared by catalog and user-table accessors.
 pub(super) struct RowInserter<'m, 'r> {
@@ -121,80 +149,6 @@ impl<'m, 'r> RowInserter<'m, 'r> {
     }
 }
 
-/// Hot row-page delete context shared by catalog and user-table accessors.
-pub(super) struct HotRowDeleter<'m, 'r> {
-    metadata: &'m TableMetadata,
-    table_id: TableID,
-    rt: TrxRuntime<'r>,
-}
-
-impl<'m, 'r> HotRowDeleter<'m, 'r> {
-    /// Create a hot-row deleter for one metadata snapshot and transaction.
-    #[inline]
-    pub(super) fn new(table_id: TableID, metadata: &'m TableMetadata, rt: TrxRuntime<'r>) -> Self {
-        Self {
-            metadata,
-            table_id,
-            rt,
-        }
-    }
-
-    /// Delete one hot row after validating that the row belongs to the page.
-    #[inline]
-    pub(super) async fn delete(
-        &self,
-        effects: &mut StmtEffects,
-        page_guard: PageSharedGuard<RowPage>,
-        row_id: RowID,
-        index_no: usize,
-        key_vals: &[Val],
-        log_by_key: bool,
-    ) -> DeleteInternal {
-        let page_id = page_guard.page_id();
-        let page = page_guard.page();
-        if !page.row_id_in_valid_range(row_id) {
-            return DeleteInternal::NotFound;
-        }
-        // The undo-head lock is the conflict check for hot delete. Once the
-        // lock is owned, the row-page delete bit becomes the latest image and
-        // the same undo entry is rewritten to `Delete`.
-        let mut lock_row = HotRowUpdater::new(self.table_id, self.metadata, self.rt)
-            .lock_for_write(effects, &page_guard, row_id, Some((index_no, key_vals)))
-            .await;
-        match &mut lock_row {
-            LockRowForWrite::InvalidIndex => DeleteInternal::NotFound,
-            LockRowForWrite::WriteConflict => DeleteInternal::WriteConflict,
-            LockRowForWrite::RetryInTransition => DeleteInternal::RetryInTransition,
-            LockRowForWrite::Ok(access) => {
-                let mut access = access
-                    .take()
-                    .expect("successful hot-row write lock must provide row write access");
-                if access.row().is_deleted() {
-                    return DeleteInternal::NotFound;
-                }
-                access.delete_row();
-                // update LOCK entry to DELETE entry.
-                effects.update_last_row_undo(RowUndoKind::Delete);
-                drop(access); // unlock row.
-                drop(lock_row);
-                // hold page lock in order to update index later.
-                // create redo log.
-                let redo_entry = RowRedo {
-                    page_id,
-                    row_id,
-                    kind: if log_by_key {
-                        RowRedoKind::DeleteByPrimaryKey(SelectKey::new(index_no, key_vals.to_vec()))
-                    } else {
-                        RowRedoKind::Delete
-                    },
-                };
-                effects.insert_row_redo(self.table_id, redo_entry);
-                DeleteInternal::Ok(page_guard)
-            }
-        }
-    }
-}
-
 /// Prepared replacement state for a hot-row move update.
 pub(super) struct PreparedHotMoveUpdate {
     /// Replacement row values to insert as the new hot row.
@@ -205,34 +159,44 @@ pub(super) struct PreparedHotMoveUpdate {
     pub(super) index_branches: Vec<IndexBranch>,
 }
 
-/// Hot row-page update context shared by catalog and user-table accessors.
-pub(super) struct HotRowUpdater<'m, 'r> {
+/// Hot row-page mutation context shared by catalog and user-table accessors.
+pub(super) struct HotRowMutator<'m, 'r, 'g> {
     metadata: &'m TableMetadata,
     table_id: TableID,
     rt: TrxRuntime<'r>,
+    page_guard: &'g PageSharedGuard<RowPage>,
+    row_id: RowID,
 }
 
-impl<'m, 'r> HotRowUpdater<'m, 'r> {
-    /// Create a hot-row updater for one metadata snapshot and transaction.
+impl<'m, 'r, 'g> HotRowMutator<'m, 'r, 'g> {
+    /// Create a hot-row mutator for one page row, metadata snapshot, and transaction.
     #[inline]
-    pub(super) fn new(table_id: TableID, metadata: &'m TableMetadata, rt: TrxRuntime<'r>) -> Self {
+    pub(super) fn new(
+        table_id: TableID,
+        metadata: &'m TableMetadata,
+        rt: TrxRuntime<'r>,
+        page_guard: &'g PageSharedGuard<RowPage>,
+        row_id: RowID,
+    ) -> Self {
         Self {
             metadata,
             table_id,
             rt,
+            page_guard,
+            row_id,
         }
     }
 
     /// Lock a hot row by installing a provisional row undo entry.
     #[expect(clippy::await_holding_lock, reason = "clippy false positive")]
     #[inline]
-    pub(super) async fn lock_for_write<'b>(
+    pub(super) async fn lock_for_write(
         &self,
         effects: &mut StmtEffects,
-        page_guard: &'b PageSharedGuard<RowPage>,
-        row_id: RowID,
         key: Option<(usize, &[Val])>,
-    ) -> LockRowForWrite<'b> {
+    ) -> LockRowForWrite<'g> {
+        let page_guard = self.page_guard;
+        let row_id = self.row_id;
         let page = page_guard.page();
         let ver_map = page_guard.unwrap_vmap();
         loop {
@@ -281,32 +245,75 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
         }
     }
 
+    /// Delete the hot row after validating that it belongs to the page.
+    #[inline]
+    pub(super) async fn delete(
+        &self,
+        effects: &mut StmtEffects,
+        index_no: usize,
+        key_vals: &[Val],
+        log_by_key: bool,
+    ) -> OperationResult<DeleteInternal> {
+        let page_guard = self.page_guard;
+        let row_id = self.row_id;
+        let page_id = page_guard.page_id();
+        let page = page_guard.page();
+        if !page.row_id_in_valid_range(row_id) {
+            return Ok(DeleteInternal::NotFound);
+        }
+        // The undo-head lock is the conflict check for hot delete. Once the
+        // lock is owned, the row-page delete bit becomes the latest image and
+        // the same undo entry is rewritten to `Delete`.
+        let mut lock_row = self
+            .lock_for_write(effects, Some((index_no, key_vals)))
+            .await;
+        match &mut lock_row {
+            LockRowForWrite::InvalidIndex => Ok(DeleteInternal::NotFound),
+            LockRowForWrite::WriteConflict => Err(Report::new(OperationError::WriteConflict)
+                .attach("delete MVCC row-page write lock")),
+            LockRowForWrite::RetryInTransition => Ok(DeleteInternal::RetryInTransition),
+            LockRowForWrite::Ok(access) => {
+                let mut access = access
+                    .take()
+                    .expect("successful hot-row write lock must provide row write access");
+                if access.row().is_deleted() {
+                    return Ok(DeleteInternal::NotFound);
+                }
+                access.delete_row();
+                // update LOCK entry to DELETE entry.
+                effects.update_last_row_undo(RowUndoKind::Delete);
+                drop(access); // unlock row.
+                drop(lock_row);
+                // The caller retains the page lock in order to update indexes later.
+                // create redo log.
+                let redo_entry = RowRedo {
+                    page_id,
+                    row_id,
+                    kind: if log_by_key {
+                        RowRedoKind::DeleteByPrimaryKey(SelectKey::new(index_no, key_vals.to_vec()))
+                    } else {
+                        RowRedoKind::Delete
+                    },
+                };
+                effects.insert_row_redo(self.table_id, redo_entry);
+                Ok(DeleteInternal::Ok)
+            }
+        }
+    }
+
     /// Update a locked hot row in place, or report move-update state.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "hot row updates require row, key, update, and logging context"
-    )]
     #[inline]
     pub(super) async fn update_inplace(
         &self,
         effects: &mut StmtEffects,
-        page_guard: PageSharedGuard<RowPage>,
         index_no: usize,
         key_vals: &[Val],
-        row_id: RowID,
         update: RowUpdateInput,
         log_by_key: bool,
-    ) -> UpdateRowInplace {
+    ) -> OperationResult<UpdateRowInplace> {
         let redo_key = log_by_key.then(|| SelectKey::new(index_no, key_vals.to_vec()));
-        self.update_known_row_inner(
-            effects,
-            page_guard,
-            row_id,
-            update,
-            Some((index_no, key_vals)),
-            redo_key,
-        )
-        .await
+        self.update_known_row_inner(effects, update, Some((index_no, key_vals)), redo_key)
+            .await
     }
 
     /// Update one known page/row without revalidating an index lookup key.
@@ -314,11 +321,9 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
     pub(super) async fn update_known_row(
         &self,
         effects: &mut StmtEffects,
-        page_guard: PageSharedGuard<RowPage>,
-        row_id: RowID,
         update: RowUpdateInput,
-    ) -> UpdateRowInplace {
-        self.update_known_row_inner(effects, page_guard, row_id, update, None, None)
+    ) -> OperationResult<UpdateRowInplace> {
+        self.update_known_row_inner(effects, update, None, None)
             .await
     }
 
@@ -326,12 +331,12 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
     async fn update_known_row_inner(
         &self,
         effects: &mut StmtEffects,
-        page_guard: PageSharedGuard<RowPage>,
-        row_id: RowID,
         update: RowUpdateInput,
         lookup_key: Option<(usize, &[Val])>,
         redo_key: Option<SelectKey>,
-    ) -> UpdateRowInplace {
+    ) -> OperationResult<UpdateRowInplace> {
+        let page_guard = self.page_guard;
+        let row_id = self.row_id;
         let page_id = page_guard.page_id();
         let page = page_guard.page();
         debug_assert!(
@@ -341,19 +346,18 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
         if row_id < page.header.start_row_id
             || row_id >= page.header.start_row_id + page.header.max_row_count as u64
         {
-            return UpdateRowInplace::RowNotFound(update);
+            return Ok(UpdateRowInplace::RowNotFound(update));
         }
         // Modification is a current read: update the latest physical page
         // image, never an older version reconstructed from MVCC undo. The image
         // must remain stable until the undo-head lock is installed. The lock
         // path also rejects stale index candidates whose latest key differs.
-        let mut lock_row = self
-            .lock_for_write(effects, &page_guard, row_id, lookup_key)
-            .await;
+        let mut lock_row = self.lock_for_write(effects, lookup_key).await;
         match &mut lock_row {
-            LockRowForWrite::InvalidIndex => UpdateRowInplace::RowNotFound(update),
-            LockRowForWrite::WriteConflict => UpdateRowInplace::WriteConflict,
-            LockRowForWrite::RetryInTransition => UpdateRowInplace::RetryInTransition(update),
+            LockRowForWrite::InvalidIndex => Ok(UpdateRowInplace::RowNotFound(update)),
+            LockRowForWrite::WriteConflict => Err(Report::new(OperationError::WriteConflict)
+                .attach("update MVCC row-page write lock")),
+            LockRowForWrite::RetryInTransition => Ok(UpdateRowInplace::RetryInTransition(update)),
             LockRowForWrite::Ok(access) => {
                 let mut access = access
                     .take()
@@ -362,88 +366,90 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
                 if access.row().is_deleted() {
                     drop(access);
                     drop(lock_row);
-                    return UpdateRowInplace::RowDeleted(update);
+                    return Ok(UpdateRowInplace::RowDeleted(update));
                 }
-                match access.update_row(self.metadata.col.as_ref(), update.as_view(), frozen) {
-                    UpdateRow::NoFreeSpaceOrFrozen(old_row) => {
-                        // The hot row cannot be updated in place because the
-                        // page has no reusable space or has been frozen for
-                        // tuple movement. Convert this statement into a move
-                        // update: delete the old RowID with undo, insert the
-                        // replacement as a new hot RowID, and connect unique
-                        // owners with runtime branches when older snapshots
-                        // may still need the old version.
-                        //
-                        // Mark page data as deleted.
-                        access.delete_row();
-                        // Update LOCK entry to DELETE entry.
-                        effects.update_last_row_undo(RowUndoKind::Delete);
-                        drop(access); // unlock row
-                        drop(lock_row);
-                        // Here we do not unlock page because we need to perform out-of-place
-                        // update and link undo entries of two rows via index branches.
-                        // The re-lock of current undo is required.
-                        let redo_entry = RowRedo {
-                            page_id,
-                            row_id,
-                            // use DELETE for redo is ok, no version chain should be maintained if recovering from redo.
-                            kind: redo_key
-                                .clone()
-                                .map(RowRedoKind::DeleteByPrimaryKey)
-                                .unwrap_or(RowRedoKind::Delete),
-                        };
-                        effects.insert_row_redo(self.table_id, redo_entry);
-                        UpdateRowInplace::NoFreeSpace(row_id, old_row, update, page_guard)
-                    }
-                    UpdateRow::Ok(mut row) => {
-                        // In-place update keeps the RowID stable. Changed new
-                        // values are moved into redo on the successful path.
-                        let mut index_change_cols = FastHashMap::default();
-                        // perform in-place update.
-                        let (mut undo_cols, mut redo_cols) = (vec![], vec![]);
-                        for UpdateCol { idx, val } in update {
-                            if let Some((old_val, var_offset)) =
-                                row.different(self.metadata.col.as_ref(), idx, &val)
-                            {
-                                // we also check whether the value change is related to any index,
-                                // so we can update index later.
-                                if self.metadata.idx.index_columns().contains(&idx) {
-                                    index_change_cols.insert(idx, old_val.clone());
-                                }
-                                // actual update
-                                row.update_col(self.metadata.col.as_ref(), idx, &val);
-                                // record undo and redo
-                                undo_cols.push(UndoCol {
-                                    idx,
-                                    val: old_val,
-                                    var_offset,
-                                });
-                                redo_cols.push(UpdateCol { idx, val });
-                            }
-                        }
-                        // The provisional row lock now becomes the operation
-                        // kind that MVCC reads and rollback will interpret.
-                        effects.update_last_row_undo(RowUndoKind::Update(undo_cols));
-                        drop(access); // unlock the row.
-                        drop(lock_row);
-                        // we may still need this page if we'd like to update index.
-                        if !redo_cols.is_empty() {
-                            // A no-op update still used a row lock, but only a
-                            // real value change needs redo.
+                Ok(
+                    match access.update_row(self.metadata.col.as_ref(), update.as_view(), frozen) {
+                        UpdateRow::NoFreeSpaceOrFrozen(old_row) => {
+                            // The hot row cannot be updated in place because the
+                            // page has no reusable space or has been frozen for
+                            // tuple movement. Convert this statement into a move
+                            // update: delete the old RowID with undo, insert the
+                            // replacement as a new hot RowID, and connect unique
+                            // owners with runtime branches when older snapshots
+                            // may still need the old version.
+                            //
+                            // Mark page data as deleted.
+                            access.delete_row();
+                            // Update LOCK entry to DELETE entry.
+                            effects.update_last_row_undo(RowUndoKind::Delete);
+                            drop(access); // unlock row
+                            drop(lock_row);
+                            // Here we do not unlock page because we need to perform out-of-place
+                            // update and link undo entries of two rows via index branches.
+                            // The re-lock of current undo is required.
                             let redo_entry = RowRedo {
                                 page_id,
                                 row_id,
+                                // use DELETE for redo is ok, no version chain should be maintained if recovering from redo.
                                 kind: redo_key
-                                    .map(|key| {
-                                        RowRedoKind::UpdateByPrimaryKey(key, redo_cols.clone())
-                                    })
-                                    .unwrap_or(RowRedoKind::Update(redo_cols)),
+                                    .clone()
+                                    .map(RowRedoKind::DeleteByPrimaryKey)
+                                    .unwrap_or(RowRedoKind::Delete),
                             };
                             effects.insert_row_redo(self.table_id, redo_entry);
+                            UpdateRowInplace::NoFreeSpaceOrFrozen(row_id, old_row, update)
                         }
-                        UpdateRowInplace::Ok(row_id, index_change_cols, page_guard)
-                    }
-                }
+                        UpdateRow::Ok(mut row) => {
+                            // In-place update keeps the RowID stable. Changed new
+                            // values are moved into redo on the successful path.
+                            let mut index_change_cols = FastHashMap::default();
+                            // perform in-place update.
+                            let (mut undo_cols, mut redo_cols) = (vec![], vec![]);
+                            for UpdateCol { idx, val } in update {
+                                if let Some((old_val, var_offset)) =
+                                    row.different(self.metadata.col.as_ref(), idx, &val)
+                                {
+                                    // we also check whether the value change is related to any index,
+                                    // so we can update index later.
+                                    if self.metadata.idx.index_columns().contains(&idx) {
+                                        index_change_cols.insert(idx, old_val.clone());
+                                    }
+                                    // actual update
+                                    row.update_col(self.metadata.col.as_ref(), idx, &val);
+                                    // record undo and redo
+                                    undo_cols.push(UndoCol {
+                                        idx,
+                                        val: old_val,
+                                        var_offset,
+                                    });
+                                    redo_cols.push(UpdateCol { idx, val });
+                                }
+                            }
+                            // The provisional row lock now becomes the operation
+                            // kind that MVCC reads and rollback will interpret.
+                            effects.update_last_row_undo(RowUndoKind::Update(undo_cols));
+                            drop(access); // unlock the row.
+                            drop(lock_row);
+                            // we may still need this page if we'd like to update index.
+                            if !redo_cols.is_empty() {
+                                // A no-op update still used a row lock, but only a
+                                // real value change needs redo.
+                                let redo_entry = RowRedo {
+                                    page_id,
+                                    row_id,
+                                    kind: redo_key
+                                        .map(|key| {
+                                            RowRedoKind::UpdateByPrimaryKey(key, redo_cols.clone())
+                                        })
+                                        .unwrap_or(RowRedoKind::Update(redo_cols)),
+                                };
+                                effects.insert_row_redo(self.table_id, redo_entry);
+                            }
+                            UpdateRowInplace::Ok(row_id, index_change_cols)
+                        }
+                    },
+                )
             }
         }
     }
@@ -454,9 +460,9 @@ impl<'m, 'r> HotRowUpdater<'m, 'r> {
         &self,
         old_row: Vec<Val>,
         update: RowUpdateInput,
-        old_id: RowID,
-        old_guard: PageSharedGuard<RowPage>,
     ) -> PreparedHotMoveUpdate {
+        let old_guard = self.page_guard;
+        let old_id = self.row_id;
         // Build the replacement hot row and remember indexed old values. The
         // caller already turned the old hot row's first undo entry into
         // `Delete`, so this path is logically delete-old plus insert-new.

--- a/doradb-storage/src/table/mem_table.rs
+++ b/doradb-storage/src/table/mem_table.rs
@@ -2767,6 +2767,8 @@ mod tests {
     use crate::trx::stmt::tests as stmt_tests;
     use crate::trx::ver_map::RowPageState;
     use crate::value::{Val, ValKind};
+    use futures::FutureExt;
+    use std::panic::AssertUnwindSafe;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -4105,7 +4107,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mem_table_transition_retry_is_internal_error() {
+    fn test_mem_table_transition_update_errors_and_delete_panics() {
         smol::block_on(async {
             let temp_dir = TempDir::new().unwrap();
             let engine =
@@ -4165,18 +4167,26 @@ mod tests {
             trx.rollback().await.unwrap();
 
             let mut trx = session.begin_trx().unwrap();
-            let err = trx
-                .exec(async |stmt| {
-                    stmt.acquire_table_write_metadata_lock(mem_table_id).await?;
-                    stmt.acquire_table_write_data_lock(mem_table_id).await?;
-                    let (rt, effects) = stmt_tests::runtime_and_effects_mut(stmt);
-                    mem_table
-                        .delete_unique_mvcc(rt, effects, key.index_no, &key.vals, false)
-                        .await
-                })
-                .await
-                .unwrap_err();
-            assert_eq!(err.kind(), ErrorKind::Internal);
+            let panic = AssertUnwindSafe(trx.exec(async |stmt| {
+                stmt.acquire_table_write_metadata_lock(mem_table_id).await?;
+                stmt.acquire_table_write_data_lock(mem_table_id).await?;
+                let (rt, effects) = stmt_tests::runtime_and_effects_mut(stmt);
+                mem_table
+                    .delete_unique_mvcc(rt, effects, key.index_no, &key.vals, false)
+                    .await
+            }))
+            .catch_unwind()
+            .await
+            .expect_err("standalone MemTable delete must reject a transition page");
+            let message = panic
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| panic.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown panic");
+            assert!(
+                message.contains("standalone MemTable delete observed TRANSITION row page"),
+                "unexpected panic: {message}"
+            );
             trx.rollback().await.unwrap();
         });
     }

--- a/doradb-storage/src/table/mem_table.rs
+++ b/doradb-storage/src/table/mem_table.rs
@@ -1,7 +1,6 @@
 use super::{
-    DeleteInternal, DmlValidationDomain, DmlValidator, InsertRowIntoPage, UpdateRowInplace,
-    UpdateUniqueMvcc,
-    hot::{HotRowDeleter, HotRowUpdater, RowInserter},
+    DmlValidationDomain, DmlValidator, UpdateUniqueMvcc,
+    hot::{DeleteInternal, HotRowMutator, InsertRowIntoPage, RowInserter, UpdateRowInplace},
     index_key_is_changed, index_key_replace, missing_secondary_index, read_latest_index_key,
     row_len, unique_key_from_full_row, validate_page_row_range,
 };
@@ -1900,13 +1899,11 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                     Err(err) => return Err(err),
                 },
             };
-            let res = HotRowUpdater::new(self.table_id(), self.metadata(), rt)
-                .update_inplace(
-                    effects, page_guard, index_no, key_vals, row_id, input, log_by_key,
-                )
-                .await;
+            let res = HotRowMutator::new(self.table_id(), self.metadata(), rt, &page_guard, row_id)
+                .update_inplace(effects, index_no, key_vals, input, log_by_key)
+                .await?;
             match res {
-                UpdateRowInplace::Ok(new_row_id, index_change_cols, page_guard) => {
+                UpdateRowInplace::Ok(new_row_id, index_change_cols) => {
                     debug_assert!(row_id == new_row_id);
                     if !index_change_cols.is_empty() {
                         let result = self
@@ -1926,11 +1923,6 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                 UpdateRowInplace::RowDeleted(input) | UpdateRowInplace::RowNotFound(input) => {
                     return Ok(UpdateUniqueMvcc::NotFound(input));
                 }
-                UpdateRowInplace::WriteConflict => {
-                    return Err(Report::new(OperationError::WriteConflict)
-                        .attach("update MVCC row-page write lock")
-                        .into());
-                }
                 UpdateRowInplace::RetryInTransition(returned_input) => {
                     let _ = returned_input;
                     // Standalone/catalog MemTable owns hot row-store state
@@ -1940,7 +1932,7 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                         .attach("standalone MemTable update observed TRANSITION row page")
                         .into());
                 }
-                UpdateRowInplace::NoFreeSpace(old_row_id, old_row, returned_input, old_guard) => {
+                UpdateRowInplace::NoFreeSpaceOrFrozen(old_row_id, old_row, returned_input) => {
                     let (new_row_id, index_change_cols, new_guard) = self
                         .move_update_for_space(
                             rt,
@@ -1948,7 +1940,7 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                             old_row,
                             returned_input,
                             old_row_id,
-                            old_guard,
+                            page_guard,
                         )
                         .await?;
                     if !index_change_cols.is_empty() {
@@ -1987,8 +1979,10 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
         old_id: RowID,
         old_guard: PageSharedGuard<RowPage>,
     ) -> Result<(RowID, FastHashMap<usize, Val>, PageSharedGuard<RowPage>)> {
-        let prepared = HotRowUpdater::new(self.table_id(), self.metadata(), rt)
-            .prepare_move_update(old_row, update, old_id, old_guard);
+        let prepared = HotRowMutator::new(self.table_id(), self.metadata(), rt, &old_guard, old_id)
+            .prepare_move_update(old_row, update);
+        // Release the old row page before awaiting replacement-row insertion.
+        drop(old_guard);
         let (new_row_id, new_guard) = self
             .insert_row_internal(
                 rt,
@@ -2456,21 +2450,18 @@ impl<D: BufferPool, I: BufferPool> MemTable<D, I> {
                     Err(err) => return Err(err),
                 },
             };
-            match HotRowDeleter::new(self.table_id(), self.metadata(), rt)
-                .delete(effects, page_guard, row_id, index_no, key_vals, log_by_key)
-                .await
-            {
+            let res = HotRowMutator::new(self.table_id(), self.metadata(), rt, &page_guard, row_id)
+                .delete(effects, index_no, key_vals, log_by_key)
+                .await?;
+            match res {
                 DeleteInternal::NotFound => return Ok(DeleteMvcc::NotFound),
-                DeleteInternal::WriteConflict => return Ok(DeleteMvcc::WriteConflict),
                 DeleteInternal::RetryInTransition => {
                     // Standalone/catalog MemTable owns hot row-store state
                     // only. Without user-table column storage and checkpoint
                     // route publication, TRANSITION is not a valid state here.
-                    return Err(Report::new(InternalError::Generic)
-                        .attach("standalone MemTable delete observed TRANSITION row page")
-                        .into());
+                    unreachable!("standalone MemTable delete observed TRANSITION row page");
                 }
-                DeleteInternal::Ok(page_guard) => {
+                DeleteInternal::Ok => {
                     self.defer_delete_indexes(rt, effects, row_id, &page_guard)
                         .await?;
                     return Ok(DeleteMvcc::Deleted);

--- a/doradb-storage/src/table/mod.rs
+++ b/doradb-storage/src/table/mod.rs
@@ -49,7 +49,6 @@ use crate::map::FastHashMap;
 use crate::quiescent::QuiescentGuard;
 use crate::row::ops::{RowUpdateInput, RowUpdateView, SelectKey, UpdateCol};
 use crate::row::{RowPage, RowRead, var_len_for_insert};
-use crate::trx::undo::{IndexBranch, RowUndoKind};
 use crate::trx::{TrxContext, TrxReadProof};
 use crate::value::{PAGE_VAR_LEN_INLINE, Val};
 use error_stack::Report;
@@ -923,35 +922,9 @@ impl SecondaryIndexScopedBuilder {
     }
 }
 
-enum InsertRowIntoPage {
-    Ok(RowID, PageSharedGuard<RowPage>),
-    NoSpaceOrFrozen(Vec<Val>, RowUndoKind, Vec<IndexBranch>),
-}
-
-enum UpdateRowInplace {
-    // We keep row page lock if there is any index change,
-    // so we can read latest values from page.
-    // The hash map stores the changed column number and its old value.
-    // for other columns in the changed index, we can read value(old and new are same)
-    // from current page.
-    Ok(RowID, FastHashMap<usize, Val>, PageSharedGuard<RowPage>),
-    RowNotFound(RowUpdateInput),
-    RowDeleted(RowUpdateInput),
-    WriteConflict,
-    RetryInTransition(RowUpdateInput),
-    NoFreeSpace(RowID, Vec<Val>, RowUpdateInput, PageSharedGuard<RowPage>),
-}
-
 enum UpdateUniqueMvcc {
     Updated(RowID),
     NotFound(RowUpdateInput),
-}
-
-enum DeleteInternal {
-    Ok(PageSharedGuard<RowPage>),
-    NotFound,
-    WriteConflict,
-    RetryInTransition,
 }
 
 /// Build user-table dual-tree secondary indexes from fresh MemIndex backends


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Write conflicts during hot-row updates/deletes are now surfaced consistently as operation errors.
  - Hot-row transition retry handling was adjusted to avoid holding/reusing row page guards while waiting.
  - MVCC delete behavior no longer relies on a write-conflict delete outcome; it now returns only “deleted” or “not found.”

- **Refactor**
  - Hot-row update and delete flows were unified under a shared hot-row mutation workflow.
  - Move-update and in-place update paths were updated to use the new mutation context and revised result shapes.

- **Tests**
  - Updated hot-row and transition-related assertions to match the new error and delete-result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->