### PR TITLE
chore: remove proven invariants from error variants

### DIFF
--- a/docs/error-spec.md
+++ b/docs/error-spec.md
@@ -1,7 +1,7 @@
 # Error Handling Specification
 
 Status: Draft  
-Current implementation snapshot: 2026-07-16
+Current implementation snapshot: 2026-07-17
 
 ## Purpose
 
@@ -65,6 +65,14 @@ attachments.
 
 Internal code should use the narrowest result type that describes the errors
 it can produce.
+
+Crate-owned traits follow the same rule. When implementations have different
+failure domains, give the trait an associated error type and let each
+implementation expose its narrowest native report. The generic dispatcher
+must preserve that type; conversion to public `Error` belongs in the caller
+that actually combines unrelated implementations. Use crate `Result` directly
+only when an external trait fixes the signature or the implementation itself
+is a genuine mixed-domain seam.
 
 | Domain | Result type | Meaning | Principal modules |
 | --- | --- | --- | --- |
@@ -385,6 +393,21 @@ perform that conversion explicitly while retaining both the original frames
 and the cleanup report; a safety escalation is not permission to silently
 substitute the secondary error.
 
+### 9. Assert proven internal contracts at their owner
+
+A condition proven by a trusted constructor, exact allocation, ownership
+boundary, or fixed lifecycle is represented by an infallible API plus a
+release assertion at the narrowest owning site. Its diagnostic must identify
+the component, supplier edge, layout type or length, or column position needed
+to locate the broken contract. Do not use `debug_assert!` as the sole guard for
+a correctness contract.
+
+A condition reachable through external, persisted, replayed, configuration,
+resource, or otherwise valid runtime input remains a typed result at the first
+boundary that can validate it. Tests exercise that real validation boundary;
+they must not gain access to private state solely to manufacture an impossible
+error, and an obsolete synthetic error test is not replaced with a panic test.
+
 ## Draft Module Error-Domain Blueprint
 
 This section is the target-state blueprint for bottom-up error refactoring. It
@@ -454,12 +477,12 @@ preselect variants for migration.
 | `error` | Defines main domains, public `ErrorKind`, report conversions, and completion transport. Runtime is an established public classification with lossless typed-report conversion. | Keep transport conversion exhaustive as domains are implemented; keep public wrappers out of internal round trips. |
 | `id` | DataIntegrity only when persisted identifiers are deserialized; ordinary ID operations are infallible. | Preserve `DeserResult` instead of introducing public `Result` into ID helpers. |
 | `bitmap` | DataIntegrity for persisted bitmap deserialization; bitmap mutation and iteration are infallible under their documented bounds. | Keep bounds and shape preconditions as assertions rather than recoverable storage errors. |
-| `layout` | `LayoutResult` is caller-neutral. Persisted consumers map mismatch to DataIntegrity, configuration consumers to Config, and trusted-memory consumers to Internal or an assertion. | Audit every conversion at its semantic consumer; do not give generic layout helpers a main domain. |
+| `layout` | `LayoutResult` is caller-neutral. Persisted consumers map mismatch to DataIntegrity, configuration consumers to Config, and trusted exact-memory consumers use documented asserting helpers. | Audit every conversion at its semantic consumer; do not give generic layout helpers a main domain. |
 | `serde` | DataIntegrity for malformed, truncated, or semantically invalid persisted bytes. | Keep decoding typed through format consumers and avoid trait convenience conversions to public `Error` below a real boundary. |
 | `value` | DataIntegrity for decoded value tags and payloads; ordinary in-memory value operations are infallible. | Keep trait-required public conversions explicit and preserve the underlying DataIntegrity frame. |
 | `compression` | Compression algorithms are caller-neutral or infallible under their preconditions. The persisted format consumer assigns DataIntegrity to malformed compressed payloads. | Keep algorithm misuse asserted; do not make compression globally DataIntegrity-owned merely because LWC is its main caller. |
-| `lwc` | DataIntegrity for persisted block views, decoding, and validation; Internal for trusted builder or mutable-view misuse that remains recoverable. | Reassess builder-misuse results as assertions when construction proves the preconditions. |
-| `row` | DataIntegrity for serialized row-operation payloads; Internal for trusted row-page or vector-scan shape violations that cannot be asserted locally. | Replace public `Error` constructors in single-domain vector helpers with typed Internal reports or assertions after invariant proof. |
+| `lwc` | DataIntegrity for persisted block views, decoding, and validation; assertions for builder-owned scan shape and trusted mutable block views; Internal for genuine builder misuse and fixed-format encoding representability. | Keep `LwcBlockEncodingContract` fallible because valid highly compressible input can exceed fixed-width fields before byte capacity. |
+| `row` | DataIntegrity for serialized row-operation payloads; assertions for scan-buffer shape after the layout or catalog validator establishes it; Internal for unrelated trusted row-page misuse that remains fallible. | Validate untrusted or replayed rows before trusted vector/LWC construction and keep the downstream shape API infallible. |
 | `latch` | Config for static fallback-mode parsing; `Validation` for optimistic contention; assertions for ownership and guard invariants. | Do not turn expected validation failure into Operation or Internal errors. |
 | `map`, `memcmp`, `ptr`, `free_list` | Pure data structures and control-flow primitives. Exhaustion or absence is returned neutrally for the caller to interpret. | Keep these modules free of storage-wide error policy. |
 | `notify`, `obs`, `stats` | Notification, observability, and data-reporting primitives; no native recoverable storage domain. | Keep shutdown and waiter policy in their lifecycle-owning callers. |
@@ -471,8 +494,8 @@ preselect variants for migration.
 | Module or responsibility | Target ownership and boundary | Current migration focus |
 | --- | --- | --- |
 | `conf` | Config for supplied settings, path policy, and requested layout. Malformed existing durable state remains DataIntegrity and OS access remains IO. | Split typed validation phases instead of returning public `Result` merely because startup consumes all three. |
-| `component`: registry and shelf | Fixed-topology violations are assertions, not recoverable Internal errors. Duplicate registration or provision, missing required dependency or provision, leftover shelf state, and a missing builder registry indicate construction bugs. | Make registry/shelf operations infallible or asserting and retire the corresponding `InternalError` variants and `Error` constructors when code is changed. |
-| `component`: `Component::build` | Crate `Result` is a genuine construction boundary because individual components can fail with Config, Resource, IO, DataIntegrity, Runtime, or another subsystem domain. | Preserve each component's source report; do not wrap genuine build failures in Internal merely because the registry invokes them. |
+| `component`: registry and shelf | Fixed-topology violations are assertions, not recoverable Internal errors. Duplicate registration or provision, missing required dependency or provision, leftover shelf state, and a missing builder registry indicate construction bugs. | Keep registration order, typed supplier edges, assertion diagnostics, and lifecycle documentation synchronized. |
+| `component`: `Component::build` | `Component::Error` preserves each implementation's narrowest build domain: infallible components use `Infallible`, single-domain builders retain typed reports, and genuinely mixed builders use crate `Error`. Engine construction is the public convergence boundary across component types. | Keep `RegistryBuilder::build<C>` generic over `C::Error`; do not force the union of all component failures onto every implementation or wrap genuine build failures in Internal. |
 | `engine_poison` | Fatal producer. A later admission check may stack Lifecycle over the retained Fatal source. | Keep poison publication separate from the operation that originally failed. |
 | `io` | IO through `IoError` and `BackendResult`; Config for backend setup; `CompletionResult` for cross-thread transport only. | Decide whether the absence of a general `IoResult` alias is intentional and avoid stringifying backend reports. |
 | `file`: sparse/raw access | Config for invalid paths, IO for OS operations, and Resource for address-space or file-capacity exhaustion. | Narrow raw helpers that currently return public `Result`; attach file operation, path, offset, and size at their owning boundary. |
@@ -513,7 +536,7 @@ preselect variants for migration.
 Future tasks should migrate one dependency layer at a time:
 
 1. add Runtime/thread handling and audit pure formats and primitives (established);
-2. replace component-topology errors with assertions;
+2. preserve the established component-topology assertions;
 3. refine IO, file, buffer, log, and lock boundaries;
 4. refine row and index producers;
 5. refine table and catalog consumers;
@@ -544,6 +567,28 @@ Return `OperationResult<()>` and let the semantic caller attach context and
 convert at its boundary. This rule does not prohibit crate `Result` in a
 statement-local private orchestration chain as described above; that chain is
 itself part of the outermost operation boundary.
+
+### Forcing a top-level error onto a crate-owned trait
+
+A trait's complete implementation set may produce many unrelated domains, but
+that union does not make every implementation a mixed-domain boundary:
+
+```rust
+// Bad: an infallible or Runtime-only implementation must erase its precision.
+trait Component {
+    fn build(...) -> impl Future<Output = Result<()>>;
+}
+
+// Good: dispatch remains generic and convergence belongs to the mixed caller.
+trait Component {
+    type Error: Display;
+    fn build(...) -> impl Future<Output = std::result::Result<(), Self::Error>>;
+}
+```
+
+Choose the associated type per implementation, not from the union across all
+implementations. A specific implementation may still use public `Error` when
+its own build chain combines unrelated domains.
 
 ### Passing an operation name down for formatting
 
@@ -681,8 +726,10 @@ The following pieces already follow the intended direction:
   attaches the thread name at the canonical spawn boundary. Component builds,
   recovery planning, and transaction startup preserve that report while
   adding only their owned phase context.
-- File-system, evictor, recovery read-ahead, transaction log, purge, and
-  cleanup startup propagate spawn failures as public Runtime errors.
+- File-system and evictor components retain typed Runtime reports through
+  generic component dispatch. Recovery read-ahead, transaction log, purge,
+  and cleanup startup preserve the same report until their mixed or public
+  construction boundary converts it to a public Runtime error.
   Multi-worker transaction and purge startup reclaims already-started workers
   before returning, while rollback join panics remain secondary diagnostics on
   the initiating Runtime report.
@@ -691,11 +738,26 @@ The following pieces already follow the intended direction:
   precedes worker handoff.
 - `LayoutResult`, `DmlValidationResult`, and `BackendResult` model
   caller-neutral or subsystem-local failures.
-- Latch fallback parsing and trusted row-vector/LWC construction retain Config
-  and Internal reports until genuine convergence. Persisted LWC,
-  column-block-index, and disk-tree layout consumers retain Layout source
-  frames beneath DataIntegrity; trusted mutable layout consumers retain them
-  beneath Internal.
+- Latch fallback parsing retains Config until genuine convergence. Persisted
+  LWC, column-block-index, and DiskTree layout consumers retain Layout source
+  frames beneath DataIntegrity. Exact-sized mutable LWC and DiskTree writer
+  buffers use the asserting `layout::mut_from_bytes` contract instead of an
+  Internal layout report.
+- Fixed component registration and supplier topology is infallible under the
+  `EngineBuilder` construction order. Registry, dependency, shelf, and finish
+  operations use release assertions with component or edge diagnostics, while
+  `Component::build` uses an associated error to preserve infallible,
+  single-domain, and genuinely mixed construction outcomes until engine
+  convergence.
+- `LwcBuilder::new` establishes complete scan-buffer and statistics shape from
+  one `TableColumnLayout`. Page views from that layout and catalog rows checked
+  by `validate_catalog_row` enter an infallible append/statistics/estimate
+  chain. Catalog count, kind, and nullability failures remain DataIntegrity at
+  the validation boundary.
+- `LwcBlockEncodingContract` remains a fallible Internal representability
+  check for the persisted `u16` row count, cumulative column offsets, and null
+  bitmap length prefix. Valid compressible rows can reach that contract, so it
+  is not a proven invariant.
 - `LwcCode::decode` is the sole typed tag decoder. `ValKind::try_from(u8)`
   remains an intentional public trait convergence boundary, and
   `PersistedLwcBlock::load` remains a mixed read/completion and validation
@@ -741,9 +803,6 @@ The following areas require separate audits after the migrated slice:
   they are not established by Task 000226.
 - `DmlValidationResultExt` owns operation and table formatting that should be
   visible at foreground and recovery consumers.
-- Component registry, dependency, shelf, and builder-topology violations still
-  return public Internal errors. Replace those paths with assertions and retire
-  their obsolete error variants and convenience constructors.
 - Other convenience constructors return public `Error` from internal invariant
   producers. Audit whether each represents an assertion, a typed Internal
   report, or a true convergence boundary.
@@ -780,8 +839,9 @@ context:
   once.
 - When a failure is impossible under a production invariant, test the
   production path that establishes the invariant and keep the failure asserted
-  or infallible. Do not add a synthetic error source solely to exercise an
-  unreachable propagation branch.
+  or infallible. Do not expose or mutate private state solely to synthesize an
+  unreachable error, and do not replace its removed error test with a panic
+  test.
 - Run focused module tests, Clippy with warnings denied, and the full workspace
   test suite before completing a module stage.
 

--- a/docs/process/coding-guidance.md
+++ b/docs/process/coding-guidance.md
@@ -30,12 +30,13 @@ We rely on tooling to enforce style.
 
 ### Error Handling
 *   **Typed Domain Reports**: Internal domain-specific functions should return the matching report alias, such as `ConfigResult`, `OperationResult`, `ResourceResult`, `DataIntegrityResult`, `LifecycleResult`, `FatalResult`, or `InternalResult`. Use the crate-wide `crate::error::Result` only at public API boundaries or in functions that intentionally combine several unrelated domains.
+*   **Crate-Owned Trait Errors**: When implementations of a crate-owned trait have different failure domains, use an associated error type and let each implementation expose its narrowest result. Keep generic dispatch typed and convert only in a caller that actually combines unrelated implementations. Use crate `Result` directly only for an externally fixed signature or an implementation that is itself mixed-domain.
 *   **Fieldless Error Variants**: Define stable error classifications as fieldless `thiserror` variants. Put request-specific details, identifiers, values, and explanatory text in `error-stack` attachments instead of variant fields.
 *   **Context at the Caller**: Attach operation names, table or block identifiers, configuration field names, and other caller-owned context with `attach` or `attach_with` where that context becomes known. Do not pass parameters down the call stack solely so a leaf function can format an error message.
 *   **Cross-Domain Conversion**: Use `change_context` at the boundary where one domain consumes another domain's failure, then attach the consuming operation's context. Preserve the original report frames; do not convert to `crate::error::Error`, downcast it, and rebuild a new report.
 *   **Completion Transport**: Convert typed reports directly to `CompletionErrorKind` so producer attachments survive cross-thread handoff. Reserve generic crate-error conversion for genuinely mixed-domain completion producers.
 *   **Validation Pattern**: Use `crate::error::Validation<T>` for optimistic logic checks (Valid/Invalid) where failure is a normal control flow, distinct from `Result` (exceptional failures).
-*   **No Panics**: Avoid `unwrap()` / `expect()` in runtime paths.
+*   **Runtime Failures vs. Contracts**: Incidental `unwrap()` / `expect()` in runtime paths remains prohibited, and external or otherwise valid runtime failures must remain typed results. A proven internal contract may use a release assertion at the narrowest owning site when its constructor, exact allocation, ownership boundary, or fixed lifecycle establishes the precondition. Document the invariant locally and include the component, edge, type/length, column, or other identifying detail in the assertion diagnostic. Do not use `debug_assert!` as the only guard for a correctness contract or treat this rule as general permission to panic.
 
 ### Concurrency & Locking
 *   **Blocking Locks**: Use `parking_lot::Mutex` and `parking_lot::RwLock` for blocking operations.

--- a/docs/tasks/000227-remove-proven-invariants-from-error-variants.md
+++ b/docs/tasks/000227-remove-proven-invariants-from-error-variants.md
@@ -1,0 +1,518 @@
+---
+id: 000227
+title: Remove proven invariants from error variants
+status: proposal  # proposal | implemented | superseded
+created: 2026-07-17
+github_issue: 858
+---
+
+# Task: Remove proven invariants from error variants
+
+## Summary
+
+Shrink three internal error boundaries whose failure branches are proven
+construction contracts rather than recoverable storage failures. Fixed engine
+component topology, exact-sized trusted mutable block views, and LWC scan-buffer
+shape will become infallible APIs guarded by documented release assertions.
+Their eight obsolete `InternalError` variants and synthetic impossible-state
+tests will be removed, while malformed persisted or replayed input will remain
+checked at the boundary where it first becomes trusted.
+
+Component construction will also stop forcing the union of all implementation
+failures onto every builder. `Component::Error` will preserve infallible,
+Runtime-only, Resource-only, and genuinely mixed builders until engine
+construction performs public convergence. The pure buffer allocation chain
+used by fixed and readonly pools will remain Resource-typed for the same
+reason.
+
+The task also distinguishes a nearby case that remains genuinely fallible.
+`LwcBlockEncodingInvariant` protects fixed-width persisted-format
+representability, including a row-count limit that sufficiently compressible
+valid rows can reach before byte capacity is exhausted. Rename it to
+`LwcBlockEncodingContract`, preserve its checked behavior, and keep it separate
+from the mutable-view invariant removed by this task.
+
+## Context
+
+[`docs/error-spec.md`](../error-spec.md) defines a bottom-up error-boundary
+strategy: an impossible state proven by module ownership or lifecycle must be
+an assertion or an infallible API, and an error must not be retained merely so
+a test can manufacture an unreachable state. The specification already names
+component topology as the next construction-layer target and directs trusted
+layout, row-vector, and LWC consumers to reassess Internal results after their
+preconditions are proven.
+
+Task
+[`000226`](000226-establish-runtime-errors-and-harden-foundation-format-boundaries.md)
+preserved these branches as typed `InternalResult` paths while the broader
+producer/consumer boundary was being established. The current code now makes
+three small proof boundaries visible:
+
+| Boundary | Invariant establisher | Trusted consumers | Recoverable boundary that remains |
+| --- | --- | --- | --- |
+| Component registry and shelf topology | `EngineBuilder::build_inner` drives one fixed registration order; `Supplier<Down>` types each provision edge; `RegistryBuilder` owns the registry and shelf for the whole build | `ComponentRegistry::register` and `dependency`, `ShelfScope::put` and `take`, `RegistryBuilder::finish` | `Component::build -> Result<(), Self::Error>` preserves each implementation's native failure; `EngineBuilder::build_inner` converges across components into public `Error` |
+| Mutable LWC and DiskTree block views | `DirectBuf::zeroed` and exact payload slicing establish the runtime length; compile-time assertions equate `LwcBlock`/`BTreeNode` size with their target payload or block size and establish alignment | LWC and DiskTree writers | Generic `layout::try_mut_from_bytes` for caller-neutral/untrusted bytes and persisted readers that map layout mismatch to `DataIntegrityError` |
+| LWC scan-buffer shape | `LwcBuilder::new` derives a full `ScanBuffer` and statistics vector from one `TableColumnLayout`; table persistence creates row-page views with the same metadata | `ScanBuffer`, LWC statistics, size estimation, and encoding | Catalog/replay row validation before trusted construction, plus actual LWC format representability failures |
+
+The component proof is reinforced by
+[`docs/engine-component-lifetime.md`](../engine-component-lifetime.md) and the
+registration-order documentation in `component.rs` and `engine.rs`. A missing
+or duplicate component, provision, or finished-builder state therefore means
+the fixed engine construction program is incorrect; it is not a condition an
+engine caller can recover from.
+
+For mutable block views, immutable persisted input remains a different trust
+boundary. Short, corrupt, or structurally invalid bytes must continue to return
+`DataIntegrityError` with the caller-neutral `LayoutError` source retained.
+Only buffers allocated and sliced by trusted writers move to the asserting
+layout API.
+
+For scan shape, production has two entry paths. Table persistence passes a
+`PageVectorView` built from the same table metadata used to create the
+`LwcBuilder`. Catalog checkpoint construction passes decoded `RowRecord`
+values. Those values originate in persisted/replayed state and therefore must
+be checked with `validate_catalog_row` for count, kind, and nullability before
+entering the builder. This moves the real failure to `DataIntegrity` while
+making the downstream shape contract infallible.
+
+The retained encoding variant has three producers in `lwc/mod.rs`:
+
+- `row_count` must fit the persisted `u16` header;
+- each cumulative column end offset must fit its persisted `u16` entry; and
+- a serialized null-bitmap byte length must fit its `u16` prefix.
+
+These are checked integer-representability conditions, not mutable-view or
+scan-shape failures. In particular, highly compressible rows can keep the
+estimated payload under the byte limit while accumulating more than
+`u16::MAX` rows. The checks must therefore stay fallible in this task, with the
+variant and helper renamed from “invariant” to “contract” so the taxonomy does
+not claim that a recoverable result is impossible.
+
+Related context:
+
+- [`docs/error-spec.md`](../error-spec.md)
+- [`docs/architecture.md`](../architecture.md)
+- [`docs/engine-component-lifetime.md`](../engine-component-lifetime.md)
+- [`docs/table-file.md`](../table-file.md)
+- [`docs/index-design.md`](../index-design.md)
+- [`docs/checkpoint-and-recovery.md`](../checkpoint-and-recovery.md)
+- [`docs/process/coding-guidance.md`](../process/coding-guidance.md)
+- [`docs/process/unit-test.md`](../process/unit-test.md)
+- [`backlog 000159`](../backlogs/000159-reassess-invariant-oriented-table-scan-errors.md)
+- [`backlog 000160`](../backlogs/000160-harden-domain-specific-fault-injection-critical-workflows.md)
+
+Issue Labels:
+
+- type:task
+- priority:medium
+- codex
+
+## Goals
+
+1. Replace six fixed component-topology errors with infallible registry/shelf
+   APIs and release assertions that identify the component or supplier edge.
+2. Give `Component` an associated build error, preserve single-domain and
+   infallible implementations through `RegistryBuilder`, and converge only in
+   mixed component implementations or engine construction.
+3. Add the canonical trusted mutable-layout helper complementary to
+   `layout::ref_from_bytes` and `layout::slice_from_bytes_mut`, while preserving
+   the checked caller-neutral layout APIs.
+4. Make trusted mutable `LwcBlock` and DiskTree node views infallible after
+   exact buffer sizing has established their preconditions.
+5. Make `ScanBuffer` mutation and the LWC append/statistics/estimate chain
+   infallible under the builder-owned layout contract.
+6. Validate catalog checkpoint rows completely before the trusted LWC builder
+   so malformed durable values remain `DataIntegrityError::InvalidPayload`.
+7. Remove exactly these obsolete `InternalError` variants:
+   `ComponentShelfDuplicateProvision`, `ComponentShelfNotEmpty`,
+   `ComponentRegistryMissing`, `ComponentProvisionMissing`,
+   `EngineComponentAlreadyRegistered`, `EngineComponentMissingDependency`,
+   `MutableBlockViewMismatch`, and `ColumnScanShapeMismatch`.
+8. Rename `LwcBlockEncodingInvariant` and its construction helper to
+   `LwcBlockEncodingContract` without weakening its checked casts or changing
+   its error domain.
+9. Remove tests that fabricate the retired impossible states and do not replace
+   them with panic-expectation tests; retain normal-path and real boundary
+   coverage.
+10. Document each invariant where it is established and consumed, including
+   explicit `# Panics` contracts on asserting crate-visible APIs.
+11. Update the normative error specification and short-form coding guidance so
+    deliberate contract assertions are distinguished from incidental runtime
+    `unwrap`/`expect` calls.
+12. Keep the change task-sized, format-compatible, and limited to the selected
+    proof boundaries plus direct component-error signature fallout.
+
+## Non-Goals
+
+- Remove `ErrorKind::Internal`, eliminate `InternalError` or `InternalResult`,
+  or perform a workspace-wide error taxonomy sweep.
+- Convert or rename unrelated invariant-oriented errors in buffer, file, CoW,
+  index rewrite, recovery, worker-completion, transaction, or concurrency code.
+- Resolve `ActiveTransactionDiscarded`, `PoolGuardMissing`, `RowPageMissing`,
+  row-page cursor, or block-index reachability questions tracked by
+  [backlog 000159](../backlogs/000159-reassess-invariant-oriented-table-scan-errors.md).
+- Add or redesign fault injection for critical workflows tracked by
+  [backlog 000160](../backlogs/000160-harden-domain-specific-fault-injection-critical-workflows.md).
+- Convert `LwcBuilderMisuse` or the remaining LWC empty-build, encoding-width,
+  encoding-capacity, or prepared delete-bitmap checks to assertions.
+- Change the `LwcBlockEncodingContract` domain, redesign block splitting around
+  the `u16` row-count limit, or remove its defensive representability checks.
+- Change persisted LWC, DiskTree, row-page, catalog, or table-file layouts or
+  the bytes emitted for valid inputs.
+- Introduce type-state component builders, layout proof types, a general
+  component DAG, or another RFC-scale architecture.
+- Add public APIs or change the public storage `ErrorKind` classification.
+- Add `#[should_panic]` tests for the newly asserted contracts.
+
+## Plan
+
+### 1. Reconfirm the producer inventory and assertion rule
+
+- Start from the eight variants listed in Goals and inventory every producer,
+  conversion helper, direct caller, test, and import before editing. Do the
+  same for `LwcBlockEncodingInvariant` so the rename covers all retained
+  encoding-width branches but does not absorb unrelated LWC errors.
+- Apply one decision rule consistently: external, persisted, replayed,
+  configuration, resource, or otherwise valid runtime input stays fallible;
+  state proven by a trusted constructor, ownership boundary, fixed lifecycle,
+  or exact allocation becomes an infallible API with a release assertion.
+- Use `assert!`, `assert_eq!`, `expect`, or `unreachable!` only where the local
+  invariant documentation identifies the establisher. Do not use
+  `debug_assert!` as the sole replacement for a removed error, because release
+  builds must not continue after violating a safety/correctness contract.
+- Assertion messages must identify the component name, supplier edge, layout
+  type/length, or column position needed to diagnose the construction bug.
+
+### 2. Make fixed component topology infallible and preserve build errors
+
+In `doradb-storage/src/component.rs`:
+
+- Change `ComponentRegistry::register<C>` from `Result<()>` to `()` and assert
+  that `TypeId::of::<C>()` is absent before publishing the access handle and
+  owner. Keep `ComponentRegistry::get<C> -> Option<C::Access>` as the neutral
+  optional lookup primitive.
+- Change `ComponentRegistry::dependency<C>` from `Result<C::Access>` to
+  `C::Access`; a missing or type-inconsistent required dependency must panic
+  with `C::NAME` and the fixed registration-order contract.
+- Change `Shelf::put`/`ShelfScope::put` from `Result<()>` to `()` and assert
+  that a typed `Supplier<Down>` edge is provisioned exactly once.
+- Change `Shelf::take`/`ShelfScope::take` from `Option<Provision>` to
+  `Provision`; assert that the required upstream provision exists, and retain
+  the existing typed downcast assertion. Include both `Up::NAME` and
+  `Down::NAME` in edge diagnostics.
+- Change `RegistryBuilder::finish` from `Result<ComponentRegistry>` to
+  `ComponentRegistry`. Assert that the shelf is empty and expect the builder's
+  registry to remain armed until this consuming call. Preserve `Drop` cleanup
+  on failed component builds or unwinding.
+- Add `Component::Error: Display`, change `Component::build` to return
+  `Result<(), Self::Error>`, and make `RegistryBuilder::build<C>` return
+  `Result<(), C::Error>` without converting the report merely to log it.
+- Use `Infallible` for `EnginePoisoner` and `LockManager`; typed Runtime reports
+  for `FileSystemWorkers` and `SharedPoolEvictorWorkers`; typed Resource reports
+  for `MetaPool` and `DiskPool`; and crate `Error` for the component builders
+  whose own chains genuinely combine unrelated domains: `FileSystem`,
+  `IndexPool`, `MemPool`, `Catalog`, `TransactionSystem`, and
+  `TransactionSystemWorkers`.
+- Add public-error conversion from `Infallible` for generic engine assembly.
+  Narrow mmap array initialization, quiescent arena construction, fixed pool
+  construction, and readonly pool construction to `ResourceResult`. Keep
+  evictable pool construction on crate `Result` because it combines Config,
+  Resource, and IO failures.
+- Add or update Rustdoc on every changed crate-visible function with its
+  invariant and `# Panics` condition. Document why genuine component
+  construction failures still cross their associated error boundary.
+
+Propagate the topology and build-error signatures through `engine.rs`,
+`engine_poison.rs`,
+`buffer/mod.rs`, `buffer/evictor.rs`, `file/fs.rs`, `lock/mod.rs`,
+`catalog/mod.rs`, and `trx/sys.rs`. Remove only `?`, `Ok(())`, or test
+`unwrap()` plumbing made obsolete by the new return types; preserve all
+unrelated build errors and their context.
+
+### 3. Add and consume the trusted mutable-layout API
+
+In `doradb-storage/src/layout.rs`:
+
+- Add `mut_from_bytes<T>(&mut [u8]) -> &mut T` with the same zerocopy bounds as
+  `try_mut_from_bytes`. Implement it through the checked primitive plus one
+  documented contract assertion, mirroring `ref_from_bytes` and
+  `slice_from_bytes_mut`.
+- Keep `LayoutError`, `LayoutResult`, `try_ref_from_bytes`,
+  `try_mut_from_bytes`, and checked slice functions caller-neutral and
+  fallible. They remain the APIs for bytes whose exact layout has not already
+  been established.
+- Test a valid trusted mutable round trip and keep/add wrong-length coverage on
+  the checked primitive. Do not test the trusted helper by deliberately
+  violating its precondition.
+
+In the trusted block consumers:
+
+- Rename `LwcBlock::try_from_bytes_mut` to `LwcBlock::from_bytes_mut`, return
+  `&mut LwcBlock`, and delegate to `layout::mut_from_bytes`. Its Rustdoc must
+  state that callers provide exactly `LWC_BLOCK_PAYLOAD_SIZE` bytes allocated
+  for an LWC payload.
+- Make `btree_node_from_block_mut` return `&mut BTreeNode` through the trusted
+  helper. Document the `DirectBuf::zeroed(DISK_TREE_BLOCK_SIZE)` and compile-time
+  `size_of::<BTreeNode>()` equality that establish the contract.
+- Update LWC writer/test helpers in `lwc/mod.rs`, `lwc/block.rs`, and
+  `buffer/readonly.rs`, plus DiskTree writers/tests, without changing immutable
+  persisted validation.
+- Remove `?`/`unwrap()` calls that existed only for the trusted cast. Keep
+  persisted `try_from_bytes`/`persisted_disk_tree_node` calls checked and keep
+  their `LayoutError -> DataIntegrityError` source-preserving adaptation.
+
+### 4. Make scan-buffer and LWC shape contracts infallible
+
+In `doradb-storage/src/row/vector_scan.rs`:
+
+- Change `ScanBuffer::scan` and `ScanBuffer::append_row_values` to return `()`.
+  Replace nullability and `ValBuffer`/`ValArrayRef`/`Val` shape errors with
+  release assertions or unreachable match arms tied to the layout used by
+  `ScanBuffer::new`.
+- Make `append_scan_value` infallible. Preserve placeholder insertion for null
+  values and all current buffer/bitmap mutation behavior.
+- Document that `scan` requires a `PageVectorView` from the same
+  `TableColumnLayout`, and that `append_row_values` requires a complete row
+  already validated against that layout.
+
+In `doradb-storage/src/lwc/mod.rs`:
+
+- Change `LwcBuilder::append_view` and `append_row_values` from
+  `InternalResult<bool>` to `bool`. Keep snapshot/rollback when capacity is
+  exceeded (`false`); remove rollback-on-error control flow because shape is no
+  longer a recoverable outcome.
+- Make `append_view_inner`, `append_row_values_inner`, `scan_page_stats`,
+  `scan_row_value_stats`, `estimate_size`, `estimate_columns_size`, and
+  `estimate_column_payload` infallible. Assert the builder-owned lengths and
+  type pairing at their narrowest consumers.
+- In `LwcBuilder::build`, replace the impossible missing scan column with an
+  assertion, but retain `InternalResult<DirectBuf>` for `LwcBuilderMisuse` and
+  `LwcBlockEncodingContract`.
+- Propagate the boolean append signatures through `table/persistence.rs`,
+  `catalog/storage/mod.rs`, and affected inline tests without changing the
+  existing “fits/does not fit” control flow.
+
+At the catalog trust boundary:
+
+- Replace the length-only preflight in
+  `build_lwc_blocks_from_row_records` with `validate_catalog_row` for every
+  `RowRecord`. This must validate column count, value kind, and nullability and
+  return `DataIntegrityError::InvalidPayload` before constructing or mutating an
+  `LwcBuilder`.
+- Preserve the existing real errors for invalid row ordering/ranges, a single
+  row that cannot fit, and LWC encoding contract failures.
+
+### 5. Rename the retained fallible encoding contract
+
+In `doradb-storage/src/error.rs` and `doradb-storage/src/lwc/mod.rs`:
+
+- Rename `InternalError::LwcBlockEncodingInvariant` to
+  `InternalError::LwcBlockEncodingContract` and change its display text so it
+  describes an unsatisfied encoding contract rather than an impossible
+  invariant.
+- Rename `lwc_block_encoding_invariant()` to
+  `lwc_block_encoding_contract()` and update the row-count, cumulative-offset,
+  and null-bitmap length-prefix producers.
+- Attach the affected persisted field and actual/maximum value where that data
+  is available. Do not use unchecked narrowing casts, assert these branches,
+  or reclassify them as malformed persisted input; they are failures to encode
+  trusted in-memory values into the fixed representation.
+- Add a normal-API regression using sufficiently many highly compressible
+  valid rows to demonstrate that the `u16` row-count contract is reachable
+  without mutating private builder state. Verify the renamed Internal context.
+
+### 6. Retire obsolete variants and impossible-state tests
+
+- Delete the eight variants listed in Goals from `InternalError` and delete
+  `Error::engine_component_already_registered` and
+  `Error::engine_component_missing_dependency` after all callers are
+  infallible.
+- Remove obsolete `InternalError`, `InternalResult`, `Error`, `Report`,
+  `ResultExt`, and `LayoutError` imports only when no other producer in the file
+  needs them.
+- Remove the component tests that expect duplicate registration, missing
+  dependency, or duplicate shelf provision errors. Keep the typed access,
+  single provision/take, shelf drain, reverse shutdown, idempotent shutdown,
+  and access-before-owner-drop tests, adapting only their return-value syntax.
+- Remove the short trusted-mutable half of the combined LWC and DiskTree layout
+  adaptation tests. Retain and rename their persisted halves, which still prove
+  `LayoutError` is retained beneath `DataIntegrityError`.
+- Delete the LWC test that mutates `builder.buffer` to a partial scan set and
+  expects `ColumnScanShapeMismatch`. Do not replace it with an assertion test.
+- Retain valid all-type vector scans, null-bitmap compaction, truncation,
+  capacity rollback, LWC round trips, and persisted malformed-input tests.
+- Finish with a zero-match source audit for every removed variant and old LWC
+  encoding name.
+
+### 7. Document the established boundaries
+
+In `docs/error-spec.md`:
+
+- Add a normative rule that a proven internal contract is represented by an
+  infallible API plus a release assertion, while a condition reachable through
+  valid input or runtime state remains a typed result.
+- State that tests must exercise the real validation boundary and must not gain
+  access to private state solely to synthesize an impossible error.
+- Record the three proof boundaries from Context, including which constructor,
+  lifecycle, exact allocation, or validation step establishes each invariant.
+- Move component topology, trusted mutable block views, and LWC scan shape from
+  current debt to established behavior; remove stale statements that they
+  retain Internal layout/shape reports.
+- Record `LwcBlockEncodingContract` as retained fallible format
+  representability, not as a proven invariant, and update the implementation
+  snapshot date.
+
+In `docs/process/coding-guidance.md`:
+
+- Replace the absolute “No Panics” shorthand with a precise rule: incidental
+  runtime `unwrap`/`expect` remains prohibited, external or valid runtime
+  failures remain results, and documented release assertions are appropriate
+  for impossible internal contract violations.
+- Require assertion diagnostics and code-local invariant documentation. Do not
+  weaken the guidance into general permission to panic.
+
+### 8. Guard against boundary regressions
+
+- The main risk is asserting a branch that untrusted or valid runtime input can
+  reach. Protect against this by keeping generic checked layout tests,
+  persisted LWC/DiskTree corruption tests, catalog wrong-kind/nullability
+  tests, and the reachable LWC encoding-contract regression.
+- A second risk is accidentally erasing genuine component-build failures while
+  removing topology plumbing. Review every changed `Component::build`
+  implementation and ensure configuration, allocation, IO, spawn, recovery,
+  and startup results retain their narrowest type until a genuine mixed or
+  public convergence boundary.
+- A third risk is changing block bytes while refactoring view acquisition.
+  Preserve existing LWC/DiskTree round trips and checksum/structure validation;
+  this task changes only how trusted slices are borrowed.
+- Keep assertion sites narrow and owned. Do not add assertion wrappers at an
+  outer public boundary when the lower constructor or validator can establish
+  the contract more directly.
+
+## Implementation Notes
+
+## Impacts
+
+Primary invariant and error-definition modules:
+
+- `doradb-storage/src/error.rs`: remove eight variants and two component error
+  constructors; rename the retained LWC encoding contract variant; convert
+  `Infallible` at the public engine-build boundary.
+- `doradb-storage/src/component.rs`: infallible registry, shelf, dependency,
+  and finish APIs; associated build errors; component topology tests; and
+  invariant documentation.
+- `doradb-storage/src/layout.rs`: canonical trusted mutable value view and
+  caller-neutral checked-layout coverage.
+- `doradb-storage/src/row/vector_scan.rs`: infallible scan-buffer shape
+  operations.
+- `doradb-storage/src/lwc/block.rs` and `doradb-storage/src/lwc/mod.rs`:
+  infallible trusted mutable view, boolean append chain, asserted shape helpers,
+  retained/renamed encoding contract, and tests.
+- `doradb-storage/src/index/disk_tree.rs`: infallible trusted mutable node view
+  while preserving persisted validation.
+
+Direct component-signature consumers:
+
+- `doradb-storage/src/engine.rs`
+- `doradb-storage/src/engine_poison.rs`
+- `doradb-storage/src/buffer/mod.rs`
+- `doradb-storage/src/buffer/evictor.rs`
+- `doradb-storage/src/file/fs.rs`
+- `doradb-storage/src/lock/mod.rs`
+- `doradb-storage/src/catalog/mod.rs`
+- `doradb-storage/src/trx/sys.rs`
+
+Other direct layout/LWC consumers:
+
+- `doradb-storage/src/buffer/readonly.rs`
+- `doradb-storage/src/buffer/arena.rs`
+- `doradb-storage/src/buffer/fixed.rs`
+- `doradb-storage/src/buffer/util.rs`
+- `doradb-storage/src/table/persistence.rs`
+- `doradb-storage/src/catalog/storage/mod.rs`
+
+Documentation:
+
+- `docs/error-spec.md`
+- `docs/process/coding-guidance.md`
+- `docs/engine-component-lifetime.md` only if implementation reveals stale
+  topology wording; no lifecycle redesign is intended.
+
+There is no public API or persisted-format change. Internal return-type changes
+deliberately reduce error propagation and may require mechanical edits in
+inline tests or direct callers not listed separately above.
+
+## Test Cases
+
+1. Build the production engine component sequence and verify successful
+   construction still publishes every dependency used by `EngineInner`.
+2. Verify `ComponentRegistry::get` and infallible `dependency` return the
+   expected typed cloned access after normal registration.
+3. Verify one typed shelf provision is consumed by its declared downstream
+   component and the shelf is empty when `RegistryBuilder::finish` returns.
+4. Verify an infallible component builds and finishes normally. Verify a
+   failing fixture remains a typed Runtime report through `RegistryBuilder`,
+   converts losslessly at the public boundary, and still runs shutdown before
+   owner drop. Keep reverse shutdown order, shutdown idempotence, and
+   access-handle drop ordering unchanged.
+5. Use `layout::mut_from_bytes` with an exact mutable value buffer, mutate the
+   typed view, and verify the underlying bytes. Keep a separate checked
+   `try_mut_from_bytes` wrong-length test returning `LayoutError::Mismatch`.
+6. Build valid LWC and DiskTree blocks through their trusted mutable writer
+   paths and verify their existing round-trip, checksum, and structure tests.
+7. Feed short or malformed persisted LWC and DiskTree bytes through immutable
+   readers and verify `DataIntegrityError::InvalidPayload` retains the
+   `LayoutError::Mismatch` source where applicable.
+8. Exercise row-page vector scanning across every supported value kind,
+   nullable/non-nullable columns, deleted-row compaction, variable bytes, and
+   truncation after the infallible signature change.
+9. Exercise `LwcBuilder::append_view` and `append_row_values` success and
+   capacity overflow. Verify `false` rolls the buffer, row IDs, and statistics
+   back to the previous snapshot.
+10. Build and decode valid LWC blocks from row-page views and decoded row values
+    and verify row count, values, null bitmap, shape fingerprint, and encoded
+    bytes remain unchanged.
+11. Pass a catalog `RowRecord` with the correct value count but wrong value kind
+    and another with invalid nullability. Verify each fails before builder
+    mutation as public `DataIntegrityError::InvalidPayload`, with column context.
+12. Accumulate more than `u16::MAX` highly compressible valid rows through
+    `LwcBuilder`'s normal append API while staying under its estimated byte
+    capacity, then verify `build` returns
+    `InternalError::LwcBlockEncodingContract`. Do not mutate private fields to
+    arrange this case.
+13. Verify other retained LWC contract/misuse tests use
+    `LwcBlockEncodingContract` or `LwcBuilderMisuse` as appropriate and that no
+    removed shape/layout variant remains inspectable.
+14. Construct a too-small global readonly pool directly and verify its report
+    remains `ResourceError::BufferPoolSizeTooSmall` before public convergence.
+15. Run source audits from the worktree root:
+
+    ```bash
+    rg -n \
+      'ComponentShelfDuplicateProvision|ComponentShelfNotEmpty|ComponentRegistryMissing|ComponentProvisionMissing|EngineComponentAlreadyRegistered|EngineComponentMissingDependency|MutableBlockViewMismatch|ColumnScanShapeMismatch' \
+      doradb-storage/src docs/error-spec.md docs/process/coding-guidance.md
+
+    rg -n 'LwcBlockEncodingInvariant|lwc_block_encoding_invariant' \
+      doradb-storage/src docs/error-spec.md
+    ```
+
+    Both commands must produce no matches. Separately verify
+    `LwcBlockEncodingContract` has only the three intended encoding-width
+    producer classes and their tests/documentation.
+16. Run focused nextest coverage for component, layout, vector-scan, LWC,
+    DiskTree, table-persistence, and catalog-storage tests, followed by:
+
+    - `cargo fmt --all -- --check`
+    - `cargo clippy --workspace --all-targets -- -D warnings`
+    - `cargo nextest run --workspace`
+    - `cargo nextest run -p doradb-storage --no-default-features --features libaio`
+    - `git diff --check`
+
+No test may mutate a private production object into an impossible state merely
+to observe a removed error, and no assertion test replaces the deleted
+synthetic coverage.
+
+## Open Questions
+
+None for this task. Harder reachability decisions remain explicitly owned by
+backlogs 000159 and 000160 and are not prerequisites for implementation.

--- a/docs/tasks/000227-remove-proven-invariants-from-error-variants.md
+++ b/docs/tasks/000227-remove-proven-invariants-from-error-variants.md
@@ -1,7 +1,7 @@
 ---
 id: 000227
 title: Remove proven invariants from error variants
-status: proposal  # proposal | implemented | superseded
+status: implemented  # proposal | implemented | superseded
 created: 2026-07-17
 github_issue: 858
 ---
@@ -390,6 +390,43 @@ In `docs/process/coding-guidance.md`:
   the contract more directly.
 
 ## Implementation Notes
+
+- Component topology is now infallible after the fixed engine build order has
+  established its contracts. Registry, dependency, shelf, provision, and
+  finish operations use documented release assertions with component or edge
+  diagnostics. `Component::Error` preserves `Infallible`, Runtime, Resource,
+  and genuinely mixed implementations through generic dispatch, with public
+  convergence retained in engine construction. Pure fixed and readonly buffer
+  allocation paths were narrowed to Resource errors.
+- Added `layout::mut_from_bytes` as the asserting mutable counterpart to the
+  existing trusted layout helpers. LWC and DiskTree writer paths now use it
+  after exact allocation, while persisted readers retain checked layout
+  adaptation and `LayoutError` sources beneath DataIntegrity reports.
+- Scan-buffer mutation and the LWC append, statistics, and size-estimation
+  chain are infallible under the builder-owned layout contract. Catalog
+  checkpoint rows are fully validated for count, kind, and nullability before
+  entering that chain. Capacity overflow remains a boolean rollback result.
+- Removed the eight obsolete Internal variants and their synthetic
+  impossible-state tests. The reachable fixed-width encoding failure was
+  retained and renamed to `LwcBlockEncodingContract`, with field-specific
+  attachments and normal-API coverage for the `u16` row-count limit.
+- Review found that converting LWC append operations to booleans could retry an
+  oversized first row or page after rollback with an empty builder. Explicit
+  empty-builder guards now preserve the planned single-item failure behavior:
+  catalog rows return DataIntegrity invalid-payload context and table row pages
+  return `LwcBuilderMisuse`. Regression tests cover both paths.
+- Updated the normative error specification and coding guidance for associated
+  trait errors and proven release-asserted contracts. The unsafe inventory
+  baseline date was refreshed; its contents did not change.
+- Verification completed with the mandatory branch-diff style audit over 21
+  Rust files, including formatting and Clippy with warnings denied. Source
+  audits found no retired variant or old encoding-helper names, and confirmed
+  the retained contract has the intended three producer classes. The
+  `git diff --check` validation passed. `cargo nextest run --workspace` passed
+  1,435 tests, and the alternate `libaio` validation passed 1,359 tests.
+- There were no scope or persisted-format deviations, no new deferred work,
+  no source backlog to close, and no parent RFC to synchronize. Existing
+  backlogs 000159 and 000160 remain separate non-goals as planned.
 
 ## Impacts
 

--- a/docs/unsafe-usage-baseline.md
+++ b/docs/unsafe-usage-baseline.md
@@ -1,6 +1,6 @@
 # Unsafe Usage Baseline
 
-- Generated on: `2026-07-16`
+- Generated on: `2026-07-17`
 - Command: `tools/unsafe_inventory.rs`
 - Scope: `doradb-storage/src/{buffer,latch,row,index,io,trx,lwc,file,log,recovery}`
 

--- a/doradb-storage/src/buffer/arena.rs
+++ b/doradb-storage/src/buffer/arena.rs
@@ -3,7 +3,7 @@ use crate::buffer::guard::{FacadePageGuard, PageExclusiveGuard, PageLatchGuard};
 use crate::buffer::page::{BufferPage, Page};
 use crate::buffer::util::{deallocate_frame_and_page_arrays, initialize_frame_and_page_arrays};
 use crate::buffer::{PoolGuard, PoolIdentity};
-use crate::error::Result;
+use crate::error::ResourceResult;
 use crate::id::PageID;
 use crate::ptr::UnsafePtr;
 use crate::quiescent::{QuiescentBox, QuiescentGuard};
@@ -75,7 +75,7 @@ pub(crate) struct ArenaInner {
 
 impl ArenaInner {
     #[inline]
-    fn new(capacity: usize) -> Result<Self> {
+    fn new(capacity: usize) -> ResourceResult<Self> {
         // SAFETY: `ArenaInner::drop` destroys initialized frames and unmaps
         // both regions exactly once after the leading keepalive box drains.
         let (frames, pages) = unsafe { initialize_frame_and_page_arrays(capacity)? };
@@ -163,7 +163,7 @@ pub(crate) struct QuiescentArena {
 impl QuiescentArena {
     /// Allocates one arena with `capacity` frame/page slots.
     #[inline]
-    pub(crate) fn new(capacity: usize) -> Result<Self> {
+    pub(crate) fn new(capacity: usize) -> ResourceResult<Self> {
         let keepalive = QuiescentBox::new(());
         let identity = keepalive.owner_identity();
         Ok(Self {

--- a/doradb-storage/src/buffer/evictor.rs
+++ b/doradb-storage/src/buffer/evictor.rs
@@ -4,13 +4,13 @@ use crate::buffer::guard::PageExclusiveGuard;
 use crate::buffer::page::Page;
 use crate::buffer::{EvictableBufferPool, ReadonlyBufferPool};
 use crate::component::{Component, ComponentRegistry, ShelfScope};
-use crate::error::{Result, RuntimeResult};
+use crate::error::{RuntimeError, RuntimeResult};
 use crate::id::PageID;
 use crate::obs;
 use crate::quiescent::{QuiescentBox, SyncQuiescentGuard};
 use crate::thread;
 use crate::{DiskPool, IndexPool, MemPool};
-use error_stack::ResultExt;
+use error_stack::{Report, ResultExt};
 use event_listener::{Event, EventListener, Listener};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -783,6 +783,7 @@ impl Component for SharedPoolEvictorWorkers {
     type Config = ();
     type Owned = SharedPoolEvictorWorkersOwned;
     type Access = SharedPoolEvictorStatsHandle;
+    type Error = Report<RuntimeError>;
 
     const NAME: &'static str = "shared_pool_evictor_workers";
 
@@ -791,10 +792,10 @@ impl Component for SharedPoolEvictorWorkers {
         _config: Self::Config,
         registry: &mut ComponentRegistry,
         _shelf: ShelfScope<'_, Self>,
-    ) -> Result<()> {
-        let disk_pool = registry.dependency::<DiskPool>()?;
-        let index_pool = registry.dependency::<IndexPool>()?;
-        let mem_pool = registry.dependency::<MemPool>()?;
+    ) -> RuntimeResult<()> {
+        let disk_pool = registry.dependency::<DiskPool>();
+        let index_pool = registry.dependency::<IndexPool>();
+        let mem_pool = registry.dependency::<MemPool>();
 
         let disk_pool = disk_pool.clone_inner().into_sync();
         let index_pool = index_pool.clone_inner().into_sync();
@@ -828,7 +829,8 @@ impl Component for SharedPoolEvictorWorkers {
             wake_event,
             stats,
             evict_thread: Mutex::new(Some(handle)),
-        })
+        });
+        Ok(())
     }
 
     #[inline]
@@ -1294,12 +1296,12 @@ mod tests {
                     .unwrap();
                 builder.build::<FileSystemWorkers>(()).await.unwrap();
                 builder.build::<SharedPoolEvictorWorkers>(()).await.unwrap();
-                let registry = builder.finish().unwrap();
-                let fs = registry.dependency::<FileSystem>().unwrap();
-                let disk_pool = registry.dependency::<DiskPool>().unwrap();
-                let mem_pool = registry.dependency::<MemPool>().unwrap();
-                let index_pool = registry.dependency::<IndexPool>().unwrap();
-                let stats = registry.dependency::<SharedPoolEvictorWorkers>().unwrap();
+                let registry = builder.finish();
+                let fs = registry.dependency::<FileSystem>();
+                let disk_pool = registry.dependency::<DiskPool>();
+                let mem_pool = registry.dependency::<MemPool>();
+                let index_pool = registry.dependency::<IndexPool>();
+                let stats = registry.dependency::<SharedPoolEvictorWorkers>();
                 Self {
                     fs,
                     disk_pool,

--- a/doradb-storage/src/buffer/fixed.rs
+++ b/doradb-storage/src/buffer/fixed.rs
@@ -7,7 +7,7 @@ use crate::buffer::{
     BufferPool, BufferPoolStatsHandle, PoolGuard, PoolIdentity, PoolRole, RowPoolRole,
 };
 use crate::error::Validation::Valid;
-use crate::error::{Error, ResourceError, Result, Validation};
+use crate::error::{Error, ResourceError, ResourceResult, Result, Validation};
 use crate::id::PageID;
 use crate::latch::LatchFallbackMode;
 use crate::stats::BufferPoolCounters;
@@ -33,7 +33,7 @@ impl FixedBufferPool {
     /// We separate pages and frames so that pages are always aligned
     /// to the unit of direct IO and can be flushed via libaio.
     #[inline]
-    pub(crate) fn with_capacity(role: PoolRole, pool_size: usize) -> Result<Self> {
+    pub(crate) fn with_capacity(role: PoolRole, pool_size: usize) -> ResourceResult<Self> {
         role.assert_valid("fixed buffer pool");
         let size = pool_size / (mem::size_of::<BufferFrame>() + mem::size_of::<Page>());
         let arena = QuiescentArena::new(size)?;

--- a/doradb-storage/src/buffer/mod.rs
+++ b/doradb-storage/src/buffer/mod.rs
@@ -44,13 +44,14 @@ use crate::component::{
 };
 use crate::conf::EvictableBufferPoolConfig;
 use crate::error::Validation;
-use crate::error::{DataIntegrityResult, FileKind, Result};
+use crate::error::{DataIntegrityResult, Error, FileKind, ResourceError, ResourceResult, Result};
 use crate::file::fs::{FileSystem, FileSystemWorkers};
 use crate::id::{BlockID, PageID};
 use crate::io::Completion;
 use crate::latch::LatchFallbackMode;
 use crate::quiescent::QuiescentBox;
 use crate::stats::BufferPoolCounters;
+use error_stack::Report;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -269,6 +270,7 @@ impl Component for MetaPool {
     type Config = MetaPoolConfig;
     type Owned = FixedBufferPool;
     type Access = Self;
+    type Error = Report<ResourceError>;
 
     const NAME: &'static str = "meta_pool";
 
@@ -277,11 +279,12 @@ impl Component for MetaPool {
         config: Self::Config,
         registry: &mut ComponentRegistry,
         _shelf: ShelfScope<'_, Self>,
-    ) -> Result<()> {
+    ) -> ResourceResult<()> {
         registry.register::<Self>(FixedBufferPool::with_capacity(
             PoolRole::Meta,
             config.bytes,
-        )?)
+        )?);
+        Ok(())
     }
 
     #[inline]
@@ -297,6 +300,7 @@ impl Component for IndexPool {
     type Config = IndexPoolConfig;
     type Owned = EvictableBufferPool;
     type Access = Self;
+    type Error = Error;
 
     const NAME: &'static str = "index_pool";
 
@@ -306,15 +310,16 @@ impl Component for IndexPool {
         registry: &mut ComponentRegistry,
         mut shelf: ShelfScope<'_, Self>,
     ) -> Result<()> {
-        let fs = registry.dependency::<FileSystem>()?;
+        let fs = registry.dependency::<FileSystem>();
         let (pool, storage) = EvictableBufferPoolConfig::default()
             .role(PoolRole::Index)
             .max_mem_size(config.bytes)
             .max_file_size(config.max_file_size)
             .data_swap_file(config.swap_file)
             .build_index_for_engine(fs)?;
-        registry.register::<Self>(pool)?;
-        shelf.put::<FileSystemWorkers>(storage)
+        registry.register::<Self>(pool);
+        shelf.put::<FileSystemWorkers>(storage);
+        Ok(())
     }
 
     #[inline]
@@ -330,6 +335,7 @@ impl Component for MemPool {
     type Config = EvictableBufferPoolConfig;
     type Owned = EvictableBufferPool;
     type Access = Self;
+    type Error = Error;
 
     const NAME: &'static str = "mem_pool";
 
@@ -339,10 +345,11 @@ impl Component for MemPool {
         registry: &mut ComponentRegistry,
         mut shelf: ShelfScope<'_, Self>,
     ) -> Result<()> {
-        let fs = registry.dependency::<FileSystem>()?;
+        let fs = registry.dependency::<FileSystem>();
         let (pool, storage) = config.role(PoolRole::Mem).build_for_engine(fs)?;
-        registry.register::<Self>(pool)?;
-        shelf.put::<FileSystemWorkers>(storage)
+        registry.register::<Self>(pool);
+        shelf.put::<FileSystemWorkers>(storage);
+        Ok(())
     }
 
     #[inline]
@@ -358,6 +365,7 @@ impl Component for DiskPool {
     type Config = DiskPoolConfig;
     type Owned = ReadonlyBufferPool;
     type Access = Self;
+    type Error = Report<ResourceError>;
 
     const NAME: &'static str = "disk_pool";
 
@@ -366,13 +374,14 @@ impl Component for DiskPool {
         config: Self::Config,
         registry: &mut ComponentRegistry,
         _shelf: ShelfScope<'_, Self>,
-    ) -> Result<()> {
-        let fs = registry.dependency::<FileSystem>()?;
+    ) -> ResourceResult<()> {
+        let fs = registry.dependency::<FileSystem>();
         registry.register::<Self>(ReadonlyBufferPool::with_capacity(
             PoolRole::Disk,
             config.bytes,
             fs,
-        )?)
+        )?);
+        Ok(())
     }
 
     #[inline]

--- a/doradb-storage/src/buffer/readonly.rs
+++ b/doradb-storage/src/buffer/readonly.rs
@@ -17,7 +17,7 @@ use crate::buffer::{
 };
 use crate::error::{
     CompletionErrorKind, CompletionResult, Error, FileKind, InternalError, LifecycleError,
-    ResourceError, Result,
+    ResourceError, ResourceResult, Result,
 };
 use crate::file::fs::FileSystem;
 use crate::file::{BlockKey, SparseFile};
@@ -121,7 +121,7 @@ impl ReadonlyBufferPool {
         role: PoolRole,
         pool_size: usize,
         fs: QuiescentGuard<FileSystem>,
-    ) -> Result<Self> {
+    ) -> ResourceResult<Self> {
         Self::with_capacity_and_arbiter_builder(role, pool_size, fs, EvictionArbiter::builder())
     }
 
@@ -134,7 +134,7 @@ impl ReadonlyBufferPool {
         pool_size: usize,
         fs: QuiescentGuard<FileSystem>,
         eviction_arbiter_builder: EvictionArbiterBuilder,
-    ) -> Result<Self> {
+    ) -> ResourceResult<Self> {
         role.assert_valid("global readonly buffer pool");
         let frame_plus_page = mem::size_of::<BufferFrame>() + mem::size_of::<Page>();
         let size = pool_size / frame_plus_page;
@@ -142,8 +142,7 @@ impl ReadonlyBufferPool {
             return Err(Report::new(ResourceError::BufferPoolSizeTooSmall)
                 .attach(format!(
                     "global readonly buffer pool sizing: role={role:?}, pool_size={pool_size}, frame_plus_page={frame_plus_page}, pages={size}, min_pages={MIN_READONLY_POOL_PAGES}"
-                ))
-                .into());
+                )));
         }
         let eviction_arbiter = eviction_arbiter_builder.build(size);
         let arena = QuiescentArena::new(size)?;
@@ -1753,7 +1752,7 @@ pub(crate) mod tests {
         let mut buf = vec![0u8; COW_FILE_PAGE_SIZE];
         let payload_start = write_block_header(&mut buf, LWC_BLOCK_SPEC);
         let payload_end = payload_start + LWC_BLOCK_PAYLOAD_SIZE;
-        let page = LwcBlock::try_from_bytes_mut(&mut buf[payload_start..payload_end]).unwrap();
+        let page = LwcBlock::from_bytes_mut(&mut buf[payload_start..payload_end]);
         page.header = LwcBlockHeader::new(1, 0, 0, 0);
         write_block_checksum(&mut buf);
         buf
@@ -2271,9 +2270,8 @@ pub(crate) mod tests {
         let fs_owner = build_test_fs_owner_in(temp_dir.path()).unwrap();
         let res = ReadonlyBufferPool::with_capacity(PoolRole::Disk, bytes, fs_owner.guard());
         assert!(
-            res.as_ref().is_err_and(
-                |err| err.resource_error() == Some(ResourceError::BufferPoolSizeTooSmall)
-            )
+            res.as_ref()
+                .is_err_and(|err| err.current_context() == &ResourceError::BufferPoolSizeTooSmall)
         );
     }
 
@@ -3056,8 +3054,7 @@ pub(crate) mod tests {
             {
                 let payload_start = BLOCK_INTEGRITY_HEADER_SIZE;
                 let payload_end = payload_start + LWC_BLOCK_PAYLOAD_SIZE;
-                let page_view =
-                    LwcBlock::try_from_bytes_mut(&mut page[payload_start..payload_end]).unwrap();
+                let page_view = LwcBlock::from_bytes_mut(&mut page[payload_start..payload_end]);
                 let invalid_end = (page_view.body.len() as u16).saturating_add(1);
                 page_view.header = LwcBlockHeader::new(1, 1, 1, 0);
                 page_view.body[..2].copy_from_slice(&invalid_end.to_le_bytes());

--- a/doradb-storage/src/buffer/util.rs
+++ b/doradb-storage/src/buffer/util.rs
@@ -1,6 +1,6 @@
 use crate::buffer::frame::BufferFrame;
 use crate::buffer::page::Page;
-use crate::error::{ResourceError, ResourceResult, Result};
+use crate::error::{ResourceError, ResourceResult};
 use crate::id::PageID;
 use error_stack::Report;
 use libc::{
@@ -30,7 +30,7 @@ fn page_total_bytes(capacity: usize) -> usize {
 #[inline]
 pub(super) unsafe fn initialize_frame_and_page_arrays(
     capacity: usize,
-) -> Result<(*mut BufferFrame, *mut Page)> {
+) -> ResourceResult<(*mut BufferFrame, *mut Page)> {
     let frame_total_bytes = frame_total_bytes(capacity);
     let page_total_bytes = page_total_bytes(capacity);
     // SAFETY: this helper owns the freshly mmapped regions for the duration of
@@ -42,7 +42,7 @@ pub(super) unsafe fn initialize_frame_and_page_arrays(
             Ok(ptr) => ptr as *mut Page,
             Err(err) => {
                 mmap_deallocate(frames as *mut u8, frame_total_bytes);
-                return Err(err.into());
+                return Err(err);
             }
         };
         for i in 0..capacity {

--- a/doradb-storage/src/catalog/mod.rs
+++ b/doradb-storage/src/catalog/mod.rs
@@ -763,6 +763,7 @@ impl Component for Catalog {
     type Config = CatalogConfig;
     type Owned = Self;
     type Access = QuiescentGuard<Self>;
+    type Error = Error;
 
     const NAME: &'static str = "catalog";
 
@@ -772,16 +773,17 @@ impl Component for Catalog {
         registry: &mut ComponentRegistry,
         _shelf: ShelfScope<'_, Self>,
     ) -> Result<()> {
-        let meta_pool = registry.dependency::<MetaPool>()?;
-        let table_fs = registry.dependency::<FileSystem>()?;
-        let disk_pool = registry.dependency::<DiskPool>()?;
+        let meta_pool = registry.dependency::<MetaPool>();
+        let table_fs = registry.dependency::<FileSystem>();
+        let disk_pool = registry.dependency::<DiskPool>();
         let storage = CatalogStorage::new(
             meta_pool.clone_inner(),
             table_fs.clone(),
             disk_pool.clone_inner(),
         )
         .await?;
-        registry.register::<Self>(Catalog::new(storage, config).await?)
+        registry.register::<Self>(Catalog::new(storage, config).await?);
+        Ok(())
     }
 
     #[inline]

--- a/doradb-storage/src/catalog/storage/mod.rs
+++ b/doradb-storage/src/catalog/storage/mod.rs
@@ -870,6 +870,12 @@ fn build_lwc_blocks_from_row_records(
             builder_start = Some(row.row_id);
         }
         if !builder.append_row_values(row.row_id, &row.vals) {
+            if builder.is_empty() {
+                return Err(invalid_catalog_payload(format!(
+                    "single catalog row does not fit in LWC block: row_id={}",
+                    row.row_id
+                )));
+            }
             let start_row_id = builder_start.take().ok_or_else(|| {
                 invalid_catalog_payload("catalog LWC builder missing start row id")
             })?;
@@ -1471,6 +1477,11 @@ pub(crate) mod tests {
             assert_eq!(
                 err.data_integrity_error(),
                 Some(DataIntegrityError::InvalidPayload)
+            );
+            let report = format!("{err:?}");
+            assert!(
+                report.contains("single catalog row does not fit in LWC block: row_id=0"),
+                "{report}"
             );
             assert_eq!(storage.meta_pool.allocated(), allocated_before);
 

--- a/doradb-storage/src/catalog/storage/mod.rs
+++ b/doradb-storage/src/catalog/storage/mod.rs
@@ -854,13 +854,7 @@ fn build_lwc_blocks_from_row_records(
     rows: &[RowRecord],
 ) -> Result<Vec<PendingLwcBlock>> {
     for row in rows {
-        if row.vals.len() != metadata.col.col_count() {
-            return Err(invalid_catalog_payload(format!(
-                "catalog checkpoint row value count {} does not match column count {}",
-                row.vals.len(),
-                metadata.col.col_count()
-            )));
-        }
+        validate_catalog_row(metadata, &row.vals, "catalog checkpoint LWC row")?;
     }
     if rows.is_empty() {
         return Ok(Vec::new());
@@ -875,7 +869,7 @@ fn build_lwc_blocks_from_row_records(
         if builder.is_empty() {
             builder_start = Some(row.row_id);
         }
-        if !builder.append_row_values(row.row_id, &row.vals)? {
+        if !builder.append_row_values(row.row_id, &row.vals) {
             let start_row_id = builder_start.take().ok_or_else(|| {
                 invalid_catalog_payload("catalog LWC builder missing start row id")
             })?;
@@ -895,7 +889,7 @@ fn build_lwc_blocks_from_row_records(
 
             builder = LwcBuilder::new(&metadata.col);
             builder_start = Some(row.row_id);
-            if !builder.append_row_values(row.row_id, &row.vals)? {
+            if !builder.append_row_values(row.row_id, &row.vals) {
                 return Err(invalid_catalog_payload(format!(
                     "single catalog row does not fit in LWC block: row_id={}",
                     row.row_id
@@ -1006,7 +1000,9 @@ pub(crate) mod tests {
     use crate::buffer::{PoolGuards, PoolRole};
     use crate::catalog::USER_TABLE_ID_START;
     use crate::catalog::tests::{open_catalog_test_engine, table1, table2};
-    use crate::catalog::{CatalogCheckpointBatch, CatalogCheckpointScanStopReason};
+    use crate::catalog::{
+        CatalogCheckpointBatch, CatalogCheckpointScanStopReason, ColumnAttributes, ColumnSpec,
+    };
     use crate::error::DataIntegrityError;
     use crate::file::BlockKey;
     use crate::file::multi_table_file::publish_first_redo_log_seq_for_test as publish_mtb_first_redo_log_seq_for_test;
@@ -1480,6 +1476,41 @@ pub(crate) mod tests {
 
             assert_eq!(storage.meta_pool.allocated(), allocated_before);
         });
+    }
+
+    #[test]
+    fn test_catalog_lwc_rows_are_validated_before_trusted_builder() {
+        let metadata = TableMetadata::try_new(
+            vec![ColumnSpec::new(
+                "required_u8",
+                ValKind::U8,
+                ColumnAttributes::empty(),
+            )],
+            vec![],
+        )
+        .expect("valid table metadata");
+
+        for (case, value) in [
+            ("wrong kind", Val::I16(7)),
+            ("invalid nullability", Val::Null),
+        ] {
+            let rows = [RowRecord {
+                row_id: RowID::new(0),
+                vals: vec![value],
+            }];
+            let err = match build_lwc_blocks_from_row_records(&metadata, &rows) {
+                Ok(_) => panic!("{case} must fail catalog row validation"),
+                Err(err) => err,
+            };
+            assert_eq!(
+                err.data_integrity_error(),
+                Some(DataIntegrityError::InvalidPayload),
+                "case={case}"
+            );
+            let report = format!("{err:?}");
+            assert!(report.contains("catalog checkpoint LWC row"), "{report}");
+            assert!(report.contains("column_no=0"), "{report}");
+        }
     }
 
     #[cfg(debug_assertions)]

--- a/doradb-storage/src/component.rs
+++ b/doradb-storage/src/component.rs
@@ -1,16 +1,16 @@
 use crate::buffer::{
     BufferPool, EvictableBufferPool, FixedBufferPool, PoolGuards, PoolRole, ReadonlyBufferPool,
 };
-use crate::error::{Error, InternalError, Result};
 use crate::map::FastHashMap;
 use crate::obs;
 use crate::quiescent::{QuiescentBox, QuiescentGuard};
-use error_stack::Report;
 use std::any::{Any, TypeId};
+use std::fmt::Display;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::path::PathBuf;
+use std::result::Result as StdResult;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// One lifecycle-managed engine subsystem.
@@ -37,15 +37,21 @@ pub(crate) trait Component: Sized + 'static {
     type Config;
     type Owned: Send + Sync + 'static;
     type Access: Clone + Send + Sync + 'static;
+    /// Failure type produced while constructing this component.
+    type Error: Display;
 
     const NAME: &'static str;
 
     /// Builds and registers the component's owned runtime state.
+    ///
+    /// Each implementation retains its narrowest native error until a caller
+    /// that combines component domains, such as engine construction, converts
+    /// it to the public storage error.
     fn build(
         config: Self::Config,
         registry: &mut ComponentRegistry,
         shelf: ShelfScope<'_, Self>,
-    ) -> impl Future<Output = Result<()>> + Send;
+    ) -> impl Future<Output = StdResult<(), Self::Error>> + Send;
 
     /// Derives the cloneable dependency handle from the registered owner.
     fn access(owner: &QuiescentBox<Self::Owned>) -> Self::Access;
@@ -144,23 +150,29 @@ impl ComponentRegistry {
     /// Registration order is significant: later components may only depend on
     /// components that were registered earlier, and reverse registration order
     /// becomes the engine shutdown/drop order.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the component name is empty or the fixed engine build
+    /// program registers the same component type more than once.
     #[inline]
-    pub(crate) fn register<C: Component>(&mut self, owned: C::Owned) -> Result<()> {
-        debug_assert!(
+    pub(crate) fn register<C: Component>(&mut self, owned: C::Owned) {
+        assert!(
             !C::NAME.is_empty(),
             "component implementations must provide a stable non-empty name"
         );
         let tid = TypeId::of::<C>();
-        if self.access_map.contains_key(&tid) {
-            return Err(Error::engine_component_already_registered());
-        }
+        assert!(
+            !self.access_map.contains_key(&tid),
+            "component {} is already registered in the fixed engine build order",
+            C::NAME
+        );
 
         let owner = QuiescentBox::new(owned);
         let access = C::access(&owner);
         self.access_map.insert(tid, Box::new(access));
         self.boxed_vec
             .push(Box::new(TypedComponentBox::<C> { owner }));
-        Ok(())
     }
 
     /// Return the cloned dependency handle for a previously registered
@@ -175,10 +187,19 @@ impl ComponentRegistry {
 
     /// Fetch a required dependency handle for a previously registered
     /// component.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the fixed engine registration order has not registered the
+    /// requested component with the expected access type.
     #[inline]
-    pub(crate) fn dependency<C: Component>(&self) -> Result<C::Access> {
-        self.get::<C>()
-            .ok_or(Error::engine_component_missing_dependency())
+    pub(crate) fn dependency<C: Component>(&self) -> C::Access {
+        self.get::<C>().unwrap_or_else(|| {
+            panic!(
+                "component {} is missing from the fixed engine registration order",
+                C::NAME
+            )
+        })
     }
 
     /// Run explicit component shutdown in reverse registration order.
@@ -235,39 +256,44 @@ impl Shelf {
         (TypeId::of::<Up>(), TypeId::of::<Down>())
     }
 
-    fn put<Up, Down>(&mut self, provision: <Up as Supplier<Down>>::Provision) -> Result<()>
+    fn put<Up, Down>(&mut self, provision: <Up as Supplier<Down>>::Provision)
     where
         Up: Supplier<Down>,
         Down: Component,
     {
-        let old = self
-            .parts
-            .insert(Self::key::<Up, Down>(), Box::new(provision));
-        if old.is_some() {
-            return Err(Report::new(InternalError::ComponentShelfDuplicateProvision)
-                .attach(format!("edge={} -> {}", Up::NAME, Down::NAME))
-                .into());
-        }
-        Ok(())
+        let key = Self::key::<Up, Down>();
+        assert!(
+            !self.parts.contains_key(&key),
+            "component provision edge {} -> {} was published more than once",
+            Up::NAME,
+            Down::NAME
+        );
+        self.parts.insert(key, Box::new(provision));
     }
 
-    fn take<Up, Down>(&mut self) -> Option<<Up as Supplier<Down>>::Provision>
+    fn take<Up, Down>(&mut self) -> <Up as Supplier<Down>>::Provision
     where
         Up: Supplier<Down>,
         Down: Component,
     {
-        self.parts
+        let provision = self
+            .parts
             .remove(&Self::key::<Up, Down>())
-            .map(|provision| {
-                *provision
-                    .downcast::<<Up as Supplier<Down>>::Provision>()
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "invalid shelf provision type for edge {} -> {}",
-                            Up::NAME,
-                            Down::NAME
-                        )
-                    })
+            .unwrap_or_else(|| {
+                panic!(
+                    "component provision edge {} -> {} is missing from the fixed engine build order",
+                    Up::NAME,
+                    Down::NAME
+                )
+            });
+        *provision
+            .downcast::<<Up as Supplier<Down>>::Provision>()
+            .unwrap_or_else(|_| {
+                panic!(
+                    "invalid shelf provision type for edge {} -> {}",
+                    Up::NAME,
+                    Down::NAME
+                )
             })
     }
 
@@ -300,8 +326,13 @@ pub(crate) struct ShelfScope<'a, C> {
 
 impl<'a, C: Component> ShelfScope<'a, C> {
     /// Stores a provision from the scoped component to a downstream component.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the fixed engine build program publishes the typed edge
+    /// from `C` to `Down` more than once.
     #[inline]
-    pub(crate) fn put<Down>(&mut self, provision: <C as Supplier<Down>>::Provision) -> Result<()>
+    pub(crate) fn put<Down>(&mut self, provision: <C as Supplier<Down>>::Provision)
     where
         C: Supplier<Down>,
         Down: Component,
@@ -310,8 +341,13 @@ impl<'a, C: Component> ShelfScope<'a, C> {
     }
 
     /// Takes a provision supplied by an upstream component.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the fixed engine build program has not published the typed
+    /// edge from `Up` to `C`, or if its stored type is inconsistent.
     #[inline]
-    pub(crate) fn take<Up>(&mut self) -> Option<<Up as Supplier<C>>::Provision>
+    pub(crate) fn take<Up>(&mut self) -> <Up as Supplier<C>>::Provision
     where
         Up: Supplier<C>,
     {
@@ -343,7 +379,10 @@ impl RegistryBuilder {
 
     /// Builds one component with the provided config.
     #[inline]
-    pub(crate) async fn build<C: Component>(&mut self, config: C::Config) -> Result<()> {
+    pub(crate) async fn build<C: Component>(
+        &mut self,
+        config: C::Config,
+    ) -> StdResult<(), C::Error> {
         let registry = self
             .registry
             .as_mut()
@@ -371,14 +410,21 @@ impl RegistryBuilder {
     }
 
     /// Finishes the builder and returns the completed registry.
+    ///
+    /// # Panics
+    ///
+    /// Panics when a fixed provision edge was not consumed or when the
+    /// builder's registry was unexpectedly disarmed before this consuming
+    /// call.
     #[inline]
-    pub(crate) fn finish(mut self) -> Result<ComponentRegistry> {
-        if !self.shelf.is_empty() {
-            return Err(Report::new(InternalError::ComponentShelfNotEmpty).into());
-        }
+    pub(crate) fn finish(mut self) -> ComponentRegistry {
+        assert!(
+            self.shelf.is_empty(),
+            "component shelf still contains unconsumed provisions after the fixed engine build"
+        );
         self.registry
             .take()
-            .ok_or_else(|| Report::new(InternalError::ComponentRegistryMissing).into())
+            .expect("registry builder must remain armed until finish")
     }
 }
 
@@ -532,25 +578,30 @@ impl DiskPoolConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::{Error, ErrorKind, RuntimeError};
+    use error_stack::Report;
     use parking_lot::Mutex;
+    use std::convert::Infallible;
     use std::sync::Arc;
 
     struct ValueComponent;
 
     impl Component for ValueComponent {
-        type Config = ();
+        type Config = usize;
         type Owned = usize;
         type Access = usize;
+        type Error = Infallible;
 
         const NAME: &'static str = "value";
 
         #[inline]
         async fn build(
-            _config: Self::Config,
-            _registry: &mut ComponentRegistry,
+            config: Self::Config,
+            registry: &mut ComponentRegistry,
             _shelf: ShelfScope<'_, Self>,
-        ) -> Result<()> {
-            unreachable!("test-only component")
+        ) -> StdResult<(), Self::Error> {
+            registry.register::<Self>(config);
+            Ok(())
         }
 
         #[inline]
@@ -560,6 +611,42 @@ mod tests {
 
         #[inline]
         fn shutdown(_component: &Self::Owned) {}
+    }
+
+    struct FailingBuildOwned {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Drop for FailingBuildOwned {
+        fn drop(&mut self) {
+            self.events.lock().push("drop");
+        }
+    }
+
+    struct FailingBuildComponent;
+
+    impl Component for FailingBuildComponent {
+        type Config = Arc<Mutex<Vec<&'static str>>>;
+        type Owned = FailingBuildOwned;
+        type Access = ();
+        type Error = Report<RuntimeError>;
+
+        const NAME: &'static str = "failing-build";
+
+        async fn build(
+            events: Self::Config,
+            registry: &mut ComponentRegistry,
+            _shelf: ShelfScope<'_, Self>,
+        ) -> StdResult<(), Self::Error> {
+            registry.register::<Self>(FailingBuildOwned { events });
+            Err(Report::new(RuntimeError::BackgroundSpawn))
+        }
+
+        fn access(_owner: &QuiescentBox<Self::Owned>) -> Self::Access {}
+
+        fn shutdown(component: &Self::Owned) {
+            component.events.lock().push("shutdown");
+        }
     }
 
     struct ShutdownProbe {
@@ -576,6 +663,7 @@ mod tests {
                 type Config = ();
                 type Owned = ShutdownProbe;
                 type Access = ();
+                type Error = Infallible;
 
                 const NAME: &'static str = $name;
 
@@ -584,7 +672,7 @@ mod tests {
                     _config: Self::Config,
                     _registry: &mut ComponentRegistry,
                     _shelf: ShelfScope<'_, Self>,
-                ) -> Result<()> {
+                ) -> StdResult<(), Self::Error> {
                     unreachable!("test-only component")
                 }
 
@@ -630,6 +718,7 @@ mod tests {
         type Config = ();
         type Owned = OwnerProbe;
         type Access = AccessProbe;
+        type Error = Infallible;
 
         const NAME: &'static str = "access-order";
 
@@ -638,7 +727,7 @@ mod tests {
             _config: Self::Config,
             _registry: &mut ComponentRegistry,
             _shelf: ShelfScope<'_, Self>,
-        ) -> Result<()> {
+        ) -> StdResult<(), Self::Error> {
             unreachable!("test-only component")
         }
 
@@ -654,52 +743,56 @@ mod tests {
     }
 
     #[test]
-    fn test_component_registry_rejects_duplicate_registration() {
-        let mut registry = ComponentRegistry::new();
-        registry.register::<ValueComponent>(7).unwrap();
-        let err = registry.register::<ValueComponent>(11).unwrap_err();
-        assert_eq!(
-            err.report().downcast_ref::<InternalError>().copied(),
-            Some(InternalError::EngineComponentAlreadyRegistered)
-        );
-    }
-
-    #[test]
-    fn test_component_registry_reports_missing_dependency() {
-        let registry = ComponentRegistry::new();
-        let err = registry.dependency::<ValueComponent>().unwrap_err();
-        assert_eq!(
-            err.report().downcast_ref::<InternalError>().copied(),
-            Some(InternalError::EngineComponentMissingDependency)
-        );
-    }
-
-    #[test]
     fn test_component_registry_returns_typed_access_clone() {
         let mut registry = ComponentRegistry::new();
-        registry.register::<ValueComponent>(7).unwrap();
+        registry.register::<ValueComponent>(7);
         assert_eq!(registry.get::<ValueComponent>(), Some(7));
+        assert_eq!(registry.dependency::<ValueComponent>(), 7);
+    }
+
+    #[test]
+    fn test_registry_builder_finishes_normal_component_build() {
+        smol::block_on(async {
+            let mut builder = RegistryBuilder::new();
+            builder.build::<ValueComponent>(7).await.unwrap();
+
+            let registry = builder.finish();
+            assert_eq!(registry.dependency::<ValueComponent>(), 7);
+        });
+    }
+
+    #[test]
+    fn test_registry_builder_cleans_up_after_component_build_failure() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        {
+            let mut builder = RegistryBuilder::new();
+            let err = smol::block_on(builder.build::<FailingBuildComponent>(Arc::clone(&events)))
+                .unwrap_err();
+            assert_eq!(err.current_context(), &RuntimeError::BackgroundSpawn);
+            let err = Error::from(err);
+            assert_eq!(err.kind(), ErrorKind::Runtime);
+            assert_eq!(
+                err.downcast_ref::<RuntimeError>().copied(),
+                Some(RuntimeError::BackgroundSpawn)
+            );
+        }
+
+        assert_eq!(events.lock().as_slice(), &["shutdown", "drop"]);
     }
 
     #[test]
     fn test_component_registry_shutdown_uses_reverse_registration_order_and_is_idempotent() {
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut registry = ComponentRegistry::new();
-        registry
-            .register::<ShutdownA>(ShutdownProbe {
-                events: Arc::clone(&events),
-            })
-            .unwrap();
-        registry
-            .register::<ShutdownB>(ShutdownProbe {
-                events: Arc::clone(&events),
-            })
-            .unwrap();
-        registry
-            .register::<ShutdownC>(ShutdownProbe {
-                events: Arc::clone(&events),
-            })
-            .unwrap();
+        registry.register::<ShutdownA>(ShutdownProbe {
+            events: Arc::clone(&events),
+        });
+        registry.register::<ShutdownB>(ShutdownProbe {
+            events: Arc::clone(&events),
+        });
+        registry.register::<ShutdownC>(ShutdownProbe {
+            events: Arc::clone(&events),
+        });
 
         registry.shutdown_all();
         registry.shutdown_all();
@@ -711,11 +804,9 @@ mod tests {
     fn test_component_registry_drop_clears_access_before_owner_drop() {
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut registry = ComponentRegistry::new();
-        registry
-            .register::<AccessOrderComponent>(OwnerProbe {
-                events: Arc::clone(&events),
-            })
-            .unwrap();
+        registry.register::<AccessOrderComponent>(OwnerProbe {
+            events: Arc::clone(&events),
+        });
 
         drop(registry);
 
@@ -729,6 +820,7 @@ mod tests {
         type Config = ();
         type Owned = ();
         type Access = ();
+        type Error = Infallible;
 
         const NAME: &'static str = "up";
 
@@ -736,7 +828,7 @@ mod tests {
             _config: Self::Config,
             _registry: &mut ComponentRegistry,
             _shelf: ShelfScope<'_, Self>,
-        ) -> Result<()> {
+        ) -> StdResult<(), Self::Error> {
             unreachable!("test-only component")
         }
 
@@ -749,6 +841,7 @@ mod tests {
         type Config = ();
         type Owned = ();
         type Access = ();
+        type Error = Infallible;
 
         const NAME: &'static str = "down";
 
@@ -756,7 +849,7 @@ mod tests {
             _config: Self::Config,
             _registry: &mut ComponentRegistry,
             _shelf: ShelfScope<'_, Self>,
-        ) -> Result<()> {
+        ) -> StdResult<(), Self::Error> {
             unreachable!("test-only component")
         }
 
@@ -774,25 +867,12 @@ mod tests {
         let mut shelf = Shelf::new();
         {
             let mut up = shelf.scope::<Upstream>();
-            up.put::<Downstream>(7).unwrap();
+            up.put::<Downstream>(7);
         }
         {
             let mut down = shelf.scope::<Downstream>();
-            assert_eq!(down.take::<Upstream>(), Some(7));
-            assert_eq!(down.take::<Upstream>(), None);
+            assert_eq!(down.take::<Upstream>(), 7);
         }
         assert!(shelf.is_empty());
-    }
-
-    #[test]
-    fn test_shelf_rejects_duplicate_edge_put() {
-        let mut shelf = Shelf::new();
-        let mut up = shelf.scope::<Upstream>();
-        up.put::<Downstream>(7).unwrap();
-        let err = up.put::<Downstream>(11).unwrap_err();
-        assert_eq!(
-            err.report().downcast_ref::<InternalError>().copied(),
-            Some(InternalError::ComponentShelfDuplicateProvision)
-        );
     }
 }

--- a/doradb-storage/src/engine.rs
+++ b/doradb-storage/src/engine.rs
@@ -812,16 +812,16 @@ impl EngineConfig {
         builder.build::<TransactionSystem>(trx_cfg).await?;
 
         resolved.persist_marker_if_missing()?;
-        let registry = builder.finish()?;
-        let engine_poisoner = registry.dependency::<EnginePoisoner>()?;
-        let catalog = registry.dependency::<Catalog>()?;
-        let trx_sys = registry.dependency::<TransactionSystem>()?;
-        let meta_pool = registry.dependency::<MetaPool>()?;
-        let index_pool = registry.dependency::<IndexPool>()?;
-        let mem_pool = registry.dependency::<MemPool>()?;
-        let table_fs = registry.dependency::<FileSystem>()?;
-        let disk_pool = registry.dependency::<DiskPool>()?;
-        let lock_manager = registry.dependency::<LockManager>()?;
+        let registry = builder.finish();
+        let engine_poisoner = registry.dependency::<EnginePoisoner>();
+        let catalog = registry.dependency::<Catalog>();
+        let trx_sys = registry.dependency::<TransactionSystem>();
+        let meta_pool = registry.dependency::<MetaPool>();
+        let index_pool = registry.dependency::<IndexPool>();
+        let mem_pool = registry.dependency::<MemPool>();
+        let table_fs = registry.dependency::<FileSystem>();
+        let disk_pool = registry.dependency::<DiskPool>();
+        let lock_manager = registry.dependency::<LockManager>();
         let engine_inner = EngineInner {
             engine_poisoner,
             catalog,

--- a/doradb-storage/src/engine_poison.rs
+++ b/doradb-storage/src/engine_poison.rs
@@ -1,11 +1,13 @@
 use crate::component::{Component, ComponentRegistry, ShelfScope};
-use crate::error::{FatalError, FatalResult, Result};
+use crate::error::{FatalError, FatalResult};
 use crate::obs;
 use crate::quiescent::{QuiescentBox, QuiescentGuard};
 use crossbeam_utils::CachePadded;
 use error_stack::Report;
 use event_listener::{Event, EventListener};
 use parking_lot::Mutex;
+use std::convert::Infallible;
+use std::result::Result as StdResult;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// First fatal engine poison reason published to future admission checks.
@@ -133,6 +135,7 @@ impl Component for EnginePoisoner {
     type Config = ();
     type Owned = Self;
     type Access = QuiescentGuard<Self>;
+    type Error = Infallible;
 
     const NAME: &'static str = "engine_poisoner";
 
@@ -141,8 +144,9 @@ impl Component for EnginePoisoner {
         _config: Self::Config,
         registry: &mut ComponentRegistry,
         _shelf: ShelfScope<'_, Self>,
-    ) -> Result<()> {
-        registry.register::<Self>(Self::new())
+    ) -> StdResult<(), Self::Error> {
+        registry.register::<Self>(Self::new());
+        Ok(())
     }
 
     #[inline]

--- a/doradb-storage/src/error.rs
+++ b/doradb-storage/src/error.rs
@@ -4,6 +4,7 @@ use crate::io::{
 };
 use error_stack::{AttachmentKind, FrameKind, Report};
 use std::array::TryFromSliceError;
+use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display};
 use std::io::{self, ErrorKind as IoErrorKind};
@@ -247,18 +248,6 @@ pub(crate) enum FatalError {
 pub(crate) enum InternalError {
     #[error("internal storage error")]
     Generic,
-    #[error("component shelf duplicate provision")]
-    ComponentShelfDuplicateProvision,
-    #[error("component shelf not empty")]
-    ComponentShelfNotEmpty,
-    #[error("component registry missing")]
-    ComponentRegistryMissing,
-    #[error("component provision missing")]
-    ComponentProvisionMissing,
-    #[error("engine component already registered")]
-    EngineComponentAlreadyRegistered,
-    #[error("engine component missing dependency")]
-    EngineComponentMissingDependency,
     #[error("secondary index binding mismatch")]
     SecondaryIndexBindingMismatch,
     #[error("buffer page already allocated")]
@@ -267,8 +256,6 @@ pub(crate) enum InternalError {
     BufferPageKindMismatch,
     #[error("column storage missing")]
     ColumnStorageMissing,
-    #[error("mutable block view mismatch")]
-    MutableBlockViewMismatch,
     #[error("completion dropped")]
     CompletionDropped,
     #[error("readonly buffer mapping conflict")]
@@ -321,10 +308,8 @@ pub(crate) enum InternalError {
     CatalogRootDescriptorInvariant,
     #[error("catalog primary key missing")]
     CatalogPrimaryKeyMissing,
-    #[error("column scan shape mismatch")]
-    ColumnScanShapeMismatch,
-    #[error("LWC block encoding invariant violated")]
-    LwcBlockEncodingInvariant,
+    #[error("LWC block encoding contract is unsatisfied")]
+    LwcBlockEncodingContract,
     #[error("readonly frame index out of bounds")]
     ReadonlyFrameIndexOutOfBounds,
     #[error("readonly frame guard mismatch")]
@@ -791,18 +776,6 @@ impl Error {
         Report::new(InternalError::ColumnStorageMissing).into()
     }
 
-    /// Builds an error for duplicate engine component registration.
-    #[inline]
-    pub(crate) fn engine_component_already_registered() -> Self {
-        Report::new(InternalError::EngineComponentAlreadyRegistered).into()
-    }
-
-    /// Builds an error for a missing component dependency.
-    #[inline]
-    pub(crate) fn engine_component_missing_dependency() -> Self {
-        Report::new(InternalError::EngineComponentMissingDependency).into()
-    }
-
     #[inline]
     fn fmt_report_line(report: &Report<ErrorKind>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
@@ -899,6 +872,13 @@ impl From<Report<InternalError>> for Error {
     fn from(report: Report<InternalError>) -> Self {
         // This structural public classification adds no caller-owned diagnostic.
         Error(report.change_context(ErrorKind::Internal))
+    }
+}
+
+impl From<Infallible> for Error {
+    #[inline]
+    fn from(src: Infallible) -> Self {
+        match src {}
     }
 }
 

--- a/doradb-storage/src/file/fs.rs
+++ b/doradb-storage/src/file/fs.rs
@@ -11,7 +11,7 @@ use crate::conf::FileSystemConfig;
 use crate::conf::path::path_to_utf8;
 use crate::engine_poison::EnginePoisoner;
 use crate::error::{
-    CompletionErrorKind, Error, FatalError, InternalError, IoError, Result, RuntimeResult,
+    CompletionErrorKind, Error, FatalError, IoError, Result, RuntimeError, RuntimeResult,
 };
 use crate::file::cow_file::COW_FILE_PAGE_SIZE;
 use crate::file::multi_table_file::{
@@ -1698,6 +1698,7 @@ impl Component for FileSystemWorkers {
     type Config = ();
     type Owned = FileSystemWorkersOwned;
     type Access = ();
+    type Error = Report<RuntimeError>;
 
     const NAME: &'static str = "fs_workers";
 
@@ -1707,30 +1708,15 @@ impl Component for FileSystemWorkers {
         _config: Self::Config,
         registry: &mut ComponentRegistry,
         mut shelf: ShelfScope<'_, Self>,
-    ) -> Result<()> {
-        let builder = shelf.take::<FileSystem>().ok_or_else(|| {
-            Error::from(
-                Report::new(InternalError::ComponentProvisionMissing)
-                    .attach("provider=FileSystem, consumer=FileSystemWorkers"),
-            )
-        })?;
-        let mem_pool_file = shelf.take::<MemPool>().ok_or_else(|| {
-            Error::from(
-                Report::new(InternalError::ComponentProvisionMissing)
-                    .attach("provider=MemPool, consumer=FileSystemWorkers"),
-            )
-        })?;
-        let index_pool_file = shelf.take::<IndexPool>().ok_or_else(|| {
-            Error::from(
-                Report::new(InternalError::ComponentProvisionMissing)
-                    .attach("provider=IndexPool, consumer=FileSystemWorkers"),
-            )
-        })?;
+    ) -> RuntimeResult<()> {
+        let builder = shelf.take::<FileSystem>();
+        let mem_pool_file = shelf.take::<MemPool>();
+        let index_pool_file = shelf.take::<IndexPool>();
 
-        let fs = registry.dependency::<FileSystem>()?;
-        let engine_poisoner = registry.dependency::<EnginePoisoner>()?;
-        let mem_pool = registry.dependency::<MemPool>()?;
-        let index_pool = registry.dependency::<IndexPool>()?;
+        let fs = registry.dependency::<FileSystem>();
+        let engine_poisoner = registry.dependency::<EnginePoisoner>();
+        let mem_pool = registry.dependency::<MemPool>();
+        let index_pool = registry.dependency::<IndexPool>();
         let handle = builder
             .bind(
                 engine_poisoner,
@@ -1746,7 +1732,8 @@ impl Component for FileSystemWorkers {
         registry.register::<Self>(FileSystemWorkersOwned {
             fs,
             handle: Mutex::new(Some(handle)),
-        })
+        });
+        Ok(())
     }
 
     #[inline]
@@ -2071,6 +2058,7 @@ impl Component for FileSystem {
     type Config = FileSystemConfig;
     type Owned = Self;
     type Access = QuiescentGuard<Self>;
+    type Error = Error;
 
     const NAME: &'static str = "fs";
 
@@ -2081,8 +2069,9 @@ impl Component for FileSystem {
         mut shelf: ShelfScope<'_, Self>,
     ) -> Result<()> {
         let (fs, builder) = config.build_engine_parts()?;
-        registry.register::<Self>(fs)?;
-        shelf.put::<FileSystemWorkers>(builder)
+        registry.register::<Self>(fs);
+        shelf.put::<FileSystemWorkers>(builder);
+        Ok(())
     }
 
     #[inline]
@@ -2218,20 +2207,17 @@ pub(crate) mod tests {
 
         #[inline]
         pub(crate) fn disk_pool(&self) -> DiskPool {
-            self.registry.dependency::<DiskPool>().unwrap()
+            self.registry.dependency::<DiskPool>()
         }
 
         #[inline]
         pub(crate) fn mem_pool(&self) -> QuiescentGuard<EvictableBufferPool> {
-            self.registry.dependency::<MemPool>().unwrap().clone_inner()
+            self.registry.dependency::<MemPool>().clone_inner()
         }
 
         #[inline]
         pub(crate) fn index_pool(&self) -> QuiescentGuard<EvictableBufferPool> {
-            self.registry
-                .dependency::<IndexPool>()
-                .unwrap()
-                .clone_inner()
+            self.registry.dependency::<IndexPool>().clone_inner()
         }
     }
 
@@ -2321,8 +2307,8 @@ pub(crate) mod tests {
                 .await?;
             builder.build::<FileSystemWorkers>(()).await?;
             builder.build::<SharedPoolEvictorWorkers>(()).await?;
-            let registry = builder.finish()?;
-            let fs = registry.dependency::<FileSystem>()?;
+            let registry = builder.finish();
+            let fs = registry.dependency::<FileSystem>();
             Ok(TestFileSystem {
                 fs: Some(fs),
                 registry,
@@ -2829,8 +2815,8 @@ pub(crate) mod tests {
             .unwrap();
             let mut poison_builder = RegistryBuilder::new();
             poison_builder.build::<EnginePoisoner>(()).await.unwrap();
-            let poison_registry = poison_builder.finish().unwrap();
-            let engine_poisoner = poison_registry.dependency::<EnginePoisoner>().unwrap();
+            let poison_registry = poison_builder.finish();
+            let engine_poisoner = poison_registry.dependency::<EnginePoisoner>();
             let state_machine = StorageStateMachine::new(
                 fs.mem_pool().into_sync(),
                 mem_pool_file,
@@ -2891,8 +2877,8 @@ pub(crate) mod tests {
             .unwrap();
             let mut poison_builder = RegistryBuilder::new();
             poison_builder.build::<EnginePoisoner>(()).await.unwrap();
-            let poison_registry = poison_builder.finish().unwrap();
-            let engine_poisoner = poison_registry.dependency::<EnginePoisoner>().unwrap();
+            let poison_registry = poison_builder.finish();
+            let engine_poisoner = poison_registry.dependency::<EnginePoisoner>();
             let state_machine = StorageStateMachine::new(
                 fs.mem_pool().into_sync(),
                 mem_pool_file,

--- a/doradb-storage/src/index/disk_tree.rs
+++ b/doradb-storage/src/index/disk_tree.rs
@@ -13,9 +13,7 @@
 use super::index_stream::{NonUniqueDiskTreeCandidateStream, UniqueDiskTreeCandidateStream};
 use crate::buffer::{PoolGuard, ReadonlyBlockGuard, ReadonlyBufferPool};
 use crate::catalog::{IndexSpec, TableMetadata};
-use crate::error::{
-    ConfigError, DataIntegrityError, DataIntegrityResult, FileKind, InternalError, InternalResult,
-};
+use crate::error::{ConfigError, DataIntegrityError, DataIntegrityResult, FileKind, InternalError};
 // Existing DiskTree orchestration is a genuine mixed boundary over persisted
 // DataIntegrity, buffer/file IO, configuration, and trusted rewrite Internal
 // failures. Broader index-domain narrowing belongs to a later blueprint phase.
@@ -1514,7 +1512,7 @@ impl<'a, F: DiskTreeSpec> DiskTree<'a, F> {
             .collect::<Result<Vec<_>>>()?;
         let mut buf = DirectBuf::zeroed(DISK_TREE_BLOCK_SIZE);
         let effective_space = {
-            let node = btree_node_from_block_mut(buf.data_mut())?;
+            let node = btree_node_from_block_mut(buf.data_mut());
             pack_fixed_entries(
                 node,
                 KnownFenceNodeParams {
@@ -1574,7 +1572,7 @@ impl<'a, F: DiskTreeSpec> DiskTree<'a, F> {
             .collect::<Result<Vec<_>>>()?;
         let mut buf = DirectBuf::zeroed(DISK_TREE_BLOCK_SIZE);
         let effective_space = {
-            let node = btree_node_from_block_mut(buf.data_mut())?;
+            let node = btree_node_from_block_mut(buf.data_mut());
             pack_fixed_entries(
                 node,
                 KnownFenceNodeParams {
@@ -2105,15 +2103,19 @@ fn persisted_disk_tree_node(block: &[u8]) -> DataIntegrityResult<&BTreeNode> {
         .attach_with(|| "format=secondary_disk_tree, field=node_layout")
 }
 
-/// Safely view a zeroed direct buffer as a mutable B-tree node image.
+/// View a trusted zeroed direct buffer as a mutable B-tree node image.
 ///
-/// Writers build nodes directly inside the final block buffer so the checksum
-/// can be computed over exactly the bytes that will be written.
+/// Writers allocate exactly [`DISK_TREE_BLOCK_SIZE`] bytes with
+/// `DirectBuf::zeroed`; a compile-time assertion equates that size with
+/// `BTreeNode`. Nodes are built directly inside the final block so the checksum
+/// covers exactly the bytes that will be written.
+///
+/// # Panics
+///
+/// Panics when `block` is not exactly one mutable DiskTree node block.
 #[inline]
-fn btree_node_from_block_mut(block: &mut [u8]) -> InternalResult<&mut BTreeNode> {
-    layout::try_mut_from_bytes::<BTreeNode>(block)
-        .change_context(InternalError::MutableBlockViewMismatch)
-        .attach_with(|| "phase=build_secondary_disk_tree_node")
+fn btree_node_from_block_mut(block: &mut [u8]) -> &mut BTreeNode {
+    layout::mut_from_bytes(block)
 }
 
 #[inline]
@@ -2405,7 +2407,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
-    fn test_disk_tree_layout_adaptation_preserves_source_domain() {
+    fn test_disk_tree_persisted_layout_adaptation_preserves_source_domain() {
         let persisted = match persisted_disk_tree_node(&[0u8; 1]) {
             Ok(_) => panic!("short persisted DiskTree node must fail"),
             Err(err) => err,
@@ -2419,20 +2421,6 @@ mod tests {
             Some(LayoutError::Mismatch)
         );
         assert!(format!("{persisted:?}").contains("field=node_layout"));
-
-        let mut bytes = [0u8; 1];
-        let trusted = match btree_node_from_block_mut(&mut bytes) {
-            Ok(_) => panic!("short mutable DiskTree node must fail"),
-            Err(err) => err,
-        };
-        assert_eq!(
-            trusted.current_context(),
-            &InternalError::MutableBlockViewMismatch
-        );
-        assert_eq!(
-            trusted.downcast_ref::<LayoutError>().copied(),
-            Some(LayoutError::Mismatch)
-        );
     }
 
     fn test_row_ids<const N: usize>(values: [u64; N]) -> Vec<RowID> {
@@ -4159,7 +4147,7 @@ mod tests {
     fn test_disk_tree_block_checksum_trailer_rejects_corruption() {
         let mut buf = DirectBuf::zeroed(DISK_TREE_BLOCK_SIZE);
         {
-            let node = btree_node_from_block_mut(buf.data_mut()).unwrap();
+            let node = btree_node_from_block_mut(buf.data_mut());
             node.init(0, TrxID::new(1), b"a", BTreeU64::INVALID_VALUE, &[], false);
             node.insert_at::<BTreeU64>(0, b"a", BTreeU64::from(7));
         }

--- a/doradb-storage/src/layout.rs
+++ b/doradb-storage/src/layout.rs
@@ -113,6 +113,22 @@ where
     try_ref_from_bytes(bytes).expect("trusted bytes must match the requested zerocopy layout")
 }
 
+/// Views trusted exact mutable bytes as one typed zerocopy value.
+///
+/// # Panics
+///
+/// Panics when `bytes` does not have the exact size and alignment required by
+/// `T`. Callers must establish that layout before choosing this asserting
+/// helper over [`try_mut_from_bytes`].
+#[inline]
+pub(crate) fn mut_from_bytes<T>(bytes: &mut [u8]) -> &mut T
+where
+    T: FromBytes + IntoBytes + KnownLayout,
+{
+    try_mut_from_bytes(bytes)
+        .expect("trusted bytes must match the requested mutable zerocopy layout")
+}
+
 /// Views trusted exact bytes as a typed zerocopy slice.
 #[inline]
 pub(crate) fn slice_from_bytes<T>(bytes: &[u8]) -> &[T]
@@ -152,14 +168,20 @@ mod tests {
     }
 
     #[test]
-    fn test_try_mut_from_bytes_updates_bytes() {
+    fn test_mut_from_bytes_updates_bytes() {
         let mut bytes = [0u8; mem::size_of::<LeU32>()];
 
-        try_mut_from_bytes::<LeU32>(&mut bytes)
-            .unwrap()
-            .set(0x1122_3344);
+        mut_from_bytes::<LeU32>(&mut bytes).set(0x1122_3344);
 
         assert_eq!(bytes, [0x44, 0x33, 0x22, 0x11]);
+    }
+
+    #[test]
+    fn test_try_mut_from_bytes_rejects_wrong_len() {
+        let mut bytes = [0u8; 3];
+        let err = try_mut_from_bytes::<LeU32>(&mut bytes).unwrap_err();
+
+        assert_eq!(*err.current_context(), LayoutError::Mismatch);
     }
 
     #[test]

--- a/doradb-storage/src/lock/mod.rs
+++ b/doradb-storage/src/lock/mod.rs
@@ -7,7 +7,7 @@
 mod state;
 
 use crate::component::{Component, ComponentRegistry, ShelfScope};
-use crate::error::{OperationError, OperationResult, Result};
+use crate::error::{OperationError, OperationResult};
 use crate::id::{SessionID, TableID, TrxID};
 use crate::map::FastDashMap;
 use crate::quiescent::{QuiescentBox, QuiescentGuard};
@@ -15,7 +15,9 @@ use error_stack::Report;
 use event_listener::Event;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::convert::Infallible;
 use std::fmt;
+use std::result::Result as StdResult;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 
@@ -641,6 +643,7 @@ impl Component for LockManager {
     type Config = ();
     type Owned = Self;
     type Access = QuiescentGuard<Self>;
+    type Error = Infallible;
 
     const NAME: &'static str = "lock_manager";
 
@@ -649,8 +652,9 @@ impl Component for LockManager {
         _config: Self::Config,
         registry: &mut ComponentRegistry,
         _shelf: ShelfScope<'_, Self>,
-    ) -> Result<()> {
-        registry.register::<Self>(Self::new())
+    ) -> StdResult<(), Self::Error> {
+        registry.register::<Self>(Self::new());
+        Ok(())
     }
 
     #[inline]

--- a/doradb-storage/src/lwc/block.rs
+++ b/doradb-storage/src/lwc/block.rs
@@ -2,9 +2,7 @@
 
 use crate::buffer::{PoolGuard, ReadonlyBlockGuard, ReadonlyBufferPool};
 use crate::catalog::{IndexSpec, TableColumnLayout};
-use crate::error::{
-    DataIntegrityError, DataIntegrityResult, FileKind, InternalError, InternalResult,
-};
+use crate::error::{DataIntegrityError, DataIntegrityResult, FileKind};
 // Genuine mixed-domain convergence: `PersistedLwcBlock::load` combines
 // buffer/read completion failures with persisted DataIntegrity validation, so
 // its public storage result ends typed propagation at the load boundary.
@@ -119,17 +117,17 @@ impl LwcBlock {
         unsafe { &*input.as_ptr().cast::<Self>() }
     }
 
-    /// Mutably borrows one raw LWC payload image with the expected payload size.
+    /// Mutably borrows a trusted, exactly sized LWC payload image.
+    ///
+    /// Writers allocate a full block and pass exactly its
+    /// [`LWC_BLOCK_PAYLOAD_SIZE`] payload bytes to this helper.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `input` is not exactly one mutable LWC payload.
     #[inline]
-    pub(crate) fn try_from_bytes_mut(input: &mut [u8]) -> InternalResult<&mut Self> {
-        let input_len = input.len();
-        layout::try_mut_from_bytes::<Self>(input)
-            .change_context(InternalError::LwcBlockEncodingInvariant)
-            .attach_with(|| {
-                format!(
-                    "mutable LWC block payload has invalid length {input_len}, expected {LWC_BLOCK_PAYLOAD_SIZE}"
-                )
-            })
+    pub(crate) fn from_bytes_mut(input: &mut [u8]) -> &mut Self {
+        layout::mut_from_bytes(input)
     }
 
     /// Validates a full persisted LWC block image and returns its payload view.
@@ -557,7 +555,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lwc_layout_adaptation_preserves_source_for_persisted_and_mutable_views() {
+    fn test_lwc_persisted_layout_adaptation_preserves_source() {
         let persisted = match LwcBlock::try_from_bytes(&[0u8; 1]) {
             Ok(_) => panic!("short persisted LWC payload must fail"),
             Err(err) => err,
@@ -568,20 +566,6 @@ mod tests {
         );
         assert_eq!(
             persisted.downcast_ref::<LayoutError>().copied(),
-            Some(LayoutError::Mismatch)
-        );
-
-        let mut bytes = [0u8; 1];
-        let trusted = match LwcBlock::try_from_bytes_mut(&mut bytes) {
-            Ok(_) => panic!("short mutable LWC payload must fail"),
-            Err(err) => err,
-        };
-        assert_eq!(
-            trusted.current_context(),
-            &InternalError::LwcBlockEncodingInvariant
-        );
-        assert_eq!(
-            trusted.downcast_ref::<LayoutError>().copied(),
             Some(LayoutError::Mismatch)
         );
     }
@@ -598,8 +582,7 @@ mod tests {
         let mut buf = DirectBuf::zeroed(COW_FILE_PAGE_SIZE);
         let payload_start = write_block_header(buf.data_mut(), LWC_BLOCK_SPEC);
         let payload_end = payload_start + LWC_BLOCK_PAYLOAD_SIZE;
-        let page =
-            LwcBlock::try_from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end]).unwrap();
+        let page = LwcBlock::from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end]);
         page.header = LwcBlockHeader::new(11, 1, 1, 0);
         page.body[..2].copy_from_slice(&(2u16).to_le_bytes());
         write_block_checksum(buf.data_mut());
@@ -632,7 +615,7 @@ mod tests {
         let buf = {
             let mut builder = LwcBuilder::new(metadata.col.as_ref());
             let view = page.vector_view(metadata.col.as_ref());
-            assert!(builder.append_view(view, page.header.start_row_id).unwrap());
+            assert!(builder.append_view(view, page.header.start_row_id));
             let fingerprint = row_shape_fingerprint_for(builder.row_ids());
             builder.build(fingerprint).unwrap()
         };
@@ -642,7 +625,7 @@ mod tests {
     #[test]
     fn test_lwc_block() {
         let mut buf = DirectBuf::zeroed(LWC_BLOCK_PAYLOAD_SIZE);
-        let page = LwcBlock::try_from_bytes_mut(buf.data_mut()).unwrap();
+        let page = LwcBlock::from_bytes_mut(buf.data_mut());
         page.header = LwcBlockHeader::new(100, 50, 2, 7);
         assert!(page.header.row_shape_fingerprint() == 100);
         assert!(page.header.row_count() == 50);
@@ -676,7 +659,7 @@ mod tests {
         column_bytes[idx..].copy_from_slice(&values_bytes);
 
         let mut buf = DirectBuf::zeroed(LWC_BLOCK_PAYLOAD_SIZE);
-        let page = LwcBlock::try_from_bytes_mut(buf.data_mut()).unwrap();
+        let page = LwcBlock::from_bytes_mut(buf.data_mut());
         let col_offsets_len = mem::size_of::<u16>();
         let col_start = col_offsets_len;
         let col_end = col_start + column_bytes.len();
@@ -711,7 +694,7 @@ mod tests {
         )
         .expect("valid table metadata");
         let mut buf = DirectBuf::zeroed(LWC_BLOCK_PAYLOAD_SIZE);
-        let page = LwcBlock::try_from_bytes_mut(buf.data_mut()).unwrap();
+        let page = LwcBlock::from_bytes_mut(buf.data_mut());
         let col_offsets_len = mem::size_of::<u16>() * 2;
         let end_offset = col_offsets_len as u16;
         page.header = LwcBlockHeader::new(1, 0, 2, 0);
@@ -736,10 +719,10 @@ mod tests {
     }
 
     #[test]
-    fn test_lwc_block_try_from_bytes_mut_roundtrip() {
+    fn test_lwc_block_from_bytes_mut_roundtrip() {
         let mut buf = DirectBuf::zeroed(LWC_BLOCK_PAYLOAD_SIZE);
         {
-            let page = LwcBlock::try_from_bytes_mut(buf.data_mut()).unwrap();
+            let page = LwcBlock::from_bytes_mut(buf.data_mut());
             page.header = LwcBlockHeader::new(11, 2, 1, 0);
             page.body[..2].copy_from_slice(&(3u16).to_le_bytes());
             page.body[2] = 0xAB;
@@ -862,8 +845,7 @@ mod tests {
         let mut buf = DirectBuf::zeroed(COW_FILE_PAGE_SIZE);
         let payload_start = write_block_header(buf.data_mut(), LWC_BLOCK_SPEC);
         let payload_end = payload_start + LWC_BLOCK_PAYLOAD_SIZE;
-        let page =
-            LwcBlock::try_from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end]).unwrap();
+        let page = LwcBlock::from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end]);
         let invalid_end = (page.body.len() as u16).saturating_add(1);
         page.header = LwcBlockHeader::new(0, 1, 1, 0);
         page.body[..2].copy_from_slice(&invalid_end.to_le_bytes());
@@ -890,9 +872,7 @@ mod tests {
         let payload_start = BLOCK_INTEGRITY_HEADER_SIZE;
         let payload_end = payload_start + LWC_BLOCK_PAYLOAD_SIZE;
         {
-            let page =
-                LwcBlock::try_from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end])
-                    .unwrap();
+            let page = LwcBlock::from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end]);
             let (start_idx, end_idx) = page.col_offsets().unwrap().get(0).unwrap();
             let column = &mut page.body[start_idx..end_idx];
             let data_len = column.len().saturating_sub(11);

--- a/doradb-storage/src/lwc/mod.rs
+++ b/doradb-storage/src/lwc/mod.rs
@@ -893,74 +893,66 @@ impl<'a> LwcBuilder<'a> {
         &self.row_ids
     }
 
-    /// Appends one decoded row if the block still fits.
-    pub(crate) fn append_row_values(
-        &mut self,
-        row_id: RowID,
-        vals: &[Val],
-    ) -> InternalResult<bool> {
+    /// Appends one validated decoded row if the block still fits.
+    ///
+    /// Returns `false` and restores the previous builder state when the row
+    /// would exceed the block payload capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the row was not validated against the layout supplied to
+    /// [`Self::new`].
+    pub(crate) fn append_row_values(&mut self, row_id: RowID, vals: &[Val]) -> bool {
         let snapshot = self.snapshot_state();
-        match self.append_row_values_inner(row_id, vals) {
-            Ok(true) => Ok(true),
-            Ok(false) => {
-                self.rollback(snapshot);
-                Ok(false)
-            }
-            Err(err) => {
-                self.rollback(snapshot);
-                Err(err)
-            }
+        if self.append_row_values_inner(row_id, vals) {
+            true
+        } else {
+            self.rollback(snapshot);
+            false
         }
     }
 
     /// Appends rows described by `view` if the block still fits.
+    ///
+    /// Returns `false` and restores the previous builder state when the view
+    /// would exceed the block payload capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the page view was not constructed from the layout supplied
+    /// to [`Self::new`].
     pub(crate) fn append_view(
         &mut self,
         view: PageVectorView<'_, '_>,
         start_row_id: RowID,
-    ) -> InternalResult<bool> {
+    ) -> bool {
         let snapshot = self.snapshot_state();
-        match self.append_view_inner(view, start_row_id) {
-            Ok(true) => Ok(true),
-            Ok(false) => {
-                self.rollback(snapshot);
-                Ok(false)
-            }
-            Err(err) => {
-                self.rollback(snapshot);
-                Err(err)
-            }
+        if self.append_view_inner(view, start_row_id) {
+            true
+        } else {
+            self.rollback(snapshot);
+            false
         }
     }
 
-    fn append_view_inner(
-        &mut self,
-        view: PageVectorView<'_, '_>,
-        start_row_id: RowID,
-    ) -> InternalResult<bool> {
+    fn append_view_inner(&mut self, view: PageVectorView<'_, '_>, start_row_id: RowID) -> bool {
         let mut new_row_ids = Vec::with_capacity(view.rows_non_deleted());
         for (start_idx, end_idx) in view.range_non_deleted() {
             for idx in start_idx..end_idx {
                 new_row_ids.push(start_row_id + idx as u64);
             }
         }
-        self.scan_page_stats(&view, &new_row_ids)?;
-        self.buffer.scan(view)?;
+        self.scan_page_stats(&view, &new_row_ids);
+        self.buffer.scan(view);
         self.row_ids.extend(new_row_ids);
-        if self.estimate_size()? > LWC_BLOCK_PAYLOAD_SIZE {
-            return Ok(false);
-        }
-        Ok(true)
+        self.estimate_size() <= LWC_BLOCK_PAYLOAD_SIZE
     }
 
-    fn append_row_values_inner(&mut self, row_id: RowID, vals: &[Val]) -> InternalResult<bool> {
-        self.scan_row_value_stats(vals)?;
-        self.buffer.append_row_values(self.col_layout, vals)?;
+    fn append_row_values_inner(&mut self, row_id: RowID, vals: &[Val]) -> bool {
+        self.scan_row_value_stats(vals);
+        self.buffer.append_row_values(self.col_layout, vals);
         self.row_ids.push(row_id);
-        if self.estimate_size()? > LWC_BLOCK_PAYLOAD_SIZE {
-            return Ok(false);
-        }
-        Ok(true)
+        self.estimate_size() <= LWC_BLOCK_PAYLOAD_SIZE
     }
 
     /// Builds a persisted LWC block with the supplied row-shape fingerprint.
@@ -971,17 +963,20 @@ impl<'a> LwcBuilder<'a> {
         }
         let row_count = self.buffer.len();
         if row_count > u16::MAX as usize {
-            return Err(lwc_block_encoding_invariant());
+            return Err(lwc_block_encoding_contract()
+                .attach("field=row_count")
+                .attach(format!("actual={row_count}, maximum={}", u16::MAX)));
         }
         let mut column_payloads = Vec::with_capacity(self.col_layout.col_count());
         let mut col_offsets = Vec::with_capacity(self.col_layout.col_count());
         let mut offset = mem::size_of::<u16>() * self.col_layout.col_count();
 
         for col_idx in 0..self.col_layout.col_count() {
-            let column = self
-                .buffer
-                .column(col_idx)
-                .ok_or_else(|| Report::new(InternalError::ColumnScanShapeMismatch))?;
+            let column = self.buffer.column(col_idx).unwrap_or_else(|| {
+                panic!(
+                    "LWC builder scan buffer must contain column {col_idx} from its table layout"
+                )
+            });
             let mut data = Vec::new();
             if let Some(bitmap) = column.null_bitmap {
                 let bytes = bitmap_to_bytes(bitmap, row_count);
@@ -1047,7 +1042,9 @@ impl<'a> LwcBuilder<'a> {
             data.extend_from_slice(&payload);
             offset += data.len();
             if offset > u16::MAX as usize {
-                return Err(lwc_block_encoding_invariant());
+                return Err(lwc_block_encoding_contract()
+                    .attach(format!("field=column_end_offset, column_no={col_idx}"))
+                    .attach(format!("actual={offset}, maximum={}", u16::MAX)));
             }
             col_offsets.push(offset as u16);
             column_payloads.push(data);
@@ -1063,7 +1060,7 @@ impl<'a> LwcBuilder<'a> {
         let mut buf = DirectBuf::zeroed(COW_FILE_PAGE_SIZE);
         let payload_start = write_block_header(buf.data_mut(), LWC_BLOCK_SPEC);
         let payload_end = payload_start + LWC_BLOCK_PAYLOAD_SIZE;
-        let page = LwcBlock::try_from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end])?;
+        let page = LwcBlock::from_bytes_mut(&mut buf.data_mut()[payload_start..payload_end]);
         page.header = header;
         let mut body_idx = 0;
         for offset in col_offsets {
@@ -1094,13 +1091,14 @@ impl<'a> LwcBuilder<'a> {
         }
     }
 
-    fn scan_page_stats(
-        &mut self,
-        view: &PageVectorView<'_, '_>,
-        row_ids: &[RowID],
-    ) -> InternalResult<()> {
+    fn scan_page_stats(&mut self, view: &PageVectorView<'_, '_>, row_ids: &[RowID]) {
+        assert_eq!(
+            row_ids.len(),
+            view.rows_non_deleted(),
+            "LWC page statistics row ids must match the page view's visible rows"
+        );
         if row_ids.is_empty() {
-            return Ok(());
+            return;
         }
         for col_idx in 0..self.col_layout.col_count() {
             let (null_bitmap, values) = view.col(col_idx);
@@ -1181,13 +1179,14 @@ impl<'a> LwcBuilder<'a> {
                 ValArrayRef::F32(_) | ValArrayRef::F64(_) | ValArrayRef::VarByte(_, _) => {}
             }
         }
-        Ok(())
     }
 
-    fn scan_row_value_stats(&mut self, vals: &[Val]) -> InternalResult<()> {
-        if vals.len() != self.col_layout.col_count() {
-            return Err(Report::new(InternalError::ColumnScanShapeMismatch));
-        }
+    fn scan_row_value_stats(&mut self, vals: &[Val]) {
+        assert_eq!(
+            vals.len(),
+            self.col_layout.col_count(),
+            "LWC statistics require a complete row validated against the builder layout"
+        );
         for (col_idx, val) in vals.iter().enumerate() {
             if val.is_null() {
                 continue;
@@ -1204,10 +1203,11 @@ impl<'a> LwcBuilder<'a> {
                 (ValKind::F32, Val::F32(_))
                 | (ValKind::F64, Val::F64(_))
                 | (ValKind::VarByte, Val::VarByte(_)) => {}
-                _ => return Err(Report::new(InternalError::ColumnScanShapeMismatch)),
+                _ => unreachable!(
+                    "LWC statistics value kind for column {col_idx} must match the validated row layout"
+                ),
             }
         }
-        Ok(())
     }
 
     fn update_stats_i64<T: Copy, R: Iterator<Item = (usize, usize)>>(
@@ -1223,9 +1223,12 @@ impl<'a> LwcBuilder<'a> {
                 if null_bitmap.map(|bm| bm.bitmap_get(idx)).unwrap_or(false) {
                     continue;
                 }
-                if let Some(value) = values.get(idx) {
-                    self.stats[col_idx].update_i64(decode(*value));
-                }
+                let value = values.get(idx).unwrap_or_else(|| {
+                    panic!(
+                        "LWC page statistics column {col_idx} is missing visible row index {idx}"
+                    )
+                });
+                self.stats[col_idx].update_i64(decode(*value));
             }
         }
     }
@@ -1243,19 +1246,22 @@ impl<'a> LwcBuilder<'a> {
                 if null_bitmap.map(|bm| bm.bitmap_get(idx)).unwrap_or(false) {
                     continue;
                 }
-                if let Some(value) = values.get(idx) {
-                    self.stats[col_idx].update_u64(decode(*value));
-                }
+                let value = values.get(idx).unwrap_or_else(|| {
+                    panic!(
+                        "LWC page statistics column {col_idx} is missing visible row index {idx}"
+                    )
+                });
+                self.stats[col_idx].update_u64(decode(*value));
             }
         }
     }
 
-    fn estimate_size(&self) -> InternalResult<usize> {
+    fn estimate_size(&self) -> usize {
         let row_count = self.buffer.len();
         let mut total = LWC_BLOCK_HEADER_SIZE;
         total += mem::size_of::<u16>() * self.col_layout.col_count();
-        total += estimate_columns_size(self.col_layout, &self.buffer, &self.stats, row_count)?;
-        Ok(total)
+        total += estimate_columns_size(self.col_layout, &self.buffer, &self.stats, row_count);
+        total
     }
 }
 
@@ -1505,8 +1511,9 @@ impl<'a> LwcNullBitmapSer<'a> {
     #[inline]
     pub(crate) fn new(bytes: &'a [u8]) -> InternalResult<Self> {
         if bytes.len() > u16::MAX as usize {
-            return Err(lwc_block_encoding_invariant()
-                .attach("LWC null bitmap payload length exceeds u16::MAX"));
+            return Err(lwc_block_encoding_contract()
+                .attach("field=null_bitmap_byte_length")
+                .attach(format!("actual={}, maximum={}", bytes.len(), u16::MAX)));
         }
         Ok(LwcNullBitmapSer { bytes })
     }
@@ -1597,8 +1604,8 @@ fn persisted_lwc_layout<T>(
 }
 
 #[inline]
-fn lwc_block_encoding_invariant() -> Report<InternalError> {
-    Report::new(InternalError::LwcBlockEncodingInvariant)
+fn lwc_block_encoding_contract() -> Report<InternalError> {
+    Report::new(InternalError::LwcBlockEncodingContract)
 }
 
 #[inline]
@@ -1796,20 +1803,33 @@ fn estimate_columns_size(
     buffer: &ScanBuffer,
     stats: &[LwcColumnStats],
     row_count: usize,
-) -> InternalResult<usize> {
+) -> usize {
     let mut total = 0usize;
-    debug_assert!(stats.len() == col_layout.col_count());
+    assert_eq!(
+        stats.len(),
+        col_layout.col_count(),
+        "LWC statistics columns must match the builder table layout"
+    );
     for (col_idx, st) in stats.iter().enumerate() {
         let column = buffer
             .column(col_idx)
-            .ok_or_else(|| Report::new(InternalError::ColumnScanShapeMismatch))?;
+            .unwrap_or_else(|| {
+                panic!(
+                    "LWC size estimation scan buffer must contain column {col_idx} from its table layout"
+                )
+            });
         if column.null_bitmap.is_some() {
             total += mem::size_of::<u16>() + row_count.div_ceil(8);
         }
-        total +=
-            estimate_column_payload(col_layout.val_kind(col_idx), &column.values, st, row_count)?;
+        total += estimate_column_payload(
+            col_layout.val_kind(col_idx),
+            &column.values,
+            st,
+            row_count,
+            col_idx,
+        );
     }
-    Ok(total)
+    total
 }
 
 fn estimate_column_payload(
@@ -1817,8 +1837,9 @@ fn estimate_column_payload(
     values: &ScanColumnValues<'_>,
     stats: &LwcColumnStats,
     row_count: usize,
-) -> InternalResult<usize> {
-    let size = match (kind, values) {
+    col_idx: usize,
+) -> usize {
+    match (kind, values) {
         (ValKind::I8, ScanColumnValues::I8(_)) => {
             estimate_i64_payload(stats, row_count, mem::size_of::<i8>())
         }
@@ -1856,9 +1877,10 @@ fn estimate_column_payload(
                 + (count + 1) * mem::size_of::<u32>()
                 + data.len()
         }
-        _ => return Err(Report::new(InternalError::ColumnScanShapeMismatch)),
-    };
-    Ok(size)
+        _ => unreachable!(
+            "LWC size estimation value kind for column {col_idx} must match its table layout"
+        ),
+    }
 }
 
 fn estimate_i64_payload(stats: &LwcColumnStats, row_count: usize, unit: usize) -> usize {
@@ -2000,7 +2022,7 @@ fn read_i8(input: &[u8]) -> DataIntegrityResult<(i8, &[u8])> {
 mod tests {
     use super::*;
     use crate::catalog::{ColumnAttributes, ColumnSpec, TableMetadata};
-    use crate::error::{DataIntegrityError, DataIntegrityResult, FileKind};
+    use crate::error::{DataIntegrityError, DataIntegrityResult, FileKind, InternalError};
     use crate::file::test_block_id;
     use crate::id::RowID;
     use crate::index::ColumnBlockEntryShape;
@@ -2431,7 +2453,7 @@ mod tests {
         assert!(builder.is_empty());
         assert!(builder.row_count() == 0);
         let view = page.vector_view(metadata.col.as_ref());
-        let appended = builder.append_view(view, page.header.start_row_id).unwrap();
+        let appended = builder.append_view(view, page.header.start_row_id);
         assert!(appended);
         let expected_fingerprint = row_shape_fingerprint_for(builder.row_ids(), 100, 110);
         let buf = builder.build(expected_fingerprint).unwrap();
@@ -2506,18 +2528,10 @@ mod tests {
 
         let mut page_builder = LwcBuilder::new(metadata.col.as_ref());
         let view = page.vector_view(metadata.col.as_ref());
-        assert!(
-            page_builder
-                .append_view(view, page.header.start_row_id)
-                .unwrap()
-        );
+        assert!(page_builder.append_view(view, page.header.start_row_id));
         let mut direct_builder = LwcBuilder::new(metadata.col.as_ref());
         for (offset, vals) in rows.iter().enumerate() {
-            assert!(
-                direct_builder
-                    .append_row_values(RowID::new(10 + offset as u64), vals)
-                    .unwrap()
-            );
+            assert!(direct_builder.append_row_values(RowID::new(10 + offset as u64), vals));
         }
 
         assert_eq!(direct_builder.row_ids(), page_builder.row_ids());
@@ -2525,6 +2539,59 @@ mod tests {
         let page_buf = page_builder.build(fingerprint).unwrap();
         let direct_buf = direct_builder.build(fingerprint).unwrap();
         assert_eq!(direct_buf.as_bytes(), page_buf.as_bytes());
+    }
+
+    #[test]
+    fn test_lwc_builder_append_row_values_rolls_back_on_capacity() {
+        let metadata = TableMetadata::try_new(
+            vec![ColumnSpec::new(
+                "bytes",
+                ValKind::VarByte,
+                ColumnAttributes::empty(),
+            )],
+            vec![],
+        )
+        .expect("valid table metadata");
+        let mut builder = LwcBuilder::new(metadata.col.as_ref());
+        assert!(builder.append_row_values(RowID::new(1), &[Val::from(Vec::from(&b"ok"[..]))]));
+
+        let oversized = Val::from(vec![0u8; LWC_BLOCK_PAYLOAD_SIZE]);
+        assert!(!builder.append_row_values(RowID::new(2), &[oversized]));
+
+        assert_eq!(builder.row_count(), 1);
+        assert_eq!(builder.row_ids(), &[RowID::new(1)]);
+        assert!(builder.build(0).is_ok());
+    }
+
+    #[test]
+    fn test_lwc_builder_reports_reachable_row_count_encoding_contract() {
+        let metadata = TableMetadata::try_new(
+            vec![ColumnSpec::new(
+                "compressible",
+                ValKind::U8,
+                ColumnAttributes::empty(),
+            )],
+            vec![],
+        )
+        .expect("valid table metadata");
+        let mut builder = LwcBuilder::new(metadata.col.as_ref());
+
+        for row_no in 0..=u16::MAX {
+            assert!(builder.append_row_values(RowID::new(u64::from(row_no)), &[Val::U8(0)]));
+        }
+        assert_eq!(builder.row_count(), u16::MAX as usize + 1);
+
+        let err = match builder.build(0) {
+            Ok(_) => panic!("row count above u16::MAX must fail encoding"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.current_context(),
+            &InternalError::LwcBlockEncodingContract
+        );
+        let report = format!("{err:?}");
+        assert!(report.contains("field=row_count"), "{report}");
+        assert!(report.contains("maximum=65535"), "{report}");
     }
 
     #[test]
@@ -2561,7 +2628,7 @@ mod tests {
 
         let mut builder = LwcBuilder::new(metadata.col.as_ref());
         let view = page.vector_view(metadata.col.as_ref());
-        assert!(builder.append_view(view, page.header.start_row_id).unwrap());
+        assert!(builder.append_view(view, page.header.start_row_id));
 
         let stats = builder.stats[0].snapshot();
         assert!(stats.initialized);
@@ -2593,7 +2660,7 @@ mod tests {
 
         let mut builder = LwcBuilder::new(metadata.col.as_ref());
         let view = page.vector_view(metadata.col.as_ref());
-        assert!(builder.append_view(view, page.header.start_row_id).unwrap());
+        assert!(builder.append_view(view, page.header.start_row_id));
 
         let snapshot = builder.snapshot_state();
         let expected_row_count = builder.row_count();
@@ -2622,7 +2689,7 @@ mod tests {
             ));
         }
         let view = page.vector_view(metadata.col.as_ref());
-        assert!(builder.append_view(view, page.header.start_row_id).unwrap());
+        assert!(builder.append_view(view, page.header.start_row_id));
 
         builder.rollback(snapshot);
 
@@ -2643,49 +2710,6 @@ mod tests {
             })
             .collect();
         assert_eq!(restored_stats, expected_stats);
-    }
-
-    #[test]
-    fn test_lwc_builder_append_view_rolls_back_on_estimate_error() {
-        let metadata = TableMetadata::try_new(
-            vec![
-                ColumnSpec::new("c0", ValKind::U8, ColumnAttributes::empty()),
-                ColumnSpec::new("c1", ValKind::I16, ColumnAttributes::empty()),
-            ],
-            vec![],
-        )
-        .expect("valid table metadata");
-        let mut page = RowPage::new_test_page();
-        page.init(RowID::new(1), 4, metadata.col.as_ref());
-
-        for offset in 0..2u64 {
-            let c0 = Val::U8((10 + offset) as u8);
-            let c1 = Val::I16((20 + offset) as i16);
-            assert!(matches!(
-                page.insert(metadata.col.as_ref(), &[c0, c1]),
-                InsertRow::Ok(_)
-            ));
-        }
-
-        let mut builder = LwcBuilder::new(metadata.col.as_ref());
-        builder.buffer = ScanBuffer::new(metadata.col.as_ref(), &[0]);
-
-        let view = page.vector_view(metadata.col.as_ref());
-        let res = builder.append_view(view, page.header.start_row_id);
-
-        let err = res.expect_err("column shape mismatch must fail");
-        assert_eq!(
-            err.current_context(),
-            &InternalError::ColumnScanShapeMismatch
-        );
-        assert_eq!(builder.row_count(), 0);
-        assert!(builder.row_ids().is_empty());
-        assert!(
-            builder
-                .stats
-                .iter()
-                .all(|stat| !stat.snapshot().initialized)
-        );
     }
 
     #[test]
@@ -2761,7 +2785,7 @@ mod tests {
 
         let mut builder = LwcBuilder::new(metadata.col.as_ref());
         let view = page.vector_view(metadata.col.as_ref());
-        assert!(builder.append_view(view, page.header.start_row_id).unwrap());
+        assert!(builder.append_view(view, page.header.start_row_id));
         let buf = builder
             .build(row_shape_fingerprint_for(builder.row_ids(), 10, 13))
             .unwrap();

--- a/doradb-storage/src/row/vector_scan.rs
+++ b/doradb-storage/src/row/vector_scan.rs
@@ -77,12 +77,17 @@ impl ScanBuffer {
         })
     }
 
-    /// Scan given page and extend all rows into buffer.
-    /// Note: If error is returned, the state of this buffer might be invalid.
+    /// Scan a page view built from the same column layout as this buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `view` does not have the column kinds and nullability used
+    /// to construct this buffer.
     #[inline]
-    pub(crate) fn scan<'p, 'm>(&mut self, view: PageVectorView<'p, 'm>) -> InternalResult<()> {
+    pub(crate) fn scan<'p, 'm>(&mut self, view: PageVectorView<'p, 'm>) {
         let new_len = self.len + view.rows_non_deleted();
         for buf in &mut self.cols {
+            let col_idx = buf.col_idx;
             let (null_bitmap, vals) = view.col(buf.col_idx);
             // First, extend null bitmap.
             match (buf.null_bitmap.as_mut(), null_bitmap) {
@@ -107,7 +112,9 @@ impl ScanBuffer {
                     }
                 }
                 (None, None) => (),
-                _ => return Err(Report::new(InternalError::ColumnScanShapeMismatch)),
+                _ => panic!(
+                    "scan buffer nullability for column {col_idx} must match its table layout"
+                ),
             }
             // Second, extend values
             match (&mut buf.vals, vals) {
@@ -171,36 +178,51 @@ impl ScanBuffer {
                         }
                     }
                 }
-                _ => return Err(Report::new(InternalError::ColumnScanShapeMismatch)),
+                _ => unreachable!(
+                    "scan buffer value kind for column {col_idx} must match its table layout"
+                ),
             }
         }
         self.len = new_len;
-        Ok(())
     }
 
     /// Append one decoded row into the scan buffer.
     ///
     /// Null values still append a type-specific placeholder so column value
     /// buffers stay row-aligned with the null bitmap, matching row-page scans.
-    pub(crate) fn append_row_values(
-        &mut self,
-        col_layout: &TableColumnLayout,
-        vals: &[Val],
-    ) -> InternalResult<()> {
-        if vals.len() != col_layout.col_count() {
-            return Err(Report::new(InternalError::ColumnScanShapeMismatch));
-        }
+    ///
+    /// # Panics
+    ///
+    /// Panics when `vals` is not a complete row already validated against
+    /// `col_layout`, or when the layout differs from the one used to construct
+    /// this buffer.
+    pub(crate) fn append_row_values(&mut self, col_layout: &TableColumnLayout, vals: &[Val]) {
+        assert_eq!(
+            vals.len(),
+            col_layout.col_count(),
+            "decoded row value count must match the trusted table layout"
+        );
         for buf in &self.cols {
-            let Some(val) = vals.get(buf.col_idx) else {
-                return Err(Report::new(InternalError::ColumnScanShapeMismatch));
-            };
+            let val = vals.get(buf.col_idx).unwrap_or_else(|| {
+                panic!(
+                    "scan buffer column {} must exist in the trusted decoded row",
+                    buf.col_idx
+                )
+            });
             let col_type = col_layout.col_type(buf.col_idx);
             if val.is_null() {
-                if !col_type.nullable {
-                    return Err(Report::new(InternalError::ColumnScanShapeMismatch));
-                }
-            } else if !val.matches_kind(col_type.kind) {
-                return Err(Report::new(InternalError::ColumnScanShapeMismatch));
+                assert!(
+                    col_type.nullable,
+                    "scan buffer column {} must not receive null for a non-nullable layout",
+                    buf.col_idx
+                );
+            } else {
+                assert!(
+                    val.matches_kind(col_type.kind),
+                    "scan buffer column {} value kind must match {:?}",
+                    buf.col_idx,
+                    col_type.kind
+                );
             }
         }
 
@@ -220,9 +242,8 @@ impl ScanBuffer {
                     null_bitmap.bitmap_unset(row_idx);
                 }
             }
-            append_scan_value(&mut buf.vals, val)?;
+            append_scan_value(&mut buf.vals, val, buf.col_idx);
         }
-        Ok(())
     }
 
     /// Clear the buffer.
@@ -425,7 +446,7 @@ pub(crate) enum ValArrayRef<'a> {
     VarByte(&'a [PageVar], &'a [u8]),
 }
 
-fn append_scan_value(buf: &mut ValBuffer, val: &Val) -> InternalResult<()> {
+fn append_scan_value(buf: &mut ValBuffer, val: &Val, col_idx: usize) {
     match (buf, val) {
         (ValBuffer::I8(vals), Val::I8(value)) => vals.push(*value),
         (ValBuffer::U8(vals), Val::U8(value)) => vals.push(*value),
@@ -457,9 +478,10 @@ fn append_scan_value(buf: &mut ValBuffer, val: &Val) -> InternalResult<()> {
             let offset = data.len();
             offsets.push((offset, offset));
         }
-        _ => return Err(Report::new(InternalError::ColumnScanShapeMismatch)),
+        _ => unreachable!(
+            "scan buffer value kind for column {col_idx} must match the validated decoded row"
+        ),
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -580,8 +602,7 @@ mod tests {
             &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
         );
         let view = page.vector_view(metadata.col.as_ref());
-        let res = scanner.scan(view);
-        assert!(res.is_ok());
+        scanner.scan(view);
         assert!(scanner.len() == 98);
         scanner.clear();
         assert!(scanner.is_empty());
@@ -649,9 +670,7 @@ mod tests {
         assert!(matches!(page.delete(RowID::new(2)), Delete::Ok));
 
         let mut scanner = ScanBuffer::new(metadata.col.as_ref(), &[0]);
-        scanner
-            .scan(page.vector_view(metadata.col.as_ref()))
-            .unwrap();
+        scanner.scan(page.vector_view(metadata.col.as_ref()));
 
         assert_eq!(scanner.len(), 4);
         let col = scanner.column(0).unwrap();
@@ -773,7 +792,7 @@ mod tests {
         let mut scanner =
             ScanBuffer::new(metadata.col.as_ref(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let view = page.vector_view(metadata.col.as_ref());
-        scanner.scan(view).unwrap();
+        scanner.scan(view);
         assert_eq!(scanner.len(), 5);
 
         scanner.truncate(3);

--- a/doradb-storage/src/table/persistence.rs
+++ b/doradb-storage/src/table/persistence.rs
@@ -1191,7 +1191,7 @@ impl Table {
                     current_start = prepared.start_row_id;
                     current_end = prepared.end_row_id;
                 }
-                if !builder.append_view(view, prepared.start_row_id)? {
+                if !builder.append_view(view, prepared.start_row_id) {
                     let shape = ColumnBlockEntryShape::new(
                         current_start,
                         current_end,
@@ -1207,7 +1207,7 @@ impl Table {
                         metadata.col.as_ref(),
                         prepared.del_bitmap.clone(),
                     )?;
-                    if !builder.append_view(view, prepared.start_row_id)? {
+                    if !builder.append_view(view, prepared.start_row_id) {
                         return Err(Report::new(InternalError::LwcBuilderMisuse)
                             .attach(format!(
                                 "single row page does not fit in LWC block: page_id={}",

--- a/doradb-storage/src/table/persistence.rs
+++ b/doradb-storage/src/table/persistence.rs
@@ -1192,6 +1192,14 @@ impl Table {
                     current_end = prepared.end_row_id;
                 }
                 if !builder.append_view(view, prepared.start_row_id) {
+                    if builder.is_empty() {
+                        return Err(Report::new(InternalError::LwcBuilderMisuse)
+                            .attach(format!(
+                                "single row page does not fit in LWC block: page_id={}",
+                                prepared.page_id
+                            ))
+                            .into());
+                    }
                     let shape = ColumnBlockEntryShape::new(
                         current_start,
                         current_end,
@@ -2222,6 +2230,75 @@ mod tests {
             .await
             .unwrap();
             trx.rollback().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn test_build_lwc_blocks_rejects_oversized_first_page() {
+        smol::block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let engine = lightweight_test_engine(&temp_dir, "oversized-first-lwc-page").await;
+            let mut session = engine.new_session().unwrap();
+            let table_id = session
+                .create_table(
+                    TableSpec::new(vec![ColumnSpec::new(
+                        "payload",
+                        ValKind::VarByte,
+                        ColumnAttributes::empty(),
+                    )]),
+                    vec![],
+                )
+                .await
+                .unwrap();
+            let table = table_for_internal_assertion(&engine, table_id);
+            let metadata = table.metadata();
+            let guards = session.pool_guards();
+            let page_guard = table
+                .mem
+                .try_get_insert_page(&guards, 1, None)
+                .await
+                .unwrap();
+            let page = page_guard.page();
+            let payload_len =
+                page.header.var_field_offset() - usize::from(page.header.fix_field_end);
+            let values = [Val::from(vec![0xab; payload_len])];
+            assert!(page.insert(metadata.col.as_ref(), &values).is_ok());
+            let prepared = PreparedTransitionPage {
+                page_id: page_guard.page_id(),
+                start_row_id: page.header.start_row_id,
+                end_row_id: page.header.start_row_id + u64::from(page.header.max_row_count),
+                cutoff_ts: TrxID::new(1),
+                observed_version: 0,
+                required_cutoff_ts: None,
+                del_bitmap: page.del_bitmap(page.header.row_count()),
+                overlay_markers: Vec::new(),
+            };
+            let page_id = prepared.page_id;
+            drop(page_guard);
+
+            let err = match table
+                .build_lwc_blocks(
+                    &metadata,
+                    &guards,
+                    &[Some(prepared)],
+                    None::<fn(&RowPage, usize, RowID) -> Result<()>>,
+                )
+                .await
+            {
+                Ok(_) => panic!("oversized first row page should fail LWC block build"),
+                Err(err) => err,
+            };
+            assert_eq!(err.kind(), ErrorKind::Internal);
+            assert_eq!(
+                err.report().downcast_ref::<InternalError>().copied(),
+                Some(InternalError::LwcBuilderMisuse)
+            );
+            let report = format!("{err:?}");
+            assert!(
+                report.contains("single row page does not fit in LWC block"),
+                "{report}"
+            );
+            assert!(report.contains(&format!("page_id={page_id}")), "{report}");
         });
     }
 

--- a/doradb-storage/src/trx/sys.rs
+++ b/doradb-storage/src/trx/sys.rs
@@ -179,6 +179,7 @@ impl Component for TransactionSystemWorkers {
     type Config = ();
     type Owned = TransactionSystemWorkersOwned;
     type Access = ();
+    type Error = Error;
 
     const NAME: &'static str = "trx_sys_workers";
 
@@ -188,14 +189,10 @@ impl Component for TransactionSystemWorkers {
         registry: &mut ComponentRegistry,
         mut shelf: ShelfScope<'_, Self>,
     ) -> Result<()> {
-        let trx_sys = registry.dependency::<TransactionSystem>()?;
-        let startup = shelf.take::<TransactionSystem>().ok_or_else(|| {
-            Error::from(
-                Report::new(InternalError::ComponentProvisionMissing)
-                    .attach("provider=TransactionSystem, consumer=TransactionRuntime"),
-            )
-        })?;
-        registry.register::<Self>(startup.start(trx_sys).await?)
+        let trx_sys = registry.dependency::<TransactionSystem>();
+        let startup = shelf.take::<TransactionSystem>();
+        registry.register::<Self>(startup.start(trx_sys).await?);
+        Ok(())
     }
 
     #[inline]
@@ -1615,6 +1612,7 @@ impl Component for TransactionSystem {
     type Config = TrxSysConfig;
     type Owned = Self;
     type Access = QuiescentGuard<Self>;
+    type Error = Error;
 
     const NAME: &'static str = "trx_sys";
 
@@ -1625,13 +1623,13 @@ impl Component for TransactionSystem {
         mut shelf: ShelfScope<'_, Self>,
     ) -> Result<()> {
         config.validate()?;
-        let meta_pool = registry.dependency::<MetaPool>()?;
-        let index_pool = registry.dependency::<IndexPool>()?;
-        let mem_pool = registry.dependency::<MemPool>()?;
-        let table_fs = registry.dependency::<FileSystem>()?;
-        let disk_pool = registry.dependency::<DiskPool>()?;
-        let catalog = registry.dependency::<Catalog>()?;
-        let engine_poisoner = registry.dependency::<EnginePoisoner>()?;
+        let meta_pool = registry.dependency::<MetaPool>();
+        let index_pool = registry.dependency::<IndexPool>();
+        let mem_pool = registry.dependency::<MemPool>();
+        let table_fs = registry.dependency::<FileSystem>();
+        let disk_pool = registry.dependency::<DiskPool>();
+        let catalog = registry.dependency::<Catalog>();
+        let engine_poisoner = registry.dependency::<EnginePoisoner>();
 
         let (trx_sys, startup) = TransactionSystem::bootstrap(
             config,
@@ -1646,8 +1644,8 @@ impl Component for TransactionSystem {
             catalog,
         )
         .await?;
-        registry.register::<Self>(trx_sys)?;
-        shelf.put::<TransactionSystemWorkers>(startup)?;
+        registry.register::<Self>(trx_sys);
+        shelf.put::<TransactionSystemWorkers>(startup);
         TransactionSystemWorkers::build((), registry, shelf.scope::<TransactionSystemWorkers>())
             .await
     }


### PR DESCRIPTION
Closes #858 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of catalog checkpoint LWC rows (value kinds/nullability) with clearer contextual errors.
  * Improved robustness when building LWC blocks by explicitly rejecting oversized first pages with the offending page id.
  * Tightened buffer/readonly capacity and persisted-layout payload validation to provide more consistent error reporting.

* **Refactor**
  * Simplified component startup/dependency wiring and made invariant handling more deterministic across buffer, scan, LWC, and engine components.
  * Streamlined trusted layout conversions and removed fallible paths where mismatches are treated as contract violations.

* **Tests**
  * Updated and added unit tests covering catalog row validation and oversized LWC block build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->